### PR TITLE
Export art, UI changes, translatable search props

### DIFF
--- a/NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp
@@ -59,12 +59,37 @@ Gtk.ShortcutsWindow _shortcuts {
 
       Gtk.ShortcutsShortcut {
         title: _("Insert Front Album Art");
-        accelerator: "<Control><Shift>o";
+        accelerator: "<Control>i";
       }
 
       Gtk.ShortcutsShortcut {
         title: _("Remove Front Album Art");
         accelerator: "<Control>Delete";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Export Front Album Art");
+        accelerator: "<Control>e";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Switch Album Art");
+        accelerator: "<Control><Shift>s";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Insert Back Album Art");
+        accelerator: "<Control><Shift>i";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Remove Back Album Art");
+        accelerator: "<Control><Shift>Delete";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: _("Export Back Album Art");
+        accelerator: "<Control><Shift>e";
       }
     }
 

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -22,6 +22,7 @@ menu tagActionsMenu {
 
         item(_("Insert"), "win.insertFrontAlbumArt")
         item(_("Remove"), "win.removeFrontAlbumArt")
+        item(_("Export"), "win.exportFrontAlbumArt")
       }
 
       submenu {
@@ -29,6 +30,7 @@ menu tagActionsMenu {
 
         item(_("Insert"), "win.insertBackAlbumArt")
         item(_("Remove"), "win.removeBackAlbumArt")
+        item(_("Export"), "win.exportBackAlbumArt")
       }
     }
 
@@ -69,14 +71,6 @@ Adw.ApplicationWindow _root {
           icon-name: "folder-open-symbolic";
         }
       }
-
-      [start]
-      Gtk.Button _reloadFolderButton {
-        tooltip-text: _("Reload Music Folder (F5)");
-        visible: false;
-        icon-name: "view-refresh-symbolic";
-        action-name: "win.reloadFolder";
-      }
       
       [end]
       Gtk.MenuButton {
@@ -84,37 +78,6 @@ Adw.ApplicationWindow _root {
         menu-model: mainMenu;
         tooltip-text: _("Main Menu");
         primary: true;
-      }
-
-      [end]
-      Gtk.ToggleButton _flapToggleButton {
-        icon-name: "sidebar-show-right-symbolic";
-        tooltip-text: _("Toggle Tags Pane");
-        active: bind _folderFlap.reveal-flap bidirectional;
-        visible: false;
-      }
-
-      [end]
-      Gtk.Separator _headerEndSeparator {
-        styles ["spacer"]
-      }
-
-      [end]
-      Gtk.Button _applyButton {
-        label: _("Apply");
-        tooltip-text: _("Apply Changes To Tag (Ctrl+S)");
-        visible: false;
-        action-name: "win.apply";
-
-        styles ["suggested-action"]
-      }
-
-      [end]
-      Gtk.MenuButton _tagActionsButton {
-        icon-name: "document-properties-symbolic";
-        menu-model: tagActionsMenu;
-        visible: false;
-        tooltip-text: _("Tag Actions");
       }
 
       styles ["flat"]
@@ -164,326 +127,374 @@ Adw.ApplicationWindow _root {
 
         Adw.ViewStackPage {
           name: "Folder";
-          child: Adw.Flap _folderFlap {
-            flap-position: end;
+          child: Gtk.Box {
+            orientation: vertical;
+            Adw.Flap _folderFlap {
+              flap-position: start;
 
-            [content]
-            Adw.ViewStack _filesViewStack {
-              width-request: 320;
+              [flap]
+              Adw.ViewStack _filesViewStack {
+                width-request: 320;
 
-              Adw.ViewStackPage {
-                name: "NoFiles";
-                child: Adw.StatusPage {
-                  icon-name: "library-music-symbolic";
-                  title: _("No Music Files Found");
-                  description: _("Try a different folder");
-                };
+                Adw.ViewStackPage {
+                  name: "NoFiles";
+                  child: Adw.StatusPage {
+                    icon-name: "library-music-symbolic";
+                    title: _("No Music Files Found");
+                    description: _("Try a different folder");
+                  };
+                }
+
+                Adw.ViewStackPage {
+                  name: "Files";
+                  child: Gtk.Box {
+                    orientation: vertical;
+                    spacing: 6;
+
+                    Gtk.Box {
+                      orientation: horizontal;
+                      spacing: 12;
+                      margin-start: 12;
+                      margin-top: 12;
+                      margin-end: 12;
+
+                      Gtk.SearchEntry _musicFilesSearch {
+                        hexpand: true;
+                        placeholder-text: _("Search for filename (type ! to activate advanced search)...");
+                      }
+
+                      Gtk.Button _advancedSearchInfoButton {
+                        icon-name: "help-faq-symbolic";
+                        tooltip-text: _("Advanced Search Info");
+                      }
+                    }
+
+                    Gtk.ScrolledWindow {
+                      hexpand: true;
+                      vexpand: true;
+                      hscrollbar-policy: never;
+
+                      child: Gtk.ListBox _listMusicFiles {
+                        margin-start: 12;
+                        margin-top: 12;
+                        margin-end: 12;
+                        margin-bottom: 12;
+                        selection-mode: multiple;
+                        activate-on-single-click: false;
+
+                        styles ["card", "boxed-list"]
+                      };
+                    }
+                  };
+                }
+
+                styles [ "background" ]
               }
 
-              Adw.ViewStackPage {
-                name: "Files";
-                child: Gtk.Box {
-                  orientation: vertical;
-                  spacing: 6;
+              [separator]
+              Gtk.Separator {
+                orientation: vertical;
+              }
 
-                  Gtk.Box {
-                    orientation: horizontal;
-                    spacing: 6;
-                    margin-start: 6;
-                    margin-top: 6;
-                    margin-end: 6;
+              [content]
+              Adw.ViewStack _selectedViewStack {
+                hexpand: true;
+                vexpand: true;
+                styles [ "background" ]
 
-                    Gtk.SearchEntry _musicFilesSearch {
-                      hexpand: true;
-                      placeholder-text: _("Search for filename (type ! to activate advanced search)...");
-                    }
+                Adw.ViewStackPage {
+                  name: "NoSelected";
+                  child: Adw.StatusPage {
+                    icon-name: "library-music-symbolic";
+                    title: _("No Selected Music Files");
+                    description: _("Select some files");
+                  };
+                }
 
-                    Gtk.Button _advancedSearchInfoButton {
-                      icon-name: "help-faq-symbolic";
-                      tooltip-text: _("Advanced Search Info");
-                      visible: false;
-                    }
-                  }
-
-                  Gtk.ScrolledWindow {
+                Adw.ViewStackPage {
+                  name: "Selected";
+                  child: Gtk.ScrolledWindow {
                     hexpand: true;
                     vexpand: true;
                     hscrollbar-policy: never;
 
-                    child: Gtk.ListBox _listMusicFiles {
-                      margin-start: 6;
-                      margin-top: 6;
-                      margin-end: 6;
-                      margin-bottom: 6;
-                      selection-mode: multiple;
-                      activate-on-single-click: false;
+                    child: Adw.Clamp {
+                      child: Gtk.Box {
+                        orientation: vertical;
+                        spacing: 12;
+                        margin-start: 12;
+                        margin-top: 12;
+                        margin-end: 12;
 
-                      styles ["card", "boxed-list"]
-                    };
-                  }
-                };
-              }
-            }
-
-            [separator]
-            Gtk.Separator {
-              orientation: vertical;
-            }
-
-            [flap]
-            Adw.ViewStack _selectedViewStack {
-              hexpand: true;
-              vexpand: true;
-              styles [ "background" ]
-
-              Adw.ViewStackPage {
-                name: "NoSelected";
-                child: Adw.StatusPage {
-                  icon-name: "library-music-symbolic";
-                  title: _("No Selected Music Files");
-                  description: _("Select some files");
-                };
-              }
-
-              Adw.ViewStackPage {
-                name: "Selected";
-                child: Gtk.ScrolledWindow {
-                  hexpand: true;
-                  vexpand: true;
-                  hscrollbar-policy: never;
-
-                  child: Adw.Clamp {
-                    child: Gtk.Box {
-                      orientation: vertical;
-                      spacing: 12;
-                      margin-start: 12;
-                      margin-top: 6;
-                      margin-end: 12;
-                      margin-bottom: 6;
-
-                      Gtk.Overlay {
-                        [overlay]
-                        Adw.Bin {
-                          margin-top: 12;
-                          margin-bottom: 12;
-                          halign: center;
-                          valign: center;
-                          width-request: 260;
-                          height-request: 260;
-
-                          Gtk.Box {
-                            orientation: vertical;
+                        Gtk.Overlay {
+                          [overlay]
+                          Adw.Bin {
+                            margin-top: 12;
+                            margin-bottom: 12;
                             halign: center;
                             valign: center;
+                            width-request: 260;
+                            height-request: 260;
 
-                            Gtk.Button _insertAlbumArtButton {
-                              Adw.ButtonContent {
-                                icon-name: "list-add-symbolic";
-                                label: _("Insert");
-                              }
-
-                              styles [ "opaque" ]
-                            }
-
-                            Gtk.Button _removeAlbumArtButton {
-                              Adw.ButtonContent {
-                                icon-name: "list-remove-symbolic";
-                                label: _("Remove");
-                              }
-
-                              styles [ "opaque" ]
-                            }
-
-                            Gtk.Button _exportAlbumArtButton {
-                              Adw.ButtonContent {
-                                icon-name: "document-save-symbolic";
-                                label: _("Export");
-                              }
-
-                              styles [ "opaque" ]
-                            }
-
-                            Gtk.Button _switchAlbumArtButton {
-                              Adw.ButtonContent _switchAlbumArtButtonContent {
-                                icon-name: "view-paged-symbolic";
-                                label: _("Switch to Back Cover");
-                              }
-
-                              styles [ "opaque" ]
-                            }
-
-                            styles [ "linked", "art-box" ]
-                          }
-
-                          styles [ "art-bin", "osd" ]
-                        }
-
-                        child: Gtk.Overlay {
-                          halign: center;
-                          width-request: 260;
-                          height-request: 260;
-                          margin-top: 12;
-                          margin-bottom: 12;
-
-                          [overlay]
-                          Gtk.Label _artTypeLabel {
-                            halign: start;
-                            valign: end;
-                            margin-start: 6;
-                            margin-bottom: 6;
-
-                            styles [ "osd", "toolbar", "caption" ]
-                          }
-
-                          child: Adw.ViewStack _artViewStack {
-                            Adw.ViewStackPage {
-                              name: "NoImage";
-                              child: Adw.StatusPage {
-                                icon-name: "image-missing-symbolic";
-
-                                styles ["compact"]
-                              };
-                            }
-
-                            Adw.ViewStackPage {
-                              name: "Image";
-                              child: Gtk.Picture _albumArtImage {
-                                styles ["album-art-img"]
-                              };
-                            }
-
-                            Adw.ViewStackPage {
-                              name: "KeepImage";
-                              child: Adw.StatusPage {
-                                icon-name: "library-music-symbolic";
-
-                                styles ["compact"]
-                              };
-                            }
-
-                            styles ["card"]
-                          };
-                        };
-                      }
-
-                      Adw.PreferencesGroup {
-                        Adw.EntryRow _filenameRow {
-                          title: _("File Name");
-                        }
-                      }
-
-                      Adw.PreferencesGroup {
-                        title: _("Tag Properties");
-
-                        Adw.EntryRow _titleRow {
-                          title: _("Title");
-                        }
-
-                        Adw.EntryRow _artistRow {
-                          title: _("Artist");
-                        }
-
-                        Adw.EntryRow _albumRow {
-                          title: _("Album");
-                        }
-
-                        Adw.EntryRow _yearRow {
-                          title: _("Year");
-                        }
-
-                        Adw.EntryRow _trackRow {
-                          title: _("Track");
-                        }
-
-                        Adw.EntryRow _albumArtistRow {
-                          title: _("Album Artist");
-                        }
-
-                        Adw.EntryRow _genreRow {
-                          title: _("Genre");
-                        }
-
-                        Adw.EntryRow _commentRow {
-                          title: _("Comment");
-                        }
-
-                        Adw.ExpanderRow _morePropertiesRow {
-                          title: _("More Properties");
-
-                          Adw.EntryRow _bpmRow {
-                            title: _("Beats Per Minute");
-                          }
-
-                          Adw.EntryRow _composerRow {
-                            title: _("Composer");
-                          }
-
-                          Adw.EntryRow _descriptionRow {
-                            title: _("Description");
-                          }
-
-                          Adw.EntryRow _publisherRow {
-                            title: _("Publisher");
-                          }
-
-                          Adw.EntryRow _isrcRow {
-                            title: _("ISRC");
-                          }
-                        }
-                      }
-
-                      Adw.PreferencesGroup {
-                        title: _("File Properties");
-
-                        Adw.ActionRow _durationRow {
-                          title: _("Duration");
-
-                          [suffix]
-                          Gtk.Label _durationLabel {
-                            valign: center;
-                            label: "00:00:00";
-                          }
-                        }
-
-                        Adw.ActionRow {
-                          title: _("Fingerprint");
-                          title-lines: 1;
-
-                          [suffix]
-                          Adw.Clamp {
-                            orientation: horizontal;
-                            maximum-size: 200;
-
-                            child: Gtk.Label _fingerprintLabel {
-                              halign: end;
+                            Gtk.Box {
+                              orientation: vertical;
+                              halign: center;
                               valign: center;
+
+                              Gtk.Button _insertAlbumArtButton {
+                                Adw.ButtonContent {
+                                  icon-name: "list-add-symbolic";
+                                  label: _("Insert");
+                                }
+
+                                styles [ "opaque" ]
+                              }
+
+                              Gtk.Button _removeAlbumArtButton {
+                                Adw.ButtonContent {
+                                  icon-name: "list-remove-symbolic";
+                                  label: _("Remove");
+                                }
+
+                                styles [ "opaque" ]
+                              }
+
+                              Gtk.Button _exportAlbumArtButton {
+                                Adw.ButtonContent {
+                                  icon-name: "document-save-symbolic";
+                                  label: _("Export");
+                                }
+
+                                styles [ "opaque" ]
+                              }
+
+                              Gtk.Button _switchAlbumArtButton {
+                                Adw.ButtonContent _switchAlbumArtButtonContent {
+                                  icon-name: "view-paged-symbolic";
+                                  label: _("Switch to Back Cover");
+                                }
+
+                                styles [ "opaque" ]
+                              }
+
+                              styles [ "linked", "art-box" ]
+                            }
+
+                            styles [ "art-bin", "osd" ]
+                          }
+
+                          child: Gtk.Overlay {
+                            halign: center;
+                            width-request: 260;
+                            height-request: 260;
+                            margin-top: 12;
+                            margin-bottom: 12;
+
+                            [overlay]
+                            Gtk.Label _artTypeLabel {
+                              halign: start;
+                              valign: end;
+                              margin-start: 6;
+                              margin-bottom: 6;
+
+                              styles [ "osd", "toolbar", "caption" ]
+                            }
+
+                            child: Adw.ViewStack _artViewStack {
+                              Adw.ViewStackPage {
+                                name: "NoImage";
+                                child: Adw.StatusPage {
+                                  icon-name: "image-missing-symbolic";
+
+                                  styles ["compact"]
+                                };
+                              }
+
+                              Adw.ViewStackPage {
+                                name: "Image";
+                                child: Gtk.Picture _albumArtImage {
+                                  styles ["album-art-img"]
+                                };
+                              }
+
+                              Adw.ViewStackPage {
+                                name: "KeepImage";
+                                child: Adw.StatusPage {
+                                  icon-name: "library-music-symbolic";
+
+                                  styles ["compact"]
+                                };
+                              }
+
+                              styles ["card"]
                             };
-                          }
+                          };
+                        }
 
-                          [suffix]
-                          Gtk.Button _copyFingerprintButton {
-                            valign: center;
-                            icon-name: "edit-copy-symbolic";
-                            tooltip-text: _("Copy Fingerprint To Clipboard");
-
-                            styles ["flat"]
+                        Adw.PreferencesGroup {
+                          Adw.EntryRow _filenameRow {
+                            title: _("File Name");
                           }
                         }
 
-                        Adw.ActionRow {
-                          title: _("File Size");
+                        Adw.PreferencesGroup {
+                          title: _("Tag Properties");
 
-                          [suffix]
-                          Gtk.Label _fileSizeLabel {
-                            valign: center;
-                            label: _("0 MiB");
+                          Adw.EntryRow _titleRow {
+                            title: _("Title");
+                          }
+
+                          Adw.EntryRow _artistRow {
+                            title: _("Artist");
+                          }
+
+                          Adw.EntryRow _albumRow {
+                            title: _("Album");
+                          }
+
+                          Adw.EntryRow _yearRow {
+                            title: _("Year");
+                          }
+
+                          Adw.EntryRow _trackRow {
+                            title: _("Track");
+                          }
+
+                          Adw.EntryRow _albumArtistRow {
+                            title: _("Album Artist");
+                          }
+
+                          Adw.EntryRow _genreRow {
+                            title: _("Genre");
+                          }
+
+                          Adw.EntryRow _commentRow {
+                            title: _("Comment");
+                          }
+
+                          Adw.ExpanderRow _morePropertiesRow {
+                            title: _("More Properties");
+
+                            Adw.EntryRow _bpmRow {
+                              title: _("Beats Per Minute");
+                            }
+
+                            Adw.EntryRow _composerRow {
+                              title: _("Composer");
+                            }
+
+                            Adw.EntryRow _descriptionRow {
+                              title: _("Description");
+                            }
+
+                            Adw.EntryRow _publisherRow {
+                              title: _("Publisher");
+                            }
+
+                            Adw.EntryRow _isrcRow {
+                              title: _("ISRC");
+                            }
                           }
                         }
-                      }
+
+                        Adw.PreferencesGroup {
+                          title: _("File Properties");
+
+                          Adw.ActionRow _durationRow {
+                            title: _("Duration");
+
+                            [suffix]
+                            Gtk.Label _durationLabel {
+                              valign: center;
+                              label: "00:00:00";
+                            }
+                          }
+
+                          Adw.ActionRow {
+                            title: _("Fingerprint");
+                            title-lines: 1;
+
+                            [suffix]
+                            Adw.Clamp {
+                              orientation: horizontal;
+                              maximum-size: 200;
+
+                              child: Gtk.Label _fingerprintLabel {
+                                halign: end;
+                                valign: center;
+                              };
+                            }
+
+                            [suffix]
+                            Gtk.Button _copyFingerprintButton {
+                              valign: center;
+                              icon-name: "edit-copy-symbolic";
+                              tooltip-text: _("Copy Fingerprint To Clipboard");
+
+                              styles ["flat"]
+                            }
+                          }
+
+                          Adw.ActionRow {
+                            title: _("File Size");
+
+                            [suffix]
+                            Gtk.Label _fileSizeLabel {
+                              valign: center;
+                              label: _("0 MiB");
+                            }
+                          }
+                        }
+                      };
                     };
                   };
-                };
+                }
               }
+            }
+
+            Gtk.Separator { }
+
+            Gtk.CenterBox {
+              [start]
+              Gtk.Box {
+                spacing: 6;
+
+                Gtk.ToggleButton _flapToggleButton {
+                  icon-name: "sidebar-show-symbolic";
+                  tooltip-text: _("Toggle Tags Pane");
+                  active: bind _folderFlap.reveal-flap bidirectional;
+                  sensitive: false;
+                }
+
+                Gtk.Button {
+                  tooltip-text: _("Reload Music Folder (F5)");
+                  sensitive: false;
+                  icon-name: "view-refresh-symbolic";
+                  action-name: "win.reloadFolder";
+                }
+              }
+
+              [end]
+              Gtk.Box {
+                spacing: 6;
+
+                Gtk.MenuButton _tagActionsButton {
+                  icon-name: "document-properties-symbolic";
+                  menu-model: tagActionsMenu;
+                  tooltip-text: _("Tag Actions");
+                }
+
+                Gtk.Button _applyButton {
+                  label: _("Apply");
+                  tooltip-text: _("Apply Changes To Tag (Ctrl+S)");
+                  sensitive: false;
+                  action-name: "win.apply";
+
+                  styles ["suggested-action"]
+                }
+              }
+
+              styles [ "toolbar" ]
             }
           };
         }

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -149,14 +149,14 @@ Adw.ApplicationWindow _root {
                   name: "Files";
                   child: Gtk.Box {
                     orientation: vertical;
-                    spacing: 6;
 
                     Gtk.Box {
                       orientation: horizontal;
                       spacing: 12;
                       margin-start: 12;
-                      margin-top: 12;
+                      margin-top: 6;
                       margin-end: 12;
+                      margin-bottom: 6;
 
                       Gtk.SearchEntry _musicFilesSearch {
                         hexpand: true;
@@ -169,14 +169,18 @@ Adw.ApplicationWindow _root {
                       }
                     }
 
-                    Gtk.ScrolledWindow {
+                    Gtk.Separator _searchSeparator {
+                      visible: false;
+                    }
+
+                    Gtk.ScrolledWindow _scrolledWindowMusicFiles {
                       hexpand: true;
                       vexpand: true;
                       hscrollbar-policy: never;
 
                       child: Gtk.ListBox _listMusicFiles {
                         margin-start: 12;
-                        margin-top: 12;
+                        margin-top: 6;
                         margin-end: 12;
                         margin-bottom: 12;
                         selection-mode: multiple;
@@ -225,6 +229,7 @@ Adw.ApplicationWindow _root {
                         margin-start: 12;
                         margin-top: 12;
                         margin-end: 12;
+                        margin-bottom: 12;
 
                         Gtk.Overlay {
                           [overlay]
@@ -482,6 +487,7 @@ Adw.ApplicationWindow _root {
                   icon-name: "document-properties-symbolic";
                   menu-model: tagActionsMenu;
                   tooltip-text: _("Tag Actions");
+                  direction: up;
                 }
 
                 Gtk.Button _applyButton {

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -241,48 +241,52 @@ Adw.ApplicationWindow _root {
                             width-request: 260;
                             height-request: 260;
 
-                            Gtk.Box {
-                              orientation: vertical;
-                              halign: center;
-                              valign: center;
+                            Adw.Clamp {
+                              maximum-size: 240;
 
-                              Gtk.Button _insertAlbumArtButton {
-                                Adw.ButtonContent {
-                                  icon-name: "list-add-symbolic";
-                                  label: _("Insert");
+                              Gtk.Box {
+                                orientation: vertical;
+                                halign: center;
+                                valign: center;
+
+                                Gtk.Button _insertAlbumArtButton {
+                                  Adw.ButtonContent {
+                                    icon-name: "list-add-symbolic";
+                                    label: _("Insert");
+                                  }
+
+                                  styles [ "opaque" ]
                                 }
 
-                                styles [ "opaque" ]
-                              }
+                                Gtk.Button _removeAlbumArtButton {
+                                  Adw.ButtonContent {
+                                    icon-name: "list-remove-symbolic";
+                                    label: _("Remove");
+                                  }
 
-                              Gtk.Button _removeAlbumArtButton {
-                                Adw.ButtonContent {
-                                  icon-name: "list-remove-symbolic";
-                                  label: _("Remove");
+                                  styles [ "opaque" ]
                                 }
 
-                                styles [ "opaque" ]
-                              }
+                                Gtk.Button _exportAlbumArtButton {
+                                  Adw.ButtonContent {
+                                    icon-name: "document-save-symbolic";
+                                    label: _("Export");
+                                  }
 
-                              Gtk.Button _exportAlbumArtButton {
-                                Adw.ButtonContent {
-                                  icon-name: "document-save-symbolic";
-                                  label: _("Export");
+                                  styles [ "opaque" ]
                                 }
 
-                                styles [ "opaque" ]
-                              }
+                                Gtk.Button _switchAlbumArtButton {
+                                  Adw.ButtonContent _switchAlbumArtButtonContent {
+                                    icon-name: "view-paged-symbolic";
+                                    label: _("Switch to Back Cover");
+                                  }
 
-                              Gtk.Button _switchAlbumArtButton {
-                                Adw.ButtonContent _switchAlbumArtButtonContent {
-                                  icon-name: "view-paged-symbolic";
-                                  label: _("Switch to Back Cover");
+                                  styles [ "opaque" ]
                                 }
 
-                                styles [ "opaque" ]
+                                styles [ "linked", "art-box" ]
                               }
-
-                              styles [ "linked", "art-box" ]
                             }
 
                             styles [ "art-bin", "osd" ]

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -294,6 +294,15 @@ Adw.ApplicationWindow _root {
                               styles [ "opaque" ]
                             }
 
+                            Gtk.Button _exportAlbumArtButton {
+                              Adw.ButtonContent {
+                                icon-name: "document-save-symbolic";
+                                label: _("Export");
+                              }
+
+                              styles [ "opaque" ]
+                            }
+
                             Gtk.Button _switchAlbumArtButton {
                               Adw.ButtonContent _switchAlbumArtButtonContent {
                                 icon-name: "view-paged-symbolic";

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -318,39 +318,51 @@ Adw.ApplicationWindow _root {
                           styles [ "art-bin", "osd" ]
                         }
 
-                        child: Adw.ViewStack _artViewStack {
+                        child: Gtk.Overlay {
                           halign: center;
                           width-request: 260;
                           height-request: 260;
                           margin-top: 12;
                           margin-bottom: 12;
 
-                          Adw.ViewStackPage {
-                            name: "NoImage";
-                            child: Adw.StatusPage {
-                              icon-name: "image-missing-symbolic";
+                          [overlay]
+                          Gtk.Label _artTypeLabel {
+                            halign: start;
+                            valign: end;
+                            margin-start: 6;
+                            margin-bottom: 6;
 
-                              styles ["compact"]
-                            };
+                            styles [ "osd", "toolbar", "caption" ]
                           }
 
-                          Adw.ViewStackPage {
-                            name: "Image";
-                            child: Gtk.Picture _albumArtImage {
-                              styles ["album-art-img"]
-                            };
-                          }
+                          child: Adw.ViewStack _artViewStack {
+                            Adw.ViewStackPage {
+                              name: "NoImage";
+                              child: Adw.StatusPage {
+                                icon-name: "image-missing-symbolic";
 
-                          Adw.ViewStackPage {
-                            name: "KeepImage";
-                            child: Adw.StatusPage {
-                              icon-name: "library-music-symbolic";
+                                styles ["compact"]
+                              };
+                            }
 
-                              styles ["compact"]
-                            };
-                          }
+                            Adw.ViewStackPage {
+                              name: "Image";
+                              child: Gtk.Picture _albumArtImage {
+                                styles ["album-art-img"]
+                              };
+                            }
 
-                          styles ["card"]
+                            Adw.ViewStackPage {
+                              name: "KeepImage";
+                              child: Adw.StatusPage {
+                                icon-name: "library-music-symbolic";
+
+                                styles ["compact"]
+                              };
+                            }
+
+                            styles ["card"]
+                          };
                         };
                       }
 

--- a/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
+++ b/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
@@ -19,11 +19,7 @@
     <Exec Command="echo Compiling extra resources..." />
     <Exec Command="blueprint-compiler batch-compile ./Blueprints ./Blueprints ./Blueprints/*.blp" />
     <Exec Command="glib-compile-resources --sourcedir ./Resources ./Resources/org.nickvision.tagger.gresource.xml --target=$(OutDir)/org.nickvision.tagger.gresource" />
-    <Exec Command="
-      while read lang_code; do \
-        mkdir -p $(OutDir)/${lang_code}; \
-        msgfmt ../NickvisionTagger.Shared/Resources/po/${lang_code}.po -o $(OutDir)/${lang_code}/application.mo; \
-      done %3C ../NickvisionTagger.Shared/Resources/po/LINGUAS" />
+    <Exec Command="while read lang_code; do \&#xA;  mkdir -p $(OutDir)${lang_code}; \&#xA;  msgfmt ../NickvisionTagger.Shared/Resources/po/${lang_code}.po -o $(OutDir)${lang_code}/tagger.mo; \&#xA;done %3C ../NickvisionTagger.Shared/Resources/po/LINGUAS" />
   </Target>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
@@ -32,10 +28,7 @@
 
   <Target Name="PostPublish" AfterTargets="Publish">
     <Exec Command="cp $(OutDir)/org.nickvision.tagger.gresource $(PublishDir)/org.nickvision.tagger.gresource" />
-    <Exec Command="
-      while read lang_code; do \
-        cp -r $(OutDir)/${lang_code} $(PublishDir)/; \
-      done %3C ../NickvisionTagger.Shared/Resources/po/LINGUAS" />
+    <Exec Command="while read lang_code; do \&#xA;  cp -r $(OutDir)${lang_code} $(PublishDir); \&#xA;done %3C ../NickvisionTagger.Shared/Resources/po/LINGUAS" />
   </Target>
 
   <Target Name="EmbedUIFiles" BeforeTargets="BeforeResGen">

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -89,9 +89,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Adw.HeaderBar _headerBar;
     [Gtk.Connect] private readonly Adw.WindowTitle _title;
     [Gtk.Connect] private readonly Gtk.Button _openFolderButton;
-    [Gtk.Connect] private readonly Gtk.Button _reloadFolderButton;
     [Gtk.Connect] private readonly Gtk.ToggleButton _flapToggleButton;
-    [Gtk.Connect] private readonly Gtk.Separator _headerEndSeparator;
     [Gtk.Connect] private readonly Gtk.Button _applyButton;
     [Gtk.Connect] private readonly Gtk.MenuButton _tagActionsButton;
     [Gtk.Connect] private readonly Adw.ToastOverlay _toastOverlay;
@@ -457,11 +455,8 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         _viewStack.SetVisibleChildName("Loading");
         _loadingLabel.SetText(message);
-        _openFolderButton.SetVisible(false);
-        _reloadFolderButton.SetVisible(false);
-        _flapToggleButton.SetVisible(false);
-        _applyButton.SetVisible(false);
-        _tagActionsButton.SetVisible(false);
+        _applyButton.SetSensitive(false);
+        _tagActionsButton.SetSensitive(false);
     }
 
     /// <summary>
@@ -932,12 +927,12 @@ public partial class MainWindow : Adw.ApplicationWindow
                 _headerBar.RemoveCssClass("flat");
                 _title.SetSubtitle(_controller.MusicFolderPath);
                 _openFolderButton.SetVisible(true);
-                _reloadFolderButton.SetVisible(true);
-                _applyButton.SetVisible(false);
-                _tagActionsButton.SetVisible(false);
+                _applyButton.SetSensitive(false);
+                _tagActionsButton.SetSensitive(false);
                 _viewStack.SetVisibleChildName("Folder");
                 _folderFlap.SetFoldPolicy(_controller.MusicFiles.Count > 0 ? Adw.FlapFoldPolicy.Auto : Adw.FlapFoldPolicy.Always);
-                _flapToggleButton.SetVisible(_controller.MusicFiles.Count > 0);
+                _folderFlap.SetRevealFlap(true);
+                _flapToggleButton.SetSensitive(_controller.MusicFiles.Count > 0);
                 _filesViewStack.SetVisibleChildName(_controller.MusicFiles.Count > 0 ? "Files" : "NoFiles");
                 if(sendToast)
                 {
@@ -948,11 +943,6 @@ public partial class MainWindow : Adw.ApplicationWindow
             {
                 _headerBar.AddCssClass("flat");
                 _title.SetSubtitle("");
-                _openFolderButton.SetVisible(false);
-                _reloadFolderButton.SetVisible(false);
-                _flapToggleButton.SetVisible(false);
-                _applyButton.SetVisible(false);
-                _tagActionsButton.SetVisible(false);
                 _viewStack.SetVisibleChildName("NoFolder");
             }
         }
@@ -967,10 +957,9 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         _viewStack.SetVisibleChildName("Folder");
         _openFolderButton.SetVisible(true);
-        _reloadFolderButton.SetVisible(true);
-        _flapToggleButton.SetVisible(_controller.MusicFiles.Count > 0);
-        _applyButton.SetVisible(_controller.SelectedMusicFiles.Count != 0);
-        _tagActionsButton.SetVisible(_controller.SelectedMusicFiles.Count != 0);
+        _flapToggleButton.SetSensitive(_controller.MusicFiles.Count > 0);
+        _applyButton.SetSensitive(_controller.SelectedMusicFiles.Count != 0);
+        _tagActionsButton.SetSensitive(_controller.SelectedMusicFiles.Count != 0);
         var i = 0;
         foreach(var saved in _controller.MusicFileSaveStates)
         {
@@ -987,8 +976,8 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         _isSelectionOccuring = true;
         //Update Properties
-        _applyButton.SetVisible(_controller.SelectedMusicFiles.Count != 0);
-        _tagActionsButton.SetVisible(_controller.SelectedMusicFiles.Count != 0);
+        _applyButton.SetSensitive(_controller.SelectedMusicFiles.Count != 0);
+        _tagActionsButton.SetSensitive(_controller.SelectedMusicFiles.Count != 0);
         _filenameRow.SetEditable(_controller.SelectedMusicFiles.Count < 2);
         if(_controller.SelectedMusicFiles.Count == 0)
         {

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -1067,7 +1067,6 @@ public partial class MainWindow : Adw.ApplicationWindow
         var search = _musicFilesSearch.GetText().ToLower();
         if(!string.IsNullOrEmpty(search) && search[0] == '!')
         {
-            _advancedSearchInfoButton.SetVisible(true);
             var result = _controller.AdvancedSearch(search);
             if(!result.Success)
             {
@@ -1097,7 +1096,6 @@ public partial class MainWindow : Adw.ApplicationWindow
         }
         else
         {
-            _advancedSearchInfoButton.SetVisible(false);
             _musicFilesSearch.RemoveCssClass("success");
             _musicFilesSearch.RemoveCssClass("error");
             _listMusicFiles.SetFilterFunc((row) =>

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -103,6 +103,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Gtk.Button _advancedSearchInfoButton;
     [Gtk.Connect] private readonly Gtk.ListBox _listMusicFiles;
     [Gtk.Connect] private readonly Adw.ViewStack _selectedViewStack;
+    [Gtk.Connect] private readonly Gtk.Label _artTypeLabel;
     [Gtk.Connect] private readonly Adw.ViewStack _artViewStack;
     [Gtk.Connect] private readonly Gtk.Button _insertAlbumArtButton;
     [Gtk.Connect] private readonly Gtk.Button _removeAlbumArtButton;
@@ -154,6 +155,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         _musicFilesSearch.OnSearchChanged += SearchChanged;
         _advancedSearchInfoButton.OnClicked += AdvancedSearchInfo;
         _listMusicFiles.OnSelectedRowsChanged += ListMusicFiles_SelectionChanged;
+        _artTypeLabel.SetLabel(_currentAlbumArtType == AlbumArtType.Front ? _("Front") : _("Back"));
         _filenameRow.OnNotify += (sender, e) =>
         {
             if(e.Pspec.GetName() == "text")
@@ -649,6 +651,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         _currentAlbumArtType = _currentAlbumArtType == AlbumArtType.Front ? AlbumArtType.Back : AlbumArtType.Front;
         _switchAlbumArtButtonContent.SetLabel(_currentAlbumArtType == AlbumArtType.Front ? _("Switch to Back Cover") : _("Switch to Front Cover"));
+        _artTypeLabel.SetLabel(_currentAlbumArtType == AlbumArtType.Front ? _("Front") : _("Back"));
         SelectedMusicFilesPropertiesChanged();
     }
 

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -99,6 +99,8 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Adw.ViewStack _filesViewStack;
     [Gtk.Connect] private readonly Gtk.SearchEntry _musicFilesSearch;
     [Gtk.Connect] private readonly Gtk.Button _advancedSearchInfoButton;
+    [Gtk.Connect] private readonly Gtk.Separator _searchSeparator;
+    [Gtk.Connect] private readonly Gtk.ScrolledWindow _scrolledWindowMusicFiles;
     [Gtk.Connect] private readonly Gtk.ListBox _listMusicFiles;
     [Gtk.Connect] private readonly Adw.ViewStack _selectedViewStack;
     [Gtk.Connect] private readonly Gtk.Label _artTypeLabel;
@@ -152,6 +154,14 @@ public partial class MainWindow : Adw.ApplicationWindow
         _title.SetTitle(_controller.AppInfo.ShortName);
         _musicFilesSearch.OnSearchChanged += SearchChanged;
         _advancedSearchInfoButton.OnClicked += AdvancedSearchInfo;
+        var musicFilesVadjustment = _scrolledWindowMusicFiles.GetVadjustment();
+        musicFilesVadjustment.OnNotify += (sender, e) =>
+        {
+            if (e.Pspec.GetName() == "value")
+            {
+                _searchSeparator.SetVisible(musicFilesVadjustment.GetValue() > 0);
+            }
+        };
         _listMusicFiles.OnSelectedRowsChanged += ListMusicFiles_SelectionChanged;
         _artTypeLabel.SetLabel(_currentAlbumArtType == AlbumArtType.Front ? _("Front") : _("Back"));
         _filenameRow.OnNotify += (sender, e) =>

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -163,6 +163,9 @@ public partial class MainWindow : Adw.ApplicationWindow
             }
         };
         _listMusicFiles.OnSelectedRowsChanged += ListMusicFiles_SelectionChanged;
+        var switchAlbumArtLabel = (Gtk.Label)_switchAlbumArtButtonContent.GetLastChild();
+        switchAlbumArtLabel.SetWrap(true);
+        switchAlbumArtLabel.SetJustify(Gtk.Justification.Center);
         _artTypeLabel.SetLabel(_currentAlbumArtType == AlbumArtType.Front ? _("Front") : _("Back"));
         _filenameRow.OnNotify += (sender, e) =>
         {

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using TagLib;
 using static NickvisionTagger.Shared.Helpers.Gettext;
 
 namespace NickvisionTagger.Shared.Controllers;
@@ -574,6 +575,54 @@ public class MainWindowController
             MusicFileSaveStatesChanged?.Invoke(this, EventArgs.Empty);
         }
     }
+
+    /// <summary>
+    /// Exports the selected album art of first selected music file
+    /// </summary>
+    /// <param name="path">The path for new image file</param>
+    /// <param name="type">AlbumArtType</param>
+    public void ExportSelectedAlbumArt(string path, AlbumArtType type)
+    {
+        var musicFile = SelectedMusicFiles.First().Value;
+        if(type == AlbumArtType.Front)
+        {
+            if(!musicFile.FrontAlbumArt.IsEmpty)
+            {
+                try
+                {
+                    System.IO.File.WriteAllBytes(path, musicFile.FrontAlbumArt.Data);
+                    NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("Exported front album art to file successfully"), NotificationSeverity.Success));
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("Failed to export front album art to a file"), NotificationSeverity.Error));
+                }
+            }
+        }
+        else if(type == AlbumArtType.Back)
+        {
+            if(!musicFile.BackAlbumArt.IsEmpty)
+            {
+                try
+                {
+                    System.IO.File.WriteAllBytes(path, musicFile.BackAlbumArt.Data);
+                    NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("Exported back album art to file successfully"), NotificationSeverity.Success));
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("Failed to export back album art to a file"), NotificationSeverity.Error));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets MimeType of album art for the first selected file
+    /// </summary>
+    /// <param name="type">AlbumArtType</param>
+    public string GetFirstAlbumArtMimeType(AlbumArtType type) => new Picture(type == AlbumArtType.Front ? SelectedMusicFiles.First().Value.FrontAlbumArt : SelectedMusicFiles.First().Value.BackAlbumArt).MimeType;
 
     /// <summary>
     /// Downloads MusicBrainz metadata for the selected files

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -676,7 +676,7 @@ public class MainWindowController
                 return (false, null);
             }
             var propValPairs = search.Split(';');
-            var validProperties = new string[] { "filename", "title", "artist", "album", "year", "track", "albumartist", "genre", "comment", "bpm", "composer", "description", "publisher", "isrc" };
+            var validProperties = new string[] { "filename", _("filename"), "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "publisher", _("publisher"), "isrc", _("isrc") };
             var propertyMap = new PropertyMap();
             foreach(var propVal in propValPairs)
             {
@@ -685,7 +685,7 @@ public class MainWindowController
                 {
                     return (false, null);
                 }
-                var prop = fields[0];
+                var prop = fields[0].ToLower();
                 var val = fields[1];
                 if(!validProperties.Contains(prop))
                 {
@@ -701,23 +701,23 @@ public class MainWindowController
                 {
                     val = "NULL";
                 }
-                if(prop == "filename")
+                if(prop == "filename" || prop == _("filename"))
                 {
                     propertyMap.Filename = val;
                 }
-                else if(prop == "title")
+                else if(prop == "title" || prop == _("title"))
                 {
                     propertyMap.Title = val;
                 }
-                else if(prop == "artist")
+                else if(prop == "artist" || prop == _("artist"))
                 {
                     propertyMap.Artist = val;
                 }
-                else if(prop == "album")
+                else if(prop == "album" || prop == _("album"))
                 {
                     propertyMap.Album = val;
                 }
-                else if(prop == "year")
+                else if(prop == "year" || prop == _("year"))
                 {
                     if(val != "NULL")
                     {
@@ -732,7 +732,7 @@ public class MainWindowController
                     }
                     propertyMap.Year = val;
                 }
-                else if(prop == "track")
+                else if(prop == "track" || prop == _("track"))
                 {
                     if(val != "NULL")
                     {
@@ -747,19 +747,19 @@ public class MainWindowController
                     }
                     propertyMap.Track = val;
                 }
-                else if(prop == "albumartist")
+                else if(prop == "albumartist" || prop == _("albumartist"))
                 {
                     propertyMap.AlbumArtist = val;
                 }
-                else if(prop == "genre")
+                else if(prop == "genre" || prop == _("genre"))
                 {
                     propertyMap.Genre = val;
                 }
-                else if(prop == "comment")
+                else if(prop == "comment" || prop == _("comment"))
                 {
                     propertyMap.Comment = val;
                 }
-                else if(prop == "bpm")
+                else if(prop == "bpm" || prop == _("bpm"))
                 {
                     if(val != "NULL")
                     {
@@ -774,19 +774,19 @@ public class MainWindowController
                     }
                     propertyMap.BPM = val;
                 }
-                else if(prop == "composer")
+                else if(prop == "composer" || prop == _("composer"))
                 {
                     propertyMap.Composer = val;
                 }
-                else if(prop == "description")
+                else if(prop == "description" || prop == _("description"))
                 {
                     propertyMap.Description = val;
                 }
-                else if(prop == "publisher")
+                else if(prop == "publisher" || prop == _("publisher"))
                 {
                     propertyMap.Publisher = val;
                 }
-                else if(prop == "isrc")
+                else if(prop == "isrc" || prop == _("isrc"))
                 {
                     propertyMap.ISRC = val;
                 }

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -256,7 +256,7 @@ public class MainWindowController
         foreach(var pair in SelectedMusicFiles)
         {
             var updated = false;
-            if(map.Filename != pair.Value.Filename && map.Filename != "<keep>")
+            if(map.Filename != pair.Value.Filename && map.Filename != _("<keep>"))
             {
                 try
                 {
@@ -265,22 +265,22 @@ public class MainWindowController
                 }
                 catch { }
             }
-            if(map.Title != pair.Value.Title && map.Title != "<keep>")
+            if(map.Title != pair.Value.Title && map.Title != _("<keep>"))
             {
                 pair.Value.Title = map.Title;
                 updated = true;
             }
-            if(map.Artist != pair.Value.Artist && map.Artist != "<keep>")
+            if(map.Artist != pair.Value.Artist && map.Artist != _("<keep>"))
             {
                 pair.Value.Artist = map.Artist;
                 updated = true;
             }
-            if(map.Album != pair.Value.Album && map.Album != "<keep>")
+            if(map.Album != pair.Value.Album && map.Album != _("<keep>"))
             {
                 pair.Value.Album = map.Album;
                 updated = true;
             }
-            if(map.Year != pair.Value.Year.ToString() && map.Year != "<keep>")
+            if(map.Year != pair.Value.Year.ToString() && map.Year != _("<keep>"))
             {
                 try
                 {
@@ -289,7 +289,7 @@ public class MainWindowController
                 }
                 catch { }
             }
-            if(map.Track != pair.Value.Track.ToString() && map.Track != "<keep>")
+            if(map.Track != pair.Value.Track.ToString() && map.Track != _("<keep>"))
             {
                 try
                 {
@@ -298,22 +298,22 @@ public class MainWindowController
                 }
                 catch { }
             }
-            if(map.AlbumArtist != pair.Value.AlbumArtist && map.AlbumArtist != "<keep>")
+            if(map.AlbumArtist != pair.Value.AlbumArtist && map.AlbumArtist != _("<keep>"))
             {
                 pair.Value.AlbumArtist = map.AlbumArtist;
                 updated = true;
             }
-            if(map.Genre != pair.Value.Genre && map.Genre != "<keep>")
+            if(map.Genre != pair.Value.Genre && map.Genre != _("<keep>"))
             {
                 pair.Value.Genre = map.Genre;
                 updated = true;
             }
-            if(map.Comment != pair.Value.Comment && map.Comment != "<keep>")
+            if(map.Comment != pair.Value.Comment && map.Comment != _("<keep>"))
             {
                 pair.Value.Comment = map.Comment;
                 updated = true;
             }
-            if(map.BPM != pair.Value.BPM.ToString() && map.BPM != "<keep>")
+            if(map.BPM != pair.Value.BPM.ToString() && map.BPM != _("<keep>"))
             {
                 try
                 {
@@ -322,22 +322,22 @@ public class MainWindowController
                 }
                 catch { }
             }
-            if(map.Composer != pair.Value.Composer && map.Composer != "<keep>")
+            if(map.Composer != pair.Value.Composer && map.Composer != _("<keep>"))
             {
                 pair.Value.Composer = map.Composer;
                 updated = true;
             }
-            if(map.Description != pair.Value.Description && map.Description != "<keep>")
+            if(map.Description != pair.Value.Description && map.Description != _("<keep>"))
             {
                 pair.Value.Description = map.Description;
                 updated = true;
             }
-            if(map.Publisher != pair.Value.Publisher && map.Publisher != "<keep>")
+            if(map.Publisher != pair.Value.Publisher && map.Publisher != _("<keep>"))
             {
                 pair.Value.Publisher = map.Publisher;
                 updated = true;
             }
-            if(map.ISRC != pair.Value.ISRC && map.ISRC != "<keep>")
+            if(map.ISRC != pair.Value.ISRC && map.ISRC != _("<keep>"))
             {
                 pair.Value.ISRC = map.ISRC;
                 updated = true;
@@ -1181,24 +1181,24 @@ public class MainWindowController
                 totalDuration += pair.Value.Duration;
                 totalFileSize += pair.Value.FileSize;
             }
-            SelectedPropertyMap.Filename = "<keep>";
-            SelectedPropertyMap.Title = haveSameTitle ? first.Title : "<keep>";
-            SelectedPropertyMap.Artist = haveSameArtist ? first.Artist : "<keep>";
-            SelectedPropertyMap.Album = haveSameAlbum ? first.Album : "<keep>";
-            SelectedPropertyMap.Year = haveSameYear ? first.Year.ToString() : "<keep>";
-            SelectedPropertyMap.Track = haveSameTrack ? first.Track.ToString() : "<keep>";
-            SelectedPropertyMap.AlbumArtist = haveSameAlbumArtist ? first.AlbumArtist : "<keep>";
-            SelectedPropertyMap.Genre = haveSameGenre ? first.Genre : "<keep>";
-            SelectedPropertyMap.Comment = haveSameComment ? first.Comment : "<keep>";
-            SelectedPropertyMap.BPM = haveSameBPM ? first.BPM.ToString() : "<keep>";
-            SelectedPropertyMap.Composer = haveSameComposer ? first.Composer : "<keep>";
-            SelectedPropertyMap.Description = haveSameDescription ? first.Description : "<keep>";
-            SelectedPropertyMap.Publisher = haveSamePublisher ? first.Publisher : "<keep>";
-            SelectedPropertyMap.ISRC = haveSameISRC ? first.ISRC : "<keep>";
+            SelectedPropertyMap.Filename = _("<keep>");
+            SelectedPropertyMap.Title = haveSameTitle ? first.Title : _("<keep>");
+            SelectedPropertyMap.Artist = haveSameArtist ? first.Artist : _("<keep>");
+            SelectedPropertyMap.Album = haveSameAlbum ? first.Album : _("<keep>");
+            SelectedPropertyMap.Year = haveSameYear ? first.Year.ToString() : _("<keep>");
+            SelectedPropertyMap.Track = haveSameTrack ? first.Track.ToString() : _("<keep>");
+            SelectedPropertyMap.AlbumArtist = haveSameAlbumArtist ? first.AlbumArtist : _("<keep>");
+            SelectedPropertyMap.Genre = haveSameGenre ? first.Genre : _("<keep>");
+            SelectedPropertyMap.Comment = haveSameComment ? first.Comment : _("<keep>");
+            SelectedPropertyMap.BPM = haveSameBPM ? first.BPM.ToString() : _("<keep>");
+            SelectedPropertyMap.Composer = haveSameComposer ? first.Composer : _("<keep>");
+            SelectedPropertyMap.Description = haveSameDescription ? first.Description : _("<keep>");
+            SelectedPropertyMap.Publisher = haveSamePublisher ? first.Publisher : _("<keep>");
+            SelectedPropertyMap.ISRC = haveSameISRC ? first.ISRC : _("<keep>");
             SelectedPropertyMap.FrontAlbumArt = haveSameFrontAlbumArt ? (first.FrontAlbumArt.IsEmpty ? "noArt" : "hasArt") : "keepArt";
             SelectedPropertyMap.BackAlbumArt = haveSameBackAlbumArt ? (first.BackAlbumArt.IsEmpty ? "noArt" : "hasArt") : "keepArt";
             SelectedPropertyMap.Duration = totalDuration.ToDurationString();
-            SelectedPropertyMap.Fingerprint = "<keep>";
+            SelectedPropertyMap.Fingerprint = _("<keep>");
             SelectedPropertyMap.FileSize = totalFileSize.ToFileSizeString();
         }
         SelectedMusicFilesPropertiesChanged?.Invoke(this, EventArgs.Empty);

--- a/NickvisionTagger.Shared/Helpers/Gettext.cs
+++ b/NickvisionTagger.Shared/Helpers/Gettext.cs
@@ -6,7 +6,7 @@ namespace NickvisionTagger.Shared.Helpers;
 
 public static class Gettext
 {
-    private static readonly ICatalog _catalog = new Catalog("application", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+    private static readonly ICatalog _catalog = new Catalog("tagger", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
     
     public static string _(string text)
     {

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -467,12 +467,10 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             {
                 new Picture(FrontAlbumArt)
                 {
-                    MimeType = "image/jpeg",
                     Type = PictureType.FrontCover
                 },
                 new Picture(BackAlbumArt)
                 {
-                    MimeType = "image/jpeg",
                     Type = PictureType.BackCover
                 }
             };

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-09 21:51+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,23 +19,44 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Odesílání dat do AcoustId..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -54,148 +75,11 @@ msgstr ""
 "Pokud nezadáte nic, odešle místo toho aplikace metadata vaší značky společně "
 "s otiskem."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Převést"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr "Některé hudební soubory mají stále čekající změny. Co chcete udělat?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "Otisk byl zkopírován do schránky."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Stahování metadat z MusicBrainz..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Vložit obal alba"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Metadata pro {0} souborů úspěšně stažena"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"Do AcoustId lze najednou odeslat pouze jeden soubor. Vyberte prosím pouze "
-"jeden soubor a zkuste to znovu."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Načítání hudebních souborů ze složky..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Použít změny?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Potvrdit"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Vyberte prosím formátový řetězec."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Matrix Chat"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "GitHub repozitář"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Označte svou hudbu"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Vybráno příliš mnoho souborů"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "OK"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Zrušit"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "Úspěšně převeden {0} název souboru na značku"
-msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
-msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "Úspěšně převedena {0} značka na název souboru"
-msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
-msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Název souboru na značku"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 MiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Přispěvatelé na GitHubu ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Metadata úspěšně odeslána do AcoustId"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Pokročilé vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
 "to search files' tag contents for certain values, using a powerful tag-based "
@@ -299,99 +183,219 @@ msgstr ""
 "            * Pokročilé vyhledávání nerozlišuje velká a malá písmena\n"
 "            * Názvy vlastností musí být anglicky"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
-
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "Nepodařilo se načíst soubor s obrázkem"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Otevřít složku"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "KiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
 #, fuzzy
-msgid "Insert Front Album Art"
-msgstr "Vložit obal alba"
+msgid "album"
+msgstr "Album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Umělec alba"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Použít změny?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Umělec"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Komentář"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+#, fuzzy
+msgid "composer"
+msgstr "Skladatel"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Převést"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "Úspěšně převeden {0} název souboru na značku"
+msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
+msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "Úspěšně převedena {0} značka na název souboru"
+msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
+msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
 #, csharp-format
 msgid "David Lapshin {0}"
 msgstr "David Lapshin {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "MusicBrainz Recording Id"
-msgstr "ID nahrávky MusicBrainz"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Popis"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Zrušit"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Rušení nepoužitých změn..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Metadata pro {0} souborů úspěšně stažena"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Stahování metadat z MusicBrainz..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Vložit obal alba"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Vložit obal alba"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "Úspěšně převedena {0} značka na název souboru"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "Úspěšně převedena {0} značka na název souboru"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Název souboru na značku"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "Otisk byl zkopírován do schránky."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Formátový řetězec"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Žánr"
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Program.cs:49
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
-msgid "Tagger"
-msgstr "Označovač"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Značka na název souboru"
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "TiB"
-msgstr "TiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Rušení nepoužitých změn..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Odeslat do AcoustId"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Ukládání značek..."
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "MiB"
-
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "GitHub repozitář"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Vložit obal alba"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+#, fuzzy
+msgid "Insert Front Album Art"
+msgstr "Vložit obal alba"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "KiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -399,26 +403,177 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Načítání hudebních souborů ze složky..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Matrix Chat"
+
 #: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
+msgid "MiB"
+msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Formátový řetězec"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "MusicBrainz Recording Id"
+msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
 msgstr ""
+"Nicholas Logozzo {0}\n"
+"Přispěvatelé na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "OK"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"Do AcoustId lze najednou odeslat pouze jeden soubor. Vyberte prosím pouze "
+"jeden soubor a zkuste to znovu."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Otevřít složku"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Vyberte prosím formátový řetězec."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+#, fuzzy
+msgid "publisher"
+msgstr "Vydavatel"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Ukládání značek..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr "Některé hudební soubory mají stále čekající změny. Co chcete udělat?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Potvrdit"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Odeslat do AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Metadata úspěšně odeslána do AcoustId"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Odesílání dat do AcoustId..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "Switch to Back Cover"
 msgstr ""
 
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Značka na název souboru"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Označte svou hudbu"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:49
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
+msgid "Tagger"
+msgstr "Označovač"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "TiB"
+msgstr "TiB"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Název"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Vybráno příliš mnoho souborů"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Stopa"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
+
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "Nepodařilo se načíst soubor s obrázkem"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
+msgstr ""
+
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Předvolby"
@@ -486,7 +641,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Zachovat časové razítko změny"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Webové služby"
 
@@ -564,32 +719,42 @@ msgstr "Převést značku na název souboru"
 msgid "Remove Front Album Art"
 msgstr "Odstranit obal alba"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Obal alba"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Odstranit obal alba"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Webové služby"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Stáhnout metadata z MusicBrainz"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplikace"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Klávesové zkratky"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "O aplikaci Označovač"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Opustit"
 
@@ -597,170 +762,168 @@ msgstr "Opustit"
 msgid "Album Art"
 msgstr "Obal alba"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Vložit"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Odebrat"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Otevřít složku s hudbou (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Otevřít"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Znovu načíst složku s hudbou (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Hlavní nabídka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Přepnout panel značek"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Použít změny u značky (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Akce značky"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Označte svou hudbu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Začněte otevřením složky s hudbou"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Zkuste jinou složku"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr ""
 "Hledat název souboru (zadejte ! pro aktivaci pokročilého vyhledávání)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Vyberte nějaké soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Název souboru"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Vlastnosti značky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Název"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Umělec"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Rok"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Stopa"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Umělec alba"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Žánr"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Komentář"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr "Další vlastnosti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr "Skladatel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 msgid "Description"
 msgstr "Popis"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr "ISRC"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Doba trvání"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Otisk"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Zkopírovat otisk do schránky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Velikost souboru"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Přepnout panel značek"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Znovu načíst složku s hudbou (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Akce značky"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Použít změny u značky (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-02 01:57+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,23 +19,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Daten werden zu AcoustId gesendet..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -55,147 +76,11 @@ msgstr ""
 "Wenn du keinen angibst, wird Tagger stattdessen die Metadaten deiner Tags in "
 "Verbindung mit dem Fingerabdruck übermitteln."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Konvertieren"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Einige Musikdateien haben ungespeicherte Änderungen. Was möchtest du tun?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "Fingerabdruck zur Zwischenablage kopiert."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Albumcover einfügen"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"Es kann jeweils nur eine Datei an AcoustID übermittelt werden. Bitte wähle "
-"nur eine Datei aus und versuche es erneut."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Lade Musikdateien von Ordner..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Änderungen anwenden?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Senden"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Bitte Formatvorlage auswählen."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Matrix-Chat"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "GitHub-Repo"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Tage deine Musik"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Zu viele Dateien ausgewählt"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "OK"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Verwerfen"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
-msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
-msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Dateiname zu Tag"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 MiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Beitragende auf GitHub ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Erweiterte Suche"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 #, fuzzy
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
@@ -294,60 +179,347 @@ msgstr ""
 "            * Erweiterte Suche ignoriert Groß- / Kleinschreibung\n"
 "            * Namen von Eigenschaften müssen Englisch sein"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Feliks Weber <feliks@notabit.eu>"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+#, fuzzy
+msgid "album"
+msgstr "Album"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "Konnte Bilddatei nicht laden"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Album-Interpret"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Ordner öffnen"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
+msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Änderungen anwenden?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Künstler"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "KiB"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Kommentar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Konvertieren"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
+msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
+msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr "David Lapshin {0}"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Länge"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Verwerfen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Nicht angewendete Änderungen werden verworfen..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Albumcover einfügen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Albumcover einfügen"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "{0} Tag erfolgreich zu Dateiname konvertiert"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "{0} Tag erfolgreich zu Dateiname konvertiert"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Dateiname zu Tag"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "Fingerabdruck zur Zwischenablage kopiert."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Formatvorlage"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Genre"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr "GiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "GitHub-Repo"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Albumcover einfügen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumcover einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr "Anwenden"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "KiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
-msgstr "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] "{0} Musikdatei geladen."
+msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Lade Musikdateien von Ordner..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Matrix-Chat"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "MiB"
+msgstr "MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
-msgstr "GiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Beitragende auf GitHub ❤️ {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "OK"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"Es kann jeweils nur eine Datei an AcoustID übermittelt werden. Bitte wähle "
+"nur eine Datei aus und versuche es erneut."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Ordner öffnen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Bitte Formatvorlage auswählen."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Tags werden gespeichert..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Einige Musikdateien haben ungespeicherte Änderungen. Was möchtest du tun?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Senden"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Zu AcoustId senden"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Daten werden zu AcoustId gesendet..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Tag zu Dateiname"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Tage deine Musik"
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
@@ -355,64 +527,45 @@ msgstr "GiB"
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Tag zu Dateiname"
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Nicht angewendete Änderungen werden verworfen..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Zu AcoustId senden"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Tags werden gespeichert..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Track"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] "{0} Musikdatei geladen."
-msgstr[1] "{0} Musikdateien geladen."
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Formatvorlage"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Einstellungen"
@@ -480,7 +633,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Modifizier-Zeitstempel erhalten"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Web-Dienste"
 
@@ -557,32 +710,42 @@ msgstr "Tag zu Dateinamen konvertieren"
 msgid "Remove Front Album Art"
 msgstr "Albumcover entfernen"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Albumcover"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Albumcover entfernen"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Web-Dienste"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz-Metadaten herunterladen"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Anwendung"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Tastenkürzel"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "Über Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Beenden"
 
@@ -590,172 +753,170 @@ msgstr "Beenden"
 msgid "Album Art"
 msgstr "Albumcover"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Einfügen"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Entfernen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Musikordner öffnen (Strg+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Öffnen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Musikordner neu laden (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Tag-Bereich zeigen/verstecken"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Änderungen auf Tag anwenden (Strg+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Tag-Aktionen"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Tage deine Musik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Öffne einen Ordner mit Musik um loszulegen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Versuche einen anderen Ordner"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr ""
 "Suche nach Dateinamen (schreibe ! um erweiterte Suche zu aktivieren)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Wähle Dateien aus"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Dateiname"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Tag-Eigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Titel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Künstler"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Jahr"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Track"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Album-Interpret"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Genre"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Kommentar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 #, fuzzy
 msgid "More Properties"
 msgstr "Dateieigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 #, fuzzy
 msgid "Description"
 msgstr "Länge"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Dateieigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Länge"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Fingerabdruck in die Zwischenablage kopieren"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Dateigröße"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Tag-Bereich zeigen/verstecken"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Musikordner neu laden (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Tag-Aktionen"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Änderungen auf Tag anwenden (Strg+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-04 02:50+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -20,23 +20,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Enviando datos a AcoustId..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -56,148 +77,11 @@ msgstr ""
 "En caso contrario, Tagger enviará los metadatos de la etiqueta asociados a "
 "la firma."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Convertir"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Algunos archivos de música aún tienen cambios pendientes de aplicar. ¿Qué le "
-"gustaría hacer?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "La firma se ha copiado al portapapeles."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Descargando metadatos de MusicBrainz…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Insertar portada del álbum"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Descargados correctamente los metadatos de {0} archivos"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"Sólo se puede enviar un archivo a AcoustID cada vez. Seleccione sólo un "
-"archivo e inténtelo de nuevo."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Cargando archivos de música desde la carpeta…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "¿Aplicar cambios?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Enviar"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Seleccione una cadena de formato."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Chat de Matrix"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "Repo de GitHub"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Etiquete su música"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Demasiados archivos seleccionados"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "Vale"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Descartar"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
-msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "Convertida la etiqueta {0} en nombre de archivo con éxito"
-msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Nombre de archivo a etiquetar"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 MiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Colaboradores en GitHub ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Metadatos enviados a AcoustId con éxito"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
 "to search files' tag contents for certain values, using a powerful tag-based "
@@ -302,60 +186,350 @@ msgstr ""
 "minúsculas.\n"
 "            * Los nombres de las propiedades deben estar en inglés"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+#, fuzzy
+msgid "album"
+msgstr "Álbum"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "No se ha podido cargar el archivo de imagen"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Artista del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Abrir carpeta"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
+msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "¿Aplicar cambios?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Artista"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "KiB"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Comentario"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+#, fuzzy
+msgid "composer"
+msgstr "Compositor"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Convertir"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
+msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "Convertida la etiqueta {0} en nombre de archivo con éxito"
+msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr "David Lapshin {0}"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Descripción"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Descartar"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Descartando cambios no aplicados..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Descargados correctamente los metadatos de {0} archivos"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Descargando metadatos de MusicBrainz…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Insertar portada del álbum"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Insertar portada del álbum"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "Convertida la etiqueta {0} en nombre de archivo con éxito"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "Convertida la etiqueta {0} en nombre de archivo con éxito"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Nombre de archivo a etiquetar"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "La firma se ha copiado al portapapeles."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Cadena de formato"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Género"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr "GiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "Repo de GitHub"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Insertar portada del álbum"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Insertar portada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr "Aplicar"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "KiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
-msgstr "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] "Cargado {0} archivo de música."
+msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Cargando archivos de música desde la carpeta…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Chat de Matrix"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "MiB"
+msgstr "MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
-msgstr "GiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Colaboradores en GitHub ❤️ {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "Vale"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"Sólo se puede enviar un archivo a AcoustID cada vez. Seleccione sólo un "
+"archivo e inténtelo de nuevo."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Abrir carpeta"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Seleccione una cadena de formato."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+#, fuzzy
+msgid "publisher"
+msgstr "Editor"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Guardando etiquetas…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Algunos archivos de música aún tienen cambios pendientes de aplicar. ¿Qué le "
+"gustaría hacer?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Enviar"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Enviar a AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Metadatos enviados a AcoustId con éxito"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Enviando datos a AcoustId..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Etiqueta a nombre de archivo"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Etiquete su música"
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
@@ -363,64 +537,45 @@ msgstr "GiB"
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Etiqueta a nombre de archivo"
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Descartando cambios no aplicados..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Enviar a AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Demasiados archivos seleccionados"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Guardando etiquetas…"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Pista"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] "Cargado {0} archivo de música."
-msgstr[1] "Cargados {0} archivos de música."
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Cadena de formato"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferencias"
@@ -488,7 +643,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Conservar fecha de modificación"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Servicios web"
 
@@ -568,32 +723,42 @@ msgstr "Convertir etiqueta en nombre de archivo"
 msgid "Remove Front Album Art"
 msgstr "Eliminar la portada del álbum"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Portada"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Eliminar la portada del álbum"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Servicios web"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Descargar metadatos de MusicBrainz"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplicación"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Atajos del teclado"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "Acerca de Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Salir"
 
@@ -601,170 +766,168 @@ msgstr "Salir"
 msgid "Album Art"
 msgstr "Portada"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Insertar"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Eliminar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Abrir carpeta de música (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Abrir"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Recargar carpeta de música (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Conmutar panel de etiquetas"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Acciones de etiqueta"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Etiquete su música"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Abra una carpeta con música para empezar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Pruebe con otra carpeta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr ""
 "Buscar nombre de archivo (escriba ! para activar la búsqueda avanzada)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Seleccione algunos archivos"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Propiedades de la etiqueta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Título"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Artista"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Álbum"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Año"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Pista"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Artista del álbum"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Género"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Comentario"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr "Más propiedades"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr "Compositor"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 msgid "Description"
 msgstr "Descripción"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr "Editor"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr "ISRC"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Propiedades del archivo"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Duración"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copiar firma al portapapeles"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Tamaño del archivo"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Conmutar panel de etiquetas"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Recargar carpeta de música (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Acciones de etiqueta"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-02 01:57+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,23 +19,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Envoi des données à AcoustId…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -55,148 +76,11 @@ msgstr ""
 "Si aucun identifiant n’est fourni, Tagger enverra vos balises de métadonnées "
 "associées à l’empreinte à la place."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Convertir"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Des fichiers de musiques ont encore des modifications en attente d’être "
-"appliquées. Que souhaitez-vous faire ?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "Empreinte copiée vers le presse-papiers."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Ajouter une pochette d'album"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"Seul un fichier peut être envoyé à AcoustId à la fois. Sélectionnez un seul "
-"fichier et essayez à nouveau."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Chargement des musiques depuis le dossier…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Appliquer les changements ?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Envoyer"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Sélectionnez un format."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Discussion Matrix"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "Dépôt GitHub"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Associez des balises à vos musiques"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Trop de fichiers sélectionnés"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "OK"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Abandonner"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "{0} nom de fichier converti en balise avec succès"
-msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "{0} balise convertie en nom de fichier avec succès"
-msgstr[1] "{0} balises converties en noms de fichiers avec succès"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Nom de fichier vers balise"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 MiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Contributeurs sur GitHub ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Métadonnées envoyées à AcoustId avec succès"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Recherche avancée"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 #, fuzzy
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
@@ -296,60 +180,348 @@ msgstr ""
 "            * La recherche avancée est sensible à la casse\n"
 "            * Les noms des propriétés doivent être saisis en anglais"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Irénée Thirion"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+#, fuzzy
+msgid "album"
+msgstr "Album"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "Impossible de charger l’image"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Artiste de l'album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Ouvrir un dossier"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
+msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Appliquer les changements ?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Artiste"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "o"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "kio"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Commentaire"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Convertir"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "{0} nom de fichier converti en balise avec succès"
+msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "{0} balise convertie en nom de fichier avec succès"
+msgstr[1] "{0} balises converties en noms de fichiers avec succès"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr "David Lapshin {0}"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Durée"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Abandonner"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Abandon des changements..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Ajouter une pochette d'album"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Ajouter une pochette d'album"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "{0} balise convertie en nom de fichier avec succès"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "{0} balise convertie en nom de fichier avec succès"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Nom de fichier vers balise"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "Empreinte copiée vers le presse-papiers."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Format"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Genre"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr "Gio"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "Dépôt GitHub"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Ajouter une pochette d'album"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Ajouter une pochette d'album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr "Appliquer"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "kio"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
-msgstr "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] "{0} musique chargée."
+msgstr[1] "{0} musiques chargées."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Chargement des musiques depuis le dossier…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Discussion Matrix"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "MiB"
+msgstr "Mio"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
-msgstr "Gio"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Contributeurs sur GitHub ❤️ {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "OK"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"Seul un fichier peut être envoyé à AcoustId à la fois. Sélectionnez un seul "
+"fichier et essayez à nouveau."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Ouvrir un dossier"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Sélectionnez un format."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Enregistrement des balises…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Des fichiers de musiques ont encore des modifications en attente d’être "
+"appliquées. Que souhaitez-vous faire ?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Envoyer"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Envoyer à AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Métadonnées envoyées à AcoustId avec succès"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Envoi des données à AcoustId…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Balise vers nom de fichier"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Associez des balises à vos musiques"
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
@@ -357,64 +529,45 @@ msgstr "Gio"
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Balise vers nom de fichier"
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "Tio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Abandon des changements..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Envoyer à AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Enregistrement des balises…"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Morceau"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "Mio"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Irénée Thirion"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] "{0} musique chargée."
-msgstr[1] "{0} musiques chargées."
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "Impossible de charger l’image"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "o"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Format"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Préférences"
@@ -482,7 +635,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Conserver l’horodatage de modification"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Services Web"
 
@@ -562,32 +715,42 @@ msgstr "Convertir la balise en nom de fichier"
 msgid "Remove Front Album Art"
 msgstr "Retirer la pochette d'album"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Couverture de l’album"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Retirer la pochette d'album"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Services Web"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Application"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis claviers"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "À propos de Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Quitter"
 
@@ -595,171 +758,169 @@ msgstr "Quitter"
 msgid "Album Art"
 msgstr "Couverture de l’album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Insérer"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Supprimer"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Ouvrir un dossier de musiques (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Ouvrir"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Recharger le dossier de musiques (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Basculer le volet des balises"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Appliquer les changements à la balise (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Actions de balise"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Étiquetez vos musiques"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Ouvrez un dossier contenant des musiques pour commencer"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Essayez un autre dossier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr "Rechercher un fichier (tapez ! pour activer la recherche avancée)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Sélectionnez des fichiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Propriétés de la balise"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Titre"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Artiste"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Année"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Morceau"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Artiste de l'album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Genre"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Commentaire"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 #, fuzzy
 msgid "More Properties"
 msgstr "Propriétés du fichier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 #, fuzzy
 msgid "Description"
 msgstr "Durée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Propriétés du fichier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Durée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Empreinte"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copier l’empreinte vers le presse-papiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Taille"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Basculer le volet des balises"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Recharger le dossier de musiques (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Actions de balise"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2022-11-17 15:03+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
@@ -15,25 +15,48 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-#, fuzzy
-msgid "Submitting data to AcoustId..."
-msgstr "Slanje metapodatka AcoustId-u …"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -54,156 +77,11 @@ msgstr ""
 "Ako se ne navede, Tagger će umjesto toga poslati metapodatke tvoje oznake u "
 "suradnji s digitalnim otiskom."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#, fuzzy
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Neke glazbene datoteke još uvijek imaju promjene koje čekaju da se "
-"primijene. Želiš li primijeniti te promjene na datoteku ili ih odbaciti?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-#, fuzzy
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Preuzmi MusicBrainz metapodatke"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Umetni sliku albuma"
-
-#: ../../../Controllers/MainWindowController.cs:594
-#, fuzzy
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Broj uspješno preuzetih metapodataka za datoteke: %d"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#, fuzzy
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"AcoustId-u se može poslati samo jedna datoteka po slanju. Odaberi samo jednu "
-"datoteku i pokušaj ponovo."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-#, fuzzy
-msgid "Loading music files from folder..."
-msgstr "Učitavanje glazbenih datoteka …"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Primijeniti promjene?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-#, fuzzy
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Nije moguće poslati metapodatke AcoustId-u."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Odaberi jedan znakovni niz formata."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Odabrano je previše datoteka"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "U redu"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Odbaci"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, fuzzy, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
-msgstr[1] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
-msgstr[2] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, fuzzy, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
-msgstr[1] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
-msgstr[2] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-#, fuzzy
-msgid "File Name to Tag"
-msgstr "Ime datoteke u oznaku"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-#, fuzzy
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Metapodaci su uspješno poslani AcoustId-u."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Napredna pretraga"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 #, fuzzy
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
@@ -300,105 +178,223 @@ msgstr ""
 "\n"
 "    * Napredna pretraga ne razlikuje velika i mala slova *"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
 #, fuzzy
-msgid "Open Folder"
-msgstr "Otvori mapu glazbe"
+msgid "album"
+msgstr "Album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Cancel"
-msgstr "Odustani"
-
-#: ../../../Helpers/MediaHelpers.cs:33
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
 #, fuzzy
-msgid "KiB"
-msgstr "KB"
+msgid "albumartist"
+msgstr "Izvođač albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
-#, fuzzy
-msgid "Insert Front Album Art"
-msgstr "Umetni sliku albuma"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Primijeniti promjene?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Izvođač"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Cancel"
+msgstr "Odustani"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Komentar"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, fuzzy, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
+msgstr[1] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
+msgstr[2] "Broj uspješno pretvorenih imena datoteka u oznake: %d"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, fuzzy, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
+msgstr[1] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
+msgstr[2] "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
 #, csharp-format
 msgid "David Lapshin {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "MusicBrainz Recording Id"
-msgstr "ID oznaka MusicBrainz snimke"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Trajanje"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Odbaci"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Odbacivanje neprimjenjenih promjena …"
+
+#: ../../../Controllers/MainWindowController.cs:643
+#, fuzzy
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Broj uspješno preuzetih metapodataka za datoteke: %d"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#, fuzzy
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Preuzmi MusicBrainz metapodatke"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Umetni sliku albuma"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Umetni sliku albuma"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "Broj uspješno pretvorenih oznaka u imena datoteka: %d"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+#, fuzzy
+msgid "File Name to Tag"
+msgstr "Ime datoteke u oznaku"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Znakovni niz formata"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Žanr"
 
 #: ../../../Helpers/MediaHelpers.cs:33
 #, fuzzy
 msgid "GiB"
 msgstr "GB"
 
-#: ../../../../NickvisionTagger.GNOME/Program.cs:49
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
-msgid "Tagger"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 #, fuzzy
-msgid "Tag to File Name"
-msgstr "Oznaka u ime datoteke"
+msgid "Insert Back Album Art"
+msgstr "Umetni sliku albuma"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+#, fuzzy
+msgid "Insert Front Album Art"
+msgstr "Umetni sliku albuma"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 #, fuzzy
-msgid "TiB"
-msgstr "TB"
+msgid "KiB"
+msgstr "KB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Odbacivanje neprimjenjenih promjena …"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Pošalji AcoustId-u"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Spremanje oznaka …"
-
-#: ../../../Helpers/MediaHelpers.cs:33
-#, fuzzy
-msgid "MiB"
-msgstr "MB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -406,26 +402,183 @@ msgstr[0] "Učitane glazbene datoteke: %d."
 msgstr[1] "Učitane glazbene datoteke: %d."
 msgstr[2] "Učitane glazbene datoteke: %d."
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+#, fuzzy
+msgid "Loading music files from folder..."
+msgstr "Učitavanje glazbenih datoteka …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Znakovni niz formata"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
+#: ../../../Helpers/MediaHelpers.cs:33
+#, fuzzy
+msgid "MiB"
+msgstr "MB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "MusicBrainz Recording Id"
+msgstr "ID oznaka MusicBrainz snimke"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "U redu"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#, fuzzy
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"AcoustId-u se može poslati samo jedna datoteka po slanju. Odaberi samo jednu "
+"datoteku i pokušaj ponovo."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+#, fuzzy
+msgid "Open Folder"
+msgstr "Otvori mapu glazbe"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Odaberi jedan znakovni niz formata."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Spremanje oznaka …"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#, fuzzy
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Neke glazbene datoteke još uvijek imaju promjene koje čekaju da se "
+"primijene. Želiš li primijeniti te promjene na datoteku ili ih odbaciti?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Pošalji AcoustId-u"
+
+#: ../../../Controllers/MainWindowController.cs:656
+#, fuzzy
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Metapodaci su uspješno poslani AcoustId-u."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#, fuzzy
+msgid "Submitting data to AcoustId..."
+msgstr "Slanje metapodatka AcoustId-u …"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "Switch to Back Cover"
 msgstr ""
 
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#, fuzzy
+msgid "Tag to File Name"
+msgstr "Oznaka u ime datoteke"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:49
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
+msgid "Tagger"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+#, fuzzy
+msgid "TiB"
+msgstr "TB"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Naslov"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Odabrano je previše datoteka"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Pjesma"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:656
+#, fuzzy
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Nije moguće poslati metapodatke AcoustId-u."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
+msgstr ""
+
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Postavke"
@@ -500,7 +653,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Sačuvaj vremensku oznaku modifikacije"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Web usluge"
 
@@ -582,35 +735,45 @@ msgstr "Pretvori oznaku u ime datoteke"
 msgid "Remove Front Album Art"
 msgstr "Ukloni sliku albuma"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Izvođač albuma"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Ukloni sliku albuma"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 #, fuzzy
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Web usluge"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 #, fuzzy
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Aplikacija"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Tipkovni prečaci"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 #, fuzzy
 msgid "About Tagger"
 msgstr "Informacije o %s"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr ""
 
@@ -619,174 +782,172 @@ msgstr ""
 msgid "Album Art"
 msgstr "Izvođač albuma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Otvori mapu glazbe (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Otvori"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Ponovo učitaj mapu glazbe (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Glavni izbornik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Primijeni promjene na oznaku (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Radnje oznaka"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 #, fuzzy
 msgid "Open a folder with music to get started"
 msgstr ""
 "Otvori mapu s glazbenim datotekama (ili povuci jednu mapu u aplikaciju)."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 #, fuzzy
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 #, fuzzy
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Naslov"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Izvođač"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Godina"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Pjesma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Izvođač albuma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Žanr"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Komentar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 #, fuzzy
 msgid "Description"
 msgstr "Trajanje"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Trajanje"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Digitalni otisak"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Veličina datoteke"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Ponovo učitaj mapu glazbe (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Radnje oznaka"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-02 01:57+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,23 +19,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Invio dei dati ad AcoustId in corso..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0} \n"
-"Fyodor Sobolev {1} \n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -55,147 +76,11 @@ msgstr ""
 "Se non viene fornito nessun identificativo, Tagger invierà i metadati "
 "associati alla firma di questo brano."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Converti"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Sono presenti alcune modifiche in attesa di essere applicate. Cosa vuoi fare?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "La firma è stata copiata negli appunti."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Download dei metadati da MusicBrainz in corso..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Inserisci copertina"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "I metadati per {0} sono stati scaricati con successo"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"È possibile inviare solamente un brano per volta ad AcoustId. Seleziona un "
-"solo brano ed invia nuovamente i dati."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Caricamento dei brani dalla cartella..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Vuoi applicare le modifiche?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Invia"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Seleziona un formato."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Chat Matrix"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "Repository GitHub"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Associa un'etichetta ai tuoi brani"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Sono stati selezionati troppi file"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "Ok"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Scarta"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "{0} nome di file è stato convertito con successo"
-msgstr[1] "{0} nomi di file sono stati convertiti con successo"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
-msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Nome del file a etichetta"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 MiB"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Hanno collaborato su GitHub ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "I metadati sono stati inviati con successo a AcoustId"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Ricerca avanzata"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 #, fuzzy
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
@@ -294,60 +179,347 @@ msgstr ""
 "            * La ricerca non tiene conto di maiuscole e minuscole\n"
 "            * I nomi delle proprietà devono essere indicate in inglese"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Federico Marchetti"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+#, fuzzy
+msgid "album"
+msgstr "Album"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "Impossibile caricare l'immagine"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Artista dell'album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Apri cartella"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
+msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Vuoi applicare le modifiche?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Artista"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "KiB"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Commento"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Converti"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "{0} nome di file è stato convertito con successo"
+msgstr[1] "{0} nomi di file sono stati convertiti con successo"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
+msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr "David Lapshin {0}"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Durata"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Scarta"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Annullamento modifiche non applicate..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "I metadati per {0} sono stati scaricati con successo"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Download dei metadati da MusicBrainz in corso..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Inserisci copertina"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Inserisci copertina"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "{0} etichetta è stata convertita in nome di file con successo"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "{0} etichetta è stata convertita in nome di file con successo"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Nome del file a etichetta"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "La firma è stata copiata negli appunti."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Formato"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Genere"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr "GiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "Repository GitHub"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Inserisci copertina"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr "Applica"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "KiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
-msgstr "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] "Brano {0} caricato."
+msgstr[1] "Brani {0} caricati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Caricamento dei brani dalla cartella..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Chat Matrix"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "MiB"
+msgstr "MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
-msgstr "GiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Hanno collaborato su GitHub ❤️ {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0} \n"
+"Fyodor Sobolev {1} \n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "Ok"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"È possibile inviare solamente un brano per volta ad AcoustId. Seleziona un "
+"solo brano ed invia nuovamente i dati."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Apri cartella"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Seleziona un formato."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Salvataggio delle etichette in corso..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Sono presenti alcune modifiche in attesa di essere applicate. Cosa vuoi fare?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Invia"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Invia ad AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "I metadati sono stati inviati con successo a AcoustId"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Invio dei dati ad AcoustId in corso..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Etichetta a nome di file"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Associa un'etichetta ai tuoi brani"
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
@@ -355,64 +527,45 @@ msgstr "GiB"
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Etichetta a nome di file"
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Annullamento modifiche non applicate..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Invia ad AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Sono stati selezionati troppi file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Salvataggio delle etichette in corso..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Numero della traccia"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Federico Marchetti"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] "Brano {0} caricato."
-msgstr[1] "Brani {0} caricati."
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "Impossibile caricare l'immagine"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Formato"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Preferenze"
@@ -480,7 +633,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Preserva la data di modifica"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Servizi Web"
 
@@ -559,32 +712,42 @@ msgstr "Converti l'etichetta al nome del file"
 msgid "Remove Front Album Art"
 msgstr "Rimuovi la copertina"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Copertina"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Rimuovi la copertina"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Servizi Web"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Applicazione"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "Informazioni su Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Esci"
 
@@ -592,171 +755,169 @@ msgstr "Esci"
 msgid "Album Art"
 msgstr "Copertina"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Inserisci"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Apri la cartella contenente i brani (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Apri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Ricarica la cartella contenente i brani (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Menù principale"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Commuta i pannelli delle etichette"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Applica le modifiche alle etichette (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Azioni sulle etichette"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Etichetta la tua musica"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Apri una cartella contenente dei brani per iniziare"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Prova una cartella diversa"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr "Cerca un brano (inserisci ! per attivare la ricerca avanzata)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Seleziona dei file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Nome del file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Proprietà delle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Titolo"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Artista"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Anno"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Numero della traccia"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Artista dell'album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Genere"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Commento"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 #, fuzzy
 msgid "More Properties"
 msgstr "Proprietà del file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 #, fuzzy
 msgid "Description"
 msgstr "Durata"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Proprietà del file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Durata"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copia l'impronta negli appunti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Dimensione"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Commuta i pannelli delle etichette"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Ricarica la cartella contenente i brani (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Azioni sulle etichette"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: 2023-07-01 12:52+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -18,21 +18,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-#, fuzzy
-msgid "Submitting data to AcoustId..."
-msgstr "Bezig met versturen naar AcoustId…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -53,154 +76,11 @@ msgstr ""
 "Als u geen id opgeeft, zal Tagger de metagegevens op basis van de "
 "controlesom versturen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Converteren"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#, fuzzy
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Enkele muziekbestanden zijn gewijzigd, maar nog niet opgeslagen. Wilt u dat "
-"nu doen of de wijzigingen verwerpen?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-#, fuzzy
-msgid "Downloading MusicBrainz metadata..."
-msgstr "MusicBrainz-metagegevens ophalen"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#, fuzzy
-msgid "Insert Back Album Art"
-msgstr "Albumhoes toevoegen"
-
-#: ../../../Controllers/MainWindowController.cs:594
-#, fuzzy
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Er zijn metagegevens van %d bestanden opgehaald"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#, fuzzy
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"U kunt slechts één bestand tegelijk naar AcoustId versturen. Kies een "
-"bestand en probeer het opnieuw."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-#, fuzzy
-msgid "Loading music files from folder..."
-msgstr "Bezig met laden van muziekbestanden…"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Wijzigingen toepassen?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-#, fuzzy
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Kies een opmaakmethode."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Teveel bestanden geselecteerd"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "Oké"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Verwerpen"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, fuzzy, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
-msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, fuzzy, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
-msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-#, fuzzy
-msgid "File Name to Tag"
-msgstr "Bestandsnaam naar tag"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-#, fuzzy
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "De metagegevens zijn verstuurd naar AcoustId."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Geavanceerd zoeken"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 #, fuzzy
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
@@ -296,61 +176,353 @@ msgstr ""
 "\n"
 "    * Zoekopdrachten zijn niet hoofdlettergevoelig. *"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Philip Goto https://philipgoto.nl/"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+#, fuzzy
+msgid "album"
+msgstr "Album"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Albumartiest"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
+msgstr "Toepassen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Wijzigingen toepassen?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Artiest"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "B"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-#, fuzzy
-msgid "Open Folder"
-msgstr "Muziekmap openen"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "KiB"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Opmerking"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Converteren"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, fuzzy, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
+msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, fuzzy, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
+msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Duur"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Verwerpen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Bezig met verwerpen van wijzigingen…"
+
+#: ../../../Controllers/MainWindowController.cs:643
+#, fuzzy
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Er zijn metagegevens van %d bestanden opgehaald"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#, fuzzy
+msgid "Downloading MusicBrainz metadata..."
+msgstr "MusicBrainz-metagegevens ophalen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Albumhoes toevoegen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Albumhoes toevoegen"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "Er zijn %d tags omgezet in bestandsnamen"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "Er zijn %d tags omgezet in bestandsnamen"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+#, fuzzy
+msgid "File Name to Tag"
+msgstr "Bestandsnaam naar tag"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Opmaakmethode"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Genre"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr "GiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+#, fuzzy
+msgid "Insert Back Album Art"
+msgstr "Albumhoes toevoegen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr "Toepassen"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
-#, csharp-format
-msgid "David Lapshin {0}"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "KiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#, fuzzy, csharp-format
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] "Er zijn %d muziekbestanden geladen."
+msgstr[1] "Er zijn %d muziekbestanden geladen."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+#, fuzzy
+msgid "Loading music files from folder..."
+msgstr "Bezig met laden van muziekbestanden…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "MiB"
+msgstr "MiB"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
-msgstr "GiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "Oké"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#, fuzzy
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"U kunt slechts één bestand tegelijk naar AcoustId versturen. Kies een "
+"bestand en probeer het opnieuw."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+#, fuzzy
+msgid "Open Folder"
+msgstr "Muziekmap openen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Kies een opmaakmethode."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Bezig met opslaan van tags…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#, fuzzy
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Enkele muziekbestanden zijn gewijzigd, maar nog niet opgeslagen. Wilt u dat "
+"nu doen of de wijzigingen verwerpen?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Versturen naar AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+#, fuzzy
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "De metagegevens zijn verstuurd naar AcoustId."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#, fuzzy
+msgid "Submitting data to AcoustId..."
+msgstr "Bezig met versturen naar AcoustId…"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#, fuzzy
+msgid "Tag to File Name"
+msgstr "Tag naar bestandsnaam"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
@@ -358,65 +530,46 @@ msgstr "GiB"
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-#, fuzzy
-msgid "Tag to File Name"
-msgstr "Tag naar bestandsnaam"
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Bezig met verwerpen van wijzigingen…"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Versturen naar AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Bezig met opslaan van tags…"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Volgnummer"
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, fuzzy, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] "Er zijn %d muziekbestanden geladen."
-msgstr[1] "Er zijn %d muziekbestanden geladen."
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "B"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Opmaakmethode"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:656
+#, fuzzy
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Voorkeuren"
@@ -487,7 +640,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Bewerktijdstip niet aanpassen"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Online-diensten"
 
@@ -569,35 +722,45 @@ msgstr "Tag omzetten in bestandsnaam"
 msgid "Remove Front Album Art"
 msgstr "Albumhoes verwijderen"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Albumartiest"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Albumhoes verwijderen"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 #, fuzzy
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Online-diensten"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 #, fuzzy
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Toepassing"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 #, fuzzy
 msgid "About Tagger"
 msgstr "Over %s"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr ""
 
@@ -606,175 +769,173 @@ msgstr ""
 msgid "Album Art"
 msgstr "Albumartiest"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Muziekmap openen (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Openen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Muziekmap herladen (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Hoofdmenu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Tagwijzigingen opslaan (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Tagacties"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 #, fuzzy
 msgid "Open a folder with music to get started"
 msgstr ""
 "Open een map met muziekbestanden of sleep een map hierheen om aan de slag te "
 "gaan."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 #, fuzzy
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 #, fuzzy
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Titel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Artiest"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Jaar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Volgnummer"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Albumartiest"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Genre"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Opmerking"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 #, fuzzy
 msgid "Description"
 msgstr "Duur"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Duur"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Controlesom"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Bestandsgrootte"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Muziekmap herladen (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Tagacties"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:27+0300\n"
 "PO-Revision-Date: 2023-07-10 13:45+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,23 +20,44 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
-msgstr "Отправка данных в AcoustId..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
+msgstr "0 МиБ"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -56,149 +77,11 @@ msgstr ""
 "Если он не указан, Tagger отправит метаданные вашего тега вместе с "
 "отпечатком."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr "Конвертировать"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-"Некоторые музыкальные файлы все еще содержат изменения, ожидающие "
-"применения. Что бы вы хотели сделать?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr "Отпечаток был скопирован в буфер обмена."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr "Загрузка метаданных MusicBrainz..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-msgid "Insert Back Album Art"
-msgstr "Вставить заднюю обложку альбома"
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr "Метаданные для {0} файлов загружены успешно"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-"Одновременно в AcoustID может быть представлен только один файл. Пожалуйста, "
-"выберите только один файл и повторите попытку."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr "Загрузка музыкальных файлов из папки..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr "Применить изменения?"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr "Отправить"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr "Выберите формат строки."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr "Чат Matrix"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr "Репозиторий GitHub"
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr "Редактируйте ваши музыкальные теги"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr "Выбрано слишком много файлов"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr "ОК"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr "Отменить"
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] "Успешно преобразовано {0} имя файла в тег"
-msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
-msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] "Успешно преобразован {0} тег в имя файла"
-msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
-msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr "Имя файла в тег"
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr "0 МиБ"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-"Nicholas Logozzo {0}\n"
-"Участники на GitHub ❤️ {1}"
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr "Метаданные для AcoustId предоставлены успешно"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr "Продвинутый поиск"
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
 "to search files' tag contents for certain values, using a powerful tag-based "
@@ -295,98 +178,216 @@ msgstr ""
 "            * Продвинутый поиск не чувствителен к регистру\n"
 "            * Имена тегов должны быть на английском языке"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
-msgstr "Давид Лапшин"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+msgid "album"
+msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
-msgstr "Не удалось загрузить файл изображения"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+#, fuzzy
+msgid "albumartist"
+msgstr "Исполнитель альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
-msgstr "Открыть папку"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Cancel"
-msgstr "Отмена"
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "KiB"
-msgstr "КиБ"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
-msgid "Insert Front Album Art"
-msgstr "Вставить переднюю обложку альбома"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr "Применить изменения?"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+#, fuzzy
+msgid "artist"
+msgstr "Исполнитель"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr "Б"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr "Задняя"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Cancel"
+msgstr "Отмена"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+#, fuzzy
+msgid "comment"
+msgstr "Комментарий"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+#, fuzzy
+msgid "composer"
+msgstr "Композитор"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr "Конвертировать"
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] "Успешно преобразовано {0} имя файла в тег"
+msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
+msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] "Успешно преобразован {0} тег в имя файла"
+msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
+msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
 #, csharp-format
 msgid "David Lapshin {0}"
 msgstr "Давид Лапшин {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "MusicBrainz Recording Id"
-msgstr "ID записи MusicBrainz"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+#, fuzzy
+msgid "description"
+msgstr "Описание"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr "Отменить"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr "Отмена изменений..."
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr "Метаданные для {0} файлов загружены успешно"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr "Загрузка метаданных MusicBrainz..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+#, fuzzy
+msgid "Export Back Album Art"
+msgstr "Вставить заднюю обложку альбома"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+#, fuzzy
+msgid "Export Front Album Art"
+msgstr "Вставить переднюю обложку альбома"
+
+#: ../../../Controllers/MainWindowController.cs:610
+#, fuzzy
+msgid "Exported back album art to file successfully"
+msgstr "Успешно преобразован {0} тег в имя файла"
+
+#: ../../../Controllers/MainWindowController.cs:594
+#, fuzzy
+msgid "Exported front album art to file successfully"
+msgstr "Успешно преобразован {0} тег в имя файла"
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr "Имя файла в тег"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr "Отпечаток был скопирован в буфер обмена."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr "Формат строки"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr "Передняя"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+#, fuzzy
+msgid "genre"
+msgstr "Жанр"
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Program.cs:49
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
-msgid "Tagger"
-msgstr "Tagger"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr "Тег в имя файла"
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "TiB"
-msgstr "ТиБ"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
-msgstr "Отмена изменений..."
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
-msgstr "Отправить в AcoustId"
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
-msgstr "Сохранение тегов..."
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
-msgstr "МиБ"
-
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr "Репозиторий GitHub"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+msgid "Insert Back Album Art"
+msgstr "Вставить заднюю обложку альбома"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+msgid "Insert Front Album Art"
+msgstr "Вставить переднюю обложку альбома"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "KiB"
+msgstr "КиБ"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -394,26 +395,179 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
+msgstr "Загрузка музыкальных файлов из папки..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
+msgstr "Чат Matrix"
+
 #: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
-msgstr "Б"
+msgid "MiB"
+msgstr "МиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
-msgstr "Формат строки"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "MusicBrainz Recording Id"
+msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr "Переключиться на переднюю обложку"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Участники на GitHub ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr "ОК"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+"Одновременно в AcoustID может быть представлен только один файл. Пожалуйста, "
+"выберите только один файл и повторите попытку."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr "Открыть папку"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr "Выберите формат строки."
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+#, fuzzy
+msgid "publisher"
+msgstr "Издатель"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr "Сохранение тегов..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+"Некоторые музыкальные файлы все еще содержат изменения, ожидающие "
+"применения. Что бы вы хотели сделать?"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr "Отправить"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr "Отправить в AcoustId"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr "Метаданные для AcoustId предоставлены успешно"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr "Отправка данных в AcoustId..."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr "Переключиться на переднюю обложку"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr "Тег в имя файла"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
+msgstr "Редактируйте ваши музыкальные теги"
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:49
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
+msgid "Tagger"
+msgstr "Tagger"
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "TiB"
+msgstr "ТиБ"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+#, fuzzy
+msgid "title"
+msgstr "Название"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
+msgstr "Выбрано слишком много файлов"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+#, fuzzy
+msgid "track"
+msgstr "Номер трека"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
+msgstr "Давид Лапшин"
+
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
+msgstr "Не удалось загрузить файл изображения"
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
+msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
+msgstr ""
+
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr "Настройки"
@@ -481,7 +635,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Сохранение временной метки модификации"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr "Веб-сервисы"
 
@@ -559,32 +713,42 @@ msgstr "Конвертировать тег в имя файла"
 msgid "Remove Front Album Art"
 msgstr "Удалить переднюю обложку альбома"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#, fuzzy
+msgid "Switch Album Art"
+msgstr "Обложка альбома"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#, fuzzy
+msgid "Remove Back Album Art"
+msgstr "Удалить переднюю обложку альбома"
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr "Веб-сервисы"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr "Скачать метаданные MusicBrainz"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr "Приложение"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr "Сочетания клавиш"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr "О Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr "Выйти"
 
@@ -592,169 +756,167 @@ msgstr "Выйти"
 msgid "Album Art"
 msgstr "Обложка альбома"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr "Передняя"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr "Вставить"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr "Удалить"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
-msgstr "Задняя"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
+msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Открыть папку с музыкой (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr "Открыть"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr "Перезагрузить папку с музыкой (F5)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr "Главное меню"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr "Переключить панели тегов"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr "Применить изменения в тегах (Ctrl+S)"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr "Действия с тегами"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr "Откройте папку с музыкой, чтобы начать"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr "Попробуйте другую папку"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr "Поиск имени файла (введите ! для продвинутого поиска)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr "Выберите несколько файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr "Имя файла"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr "Свойства тега"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr "Название"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr "Исполнитель"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr "Альбом"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr "Год"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr "Номер трека"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr "Жанр"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr "Комментарий"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr "Больше свойств"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr "Композитор"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 msgid "Description"
 msgstr "Описание"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr "Издатель"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr "ISRC"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr "Свойства файла"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr "Длительность"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Скопировать отпечаток в буфер обмена"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
 msgstr "Размер"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr "Переключить панели тегов"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr "Перезагрузить папку с музыкой (F5)"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr "Действия с тегами"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
+msgstr "Применить изменения в тегах (Ctrl+S)"
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;"

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,20 +18,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -43,141 +67,11 @@ msgid ""
 "with the fingerprint instead."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-msgid "Insert Back Album Art"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr ""
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
 "to search files' tag contents for certain values, using a powerful tag-based "
@@ -231,58 +125,326 @@ msgid ""
 "            * Property names must be in English"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+msgid "albumartist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+msgid "artist"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+msgid "comment"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+msgid "description"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+msgid "Export Back Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+msgid "Export Front Album Art"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:610
+msgid "Exported back album art to file successfully"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:594
+msgid "Exported front album art to file successfully"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+msgid "genre"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+msgid "Insert Back Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+msgid "Insert Front Album Art"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
-msgid "Insert Front Album Art"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "MusicBrainz Recording Id"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
+msgid "MiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "MusicBrainz Recording Id"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
@@ -291,64 +453,43 @@ msgstr ""
 msgid "Tagger"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr ""
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+msgid "title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+msgid "track"
 msgstr ""
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr ""
@@ -416,7 +557,7 @@ msgid "Preserve Modification Timestamp"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr ""
 
@@ -490,32 +631,40 @@ msgstr ""
 msgid "Remove Front Album Art"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+msgid "Switch Album Art"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+msgid "Remove Back Album Art"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr ""
 
@@ -523,168 +672,166 @@ msgstr ""
 msgid "Album Art"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 msgid "Description"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-10 00:14+0200\n"
+"POT-Creation-Date: 2023-07-10 18:53+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,20 +17,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:709
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
-msgid "Submitting data to AcoustId..."
+#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:268
+#: ../../../Controllers/MainWindowController.cs:273
+#: ../../../Controllers/MainWindowController.cs:278
+#: ../../../Controllers/MainWindowController.cs:283
+#: ../../../Controllers/MainWindowController.cs:292
+#: ../../../Controllers/MainWindowController.cs:301
+#: ../../../Controllers/MainWindowController.cs:306
+#: ../../../Controllers/MainWindowController.cs:311
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:325
+#: ../../../Controllers/MainWindowController.cs:330
+#: ../../../Controllers/MainWindowController.cs:335
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:1184
+#: ../../../Controllers/MainWindowController.cs:1185
+#: ../../../Controllers/MainWindowController.cs:1186
+#: ../../../Controllers/MainWindowController.cs:1187
+#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1190
+#: ../../../Controllers/MainWindowController.cs:1191
+#: ../../../Controllers/MainWindowController.cs:1192
+#: ../../../Controllers/MainWindowController.cs:1193
+#: ../../../Controllers/MainWindowController.cs:1194
+#: ../../../Controllers/MainWindowController.cs:1195
+#: ../../../Controllers/MainWindowController.cs:1196
+#: ../../../Controllers/MainWindowController.cs:1197
+#: ../../../Controllers/MainWindowController.cs:1201
+msgid "<keep>"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Fyodor Sobolev {1}\n"
-"DaPigGuy {2}"
+#: ../../../Models/PropertyMap.cs:118
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
+msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -42,141 +66,11 @@ msgid ""
 "with the fingerprint instead."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: NickvisionTagger.GNOME/Blueprints/window.blp:36
-msgid "Convert"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid ""
-"Some music files still have changes waiting to be applied. What would you "
-"like to do?"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1154
-msgid "Fingerprint was copied to clipboard."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
-msgid "Downloading MusicBrainz metadata..."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-msgid "Insert Back Album Art"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:594
-msgid "Downloaded metadata for {0} files successfully"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid ""
-"Only one file can be submitted to AcoustID at a time. Please select only one "
-"file and try again."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:388
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:492
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:515
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:550
-msgid "Loading music files from folder..."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Apply Changes?"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "Submit"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Unable to submit to AcoustId. Check API key"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Please select a format string."
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:836
-msgid "Matrix Chat"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-msgid "GitHub Repo"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Program.cs:50
-#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
-msgid "Tag your music"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-msgid "Too Many Files Selected"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:687
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
-msgid "OK"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-msgid "Discard"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:469
-#, csharp-format
-msgid "Converted {0} file name to tag successfully"
-msgid_plural "Converted {0} file names to tags successfully"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../Controllers/MainWindowController.cs:492
-#, csharp-format
-msgid "Converted {0} tag to file name successfully"
-msgid_plural "Converted {0} tags to file names successfully"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: NickvisionTagger.GNOME/Blueprints/window.blp:38
-msgid "File Name to Tag"
-msgstr ""
-
-#: ../../../Models/PropertyMap.cs:118
-#: NickvisionTagger.GNOME/Blueprints/window.blp:458
-msgid "0 MiB"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:837
-#, csharp-format
-msgid ""
-"Nicholas Logozzo {0}\n"
-"Contributors on GitHub ❤️ {1}"
-msgstr ""
-
-#: ../../../Controllers/MainWindowController.cs:607
-msgid "Submitted metadata to AcoustId successfully"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
 msgid "Advanced Search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:126
+#: ../../../Controllers/MainWindowController.cs:127
 msgid ""
 "Advanced Search is a powerful feature provided by Tagger that allows users "
 "to search files' tag contents for certain values, using a powerful tag-based "
@@ -230,58 +124,326 @@ msgid ""
 "            * Property names must be in English"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-msgid "translator-credits"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:716
+msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:511
-msgid "Unable to load image file"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:750
+msgid "albumartist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:508
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:135
-msgid "Open Folder"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+#: NickvisionTagger.GNOME/Blueprints/window.blp:494
+msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:592
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:612
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Apply Changes?"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:712
+msgid "artist"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "B"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:29
+msgid "Back"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:762
+msgid "bpm"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
 msgid "Cancel"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:758
+msgid "comment"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:777
+msgid "composer"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:618
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:638
+#: NickvisionTagger.GNOME/Blueprints/window.blp:38
+msgid "Convert"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:470
+#, csharp-format
+msgid "Converted {0} file name to tag successfully"
+msgid_plural "Converted {0} file names to tags successfully"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../Controllers/MainWindowController.cs:493
+#, csharp-format
+msgid "Converted {0} tag to file name successfully"
+msgid_plural "Converted {0} tags to file names successfully"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:896
+#, csharp-format
+msgid "David Lapshin {0}"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:781
+msgid "description"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid "Discard"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
+msgid "Discarding unapplied changes..."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:643
+msgid "Downloaded metadata for {0} files successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+msgid "Downloading MusicBrainz metadata..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
+msgid "Export Back Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:708
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
+msgid "Export Front Album Art"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:610
+msgid "Exported back album art to file successfully"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:594
+msgid "Exported front album art to file successfully"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:615
+msgid "Failed to export back album art to a file"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:599
+msgid "Failed to export front album art to a file"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: NickvisionTagger.GNOME/Blueprints/window.blp:40
+msgid "File Name to Tag"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:704
+msgid "filename"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
+msgid "Fingerprint was copied to clipboard."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Format String"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:166
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:21
+msgid "Front"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:754
+msgid "genre"
+msgstr ""
+
+#: ../../../Helpers/MediaHelpers.cs:33
+msgid "GiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
+msgid "GitHub Repo"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
+msgid "Insert Back Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
+msgid "Insert Front Album Art"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:789
+msgid "isrc"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
-msgid "Insert Front Album Art"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:531
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:699
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: NickvisionTagger.GNOME/Blueprints/window.blp:104
-msgid "Apply"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:839
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
 #, csharp-format
-msgid "David Lapshin {0}"
+msgid "Loaded {0} music file."
+msgid_plural "Loaded {0} music files."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:417
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:518
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:576
+msgid "Loading music files from folder..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-msgid "MusicBrainz Recording Id"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:893
+msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
-msgid "GiB"
+msgid "MiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "MusicBrainz Recording Id"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Contributors on GitHub ❤️ {1}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
+#, csharp-format
+msgid ""
+"Nicholas Logozzo {0}\n"
+"Fyodor Sobolev {1}\n"
+"DaPigGuy {2}"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1125
+msgid "OK"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid ""
+"Only one file can be submitted to AcoustID at a time. Please select only one "
+"file and try again."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:534
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
+#: NickvisionTagger.GNOME/Blueprints/window.blp:98
+msgid "Open Folder"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+msgid "Please select a format string."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:785
+msgid "publisher"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:761
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:803
+msgid "Saving tags..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:482
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:557
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:756
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:794
+msgid ""
+"Some music files still have changes waiting to be applied. What would you "
+"like to do?"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+msgid "Submit"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
+#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+msgid "Submit to AcoustId"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Submitted metadata to AcoustId successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:766
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+msgid "Submitting data to AcoustId..."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
+msgid "Switch to Back Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+msgid "Switch to Front Cover"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:637
+#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+msgid "Tag to File Name"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Program.cs:50
+#: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
+msgid "Tag your music"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Program.cs:49
@@ -290,64 +452,43 @@ msgstr ""
 msgid "Tagger"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-#: NickvisionTagger.GNOME/Blueprints/window.blp:39
-msgid "Tag to File Name"
-msgstr ""
-
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
-msgid "Discarding unapplied changes..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:708
+msgid "title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:692
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
-#: NickvisionTagger.GNOME/Blueprints/window.blp:46
-msgid "Submit to AcoustId"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:744
+msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:461
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-msgid "Saving tags..."
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:735
+msgid "track"
 msgstr ""
 
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "MiB"
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
+msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:892
-#, csharp-format
-msgid "Loaded {0} music file."
-msgid_plural "Loaded {0} music files."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../../../Helpers/MediaHelpers.cs:33
-msgid "B"
+#: ../../../Controllers/MainWindowController.cs:512
+msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:611
-msgid "Format String"
+#: ../../../Controllers/MainWindowController.cs:656
+msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-msgid "Switch to Front Cover"
-msgstr ""
-
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: NickvisionTagger.GNOME/Blueprints/window.blp:300
-msgid "Switch to Back Cover"
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:720
+msgid "year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:5
 msgid "Preferences"
 msgstr ""
@@ -415,7 +556,7 @@ msgid "Preserve Modification Timestamp"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "Web Services"
 msgstr ""
 
@@ -489,32 +630,40 @@ msgstr ""
 msgid "Remove Front Album Art"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:72
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+msgid "Switch Album Art"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+msgid "Remove Back Album Art"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:97
 msgctxt "Shortcut"
 msgid "Web Services"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:75
-#: NickvisionTagger.GNOME/Blueprints/window.blp:45
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:47
 msgid "Download MusicBrainz Metadata"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:86
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:111
 msgctxt "Shortcut"
 msgid "Application"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:94
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
 #: NickvisionTagger.GNOME/Blueprints/window.blp:6
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "About Tagger"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:104
+#: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 msgid "Quit"
 msgstr ""
 
@@ -522,168 +671,166 @@ msgstr ""
 msgid "Album Art"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:21
-msgid "Front"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:23
-#: NickvisionTagger.GNOME/Blueprints/window.blp:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:282
+#: NickvisionTagger.GNOME/Blueprints/window.blp:31
+#: NickvisionTagger.GNOME/Blueprints/window.blp:252
 msgid "Insert"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
-#: NickvisionTagger.GNOME/Blueprints/window.blp:31
-#: NickvisionTagger.GNOME/Blueprints/window.blp:291
+#: NickvisionTagger.GNOME/Blueprints/window.blp:32
+#: NickvisionTagger.GNOME/Blueprints/window.blp:261
 msgid "Remove"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:28
-msgid "Back"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:25
+#: NickvisionTagger.GNOME/Blueprints/window.blp:33
+#: NickvisionTagger.GNOME/Blueprints/window.blp:270
+msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Open Music Folder (Ctrl+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:68
+#: NickvisionTagger.GNOME/Blueprints/window.blp:70
 msgid "Open"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:75
-msgid "Reload Music Folder (F5)"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:79
 msgid "Main Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:92
-msgid "Toggle Tags Pane"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:105
-msgid "Apply Changes To Tag (Ctrl+S)"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:117
-msgid "Tag Actions"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:132
+#: NickvisionTagger.GNOME/Blueprints/window.blp:95
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:133
+#: NickvisionTagger.GNOME/Blueprints/window.blp:96
 msgid "Open a folder with music to get started"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:178
+#: NickvisionTagger.GNOME/Blueprints/window.blp:143
 msgid "No Music Files Found"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:179
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:198
+#: NickvisionTagger.GNOME/Blueprints/window.blp:163
 msgid "Search for filename (type ! to activate advanced search)..."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:203
+#: NickvisionTagger.GNOME/Blueprints/window.blp:168
 msgid "Advanced Search Info"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:243
+#: NickvisionTagger.GNOME/Blueprints/window.blp:213
 msgid "No Selected Music Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:244
+#: NickvisionTagger.GNOME/Blueprints/window.blp:214
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:350
+#: NickvisionTagger.GNOME/Blueprints/window.blp:341
 msgid "File Name"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:355
+#: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Tag Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:358
+#: NickvisionTagger.GNOME/Blueprints/window.blp:349
 msgid "Title"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:362
+#: NickvisionTagger.GNOME/Blueprints/window.blp:353
 msgid "Artist"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:366
+#: NickvisionTagger.GNOME/Blueprints/window.blp:357
 msgid "Album"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:370
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "Year"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:374
+#: NickvisionTagger.GNOME/Blueprints/window.blp:365
 msgid "Track"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:378
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Album Artist"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:382
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Genre"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:386
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Comment"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:390
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "More Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:393
+#: NickvisionTagger.GNOME/Blueprints/window.blp:384
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
+#: NickvisionTagger.GNOME/Blueprints/window.blp:388
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:401
+#: NickvisionTagger.GNOME/Blueprints/window.blp:392
 msgid "Description"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:405
+#: NickvisionTagger.GNOME/Blueprints/window.blp:396
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:409
+#: NickvisionTagger.GNOME/Blueprints/window.blp:400
 msgid "ISRC"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:415
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "File Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:418
+#: NickvisionTagger.GNOME/Blueprints/window.blp:409
 msgid "Duration"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: NickvisionTagger.GNOME/Blueprints/window.blp:419
 msgid "Fingerprint"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:446
+#: NickvisionTagger.GNOME/Blueprints/window.blp:437
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:453
+#: NickvisionTagger.GNOME/Blueprints/window.blp:444
 msgid "File Size"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+msgid "Toggle Tags Pane"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
+msgid "Reload Music Folder (F5)"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
+msgid "Tag Actions"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:495
+msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11

--- a/build.cake
+++ b/build.cake
@@ -97,7 +97,7 @@ Task("GeneratePot")
     .Does(() =>
 {
     StartProcess("GetText.Extractor", new ProcessSettings {
-        Arguments = $"-s ./{projectName}.GNOME -s ./{projectName}.Shared -as \"_\" -ad \"_p\" -ap \"_n\" -adp \"_pn\" -t ./{projectName}.Shared/Resources/po/{shortName}.pot"
+        Arguments = $"-o -s ./{projectName}.GNOME -s ./{projectName}.Shared -as \"_\" -ad \"_p\" -ap \"_n\" -adp \"_pn\" -t ./{projectName}.Shared/Resources/po/{shortName}.pot"
     });
     StartProcess("sh", new ProcessSettings {
         Arguments = $"-c \"xgettext --from-code=UTF-8 --add-comments --keyword=_ --keyword=C_:1c,2 -o ./{projectName}.Shared/Resources/po/{shortName}.pot -j ./{projectName}.GNOME/Blueprints/*.blp\""


### PR DESCRIPTION
| Default Size | Minimum size (320px) |
| --- | --- |
| ![](https://github.com/NickvisionApps/Tagger/assets/117388856/fa5d6b92-add8-4c80-b531-b87a97ebb18b) | ![](https://github.com/NickvisionApps/Tagger/assets/117388856/49d80403-3266-4f84-829e-0a733bc166b6) |

(ignore window corners, I use extension that makes them 16px round)

Export album art is only available when 1 album art is presented (so either 1 file is selected or multiple files with the same art are selected).

Closes #115 
Closes #68 
Related: #91 