### PR TITLE
Add More Sorting Options

### DIFF
--- a/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
@@ -63,7 +63,7 @@ Adw.PreferencesWindow _root {
       Adw.ComboRow _sortFilesRow {
         title: _("Sort Files By");
         model: Gtk.StringList {
-          strings [C_("Sort", "File Name"), C_("Sort", "File Path"), C_("Sort", "Title"), C_("Sort", "Artist"), C_("Sort", "Album"), C_("Sort", "Year"), C_("Sort", "Track"),  C_("Sort", "Genre")]
+          strings [_("File Name"), _("File Path"), _("Title"), _("Artist"), _("Album"), _("Year"), _("Track"),  _("Genre")]
         };
 
         [prefix]

--- a/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
@@ -63,7 +63,7 @@ Adw.PreferencesWindow _root {
       Adw.ComboRow _sortFilesRow {
         title: _("Sort Files By");
         model: Gtk.StringList {
-          strings [C_("Sort", "File Name"), C_("Sort", "Title"), C_("Sort", "Track"), C_("Sort", "File Path"), C_("Sort", "Album"),  C_("Sort", "Genre")]
+          strings [C_("Sort", "File Name"), C_("Sort", "File Path"), C_("Sort", "Title"), C_("Sort", "Artist"), C_("Sort", "Album"), C_("Sort", "Year"), C_("Sort", "Track"),  C_("Sort", "Genre")]
         };
 
         [prefix]

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -34,7 +34,8 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController();
         _mainWindowController.AppInfo.Changelog =
-            @"* Updated translations (Thanks everyone on Weblate!)";
+            @"* Added more sorting options
+              * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))
         {

--- a/NickvisionTagger.Shared/Models/Configuration.cs
+++ b/NickvisionTagger.Shared/Models/Configuration.cs
@@ -8,10 +8,12 @@ namespace NickvisionTagger.Shared.Models;
 public enum SortBy
 {
     Filename = 0,
-    Title,
-    Track,
     Path,
+    Title,
+    Artist,
     Album,
+    Year,
+    Track,
     Genre
 }
 

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -844,11 +844,11 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     public static bool operator !=(MusicFile? a, MusicFile? b) =>  a?.Path != b?.Path;
 
     /// <summary>
-    /// Compares two MusicFile objects by <
+    /// Compares two MusicFile objects by less than
     /// </summary>
     /// <param name="a">The first MusicFile object</param>
     /// <param name="b">The second MusicFile object</param>
-    /// <returns>True if a < b, else false</returns>
+    /// <returns>True if a is less than b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
         return SortFilesBy switch
@@ -856,7 +856,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == -1,
             SortBy.Path => a?.Path.CompareTo(b?.Path) == -1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
-            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Track.CompareTo(b?.Track) == -1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == -1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == -1,
             SortBy.Year => a?.Year.CompareTo(b?.Year) == -1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Track => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
@@ -866,11 +866,11 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     }
 
     /// <summary>
-    /// Compares two MusicFile objects by >
+    /// Compares two MusicFile objects by greater than
     /// </summary>
     /// <param name="a">The first MusicFile object</param>
     /// <param name="b">The second MusicFile object</param>
-    /// <returns>True if a > b, else false</returns>
+    /// <returns>True if a is greater than b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
         return SortFilesBy switch
@@ -878,7 +878,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == 1,
             SortBy.Path => a?.Path.CompareTo(b?.Path) == 1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
-            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Track.CompareTo(b?.Track) == 1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == 1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == 1,
             SortBy.Year => a?.Year.CompareTo(b?.Year) == 1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Track => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -854,23 +854,31 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if a < b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
+        if(SortFilesBy == SortBy.Path)
+        {
+            return a?.Path.CompareTo(b?.Path) == -1;
+        }
         if(SortFilesBy == SortBy.Title)
         {
             return a?.Title.CompareTo(b?.Title) == -1;
         }
-        else if(SortFilesBy == SortBy.Track)
+        if(SortFilesBy == SortBy.Artist)
         {
-            return a?.Track.CompareTo(b?.Track) == -1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == -1;
+            return a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist.CompareTo(b?.Artist) == 0 && a?.Track.CompareTo(b?.Track) == -1;
         }
-        else if(SortFilesBy == SortBy.Path)
-        {
-            return a?.Path.CompareTo(b?.Path) == -1;
-        }
-        else if(SortFilesBy == SortBy.Album)
+        if(SortFilesBy == SortBy.Album)
         {
             return a?.Album.CompareTo(b?.Album) == -1 || a?.Album.CompareTo(b?.Album) == 0 && a?.Track.CompareTo(b?.Track) == -1;
         }
-        else if(SortFilesBy == SortBy.Genre)
+        if(SortFilesBy == SortBy.Year)
+        {
+            return a?.Year.CompareTo(b?.Year) == -1 || a?.Year.CompareTo(b?.Year) == 0 && a?.Title.CompareTo(b?.Title) == -1;
+        }
+        if(SortFilesBy == SortBy.Track)
+        {
+            return a?.Track.CompareTo(b?.Track) == -1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == -1;
+        }
+        if(SortFilesBy == SortBy.Genre)
         {
             return a?.Genre.CompareTo(b?.Genre) == -1 || a?.Genre.CompareTo(b?.Genre) == 0 && a?.Path.CompareTo(b?.Path) == -1;
         }
@@ -885,23 +893,31 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if a > b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
+        if(SortFilesBy == SortBy.Path)
+        {
+            return a?.Path.CompareTo(b?.Path) == 1;
+        }
         if(SortFilesBy == SortBy.Title)
         {
             return a?.Title.CompareTo(b?.Title) == 1;
         }
-        else if(SortFilesBy == SortBy.Track)
+        if(SortFilesBy == SortBy.Artist)
         {
-            return a?.Track.CompareTo(b?.Track) == 1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == 1;
+            return a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist.CompareTo(b?.Artist) == 0 && a?.Track.CompareTo(b?.Track) == 1;
         }
-        else if(SortFilesBy == SortBy.Path)
-        {
-            return a?.Path.CompareTo(b?.Path) == 1;
-        }
-        else if(SortFilesBy == SortBy.Album)
+        if(SortFilesBy == SortBy.Album)
         {
             return a?.Album.CompareTo(b?.Album) == 1 || a?.Album.CompareTo(b?.Album) == 0 && a?.Track.CompareTo(b?.Track) == 1;
         }
-        else if(SortFilesBy == SortBy.Genre)
+        if(SortFilesBy == SortBy.Year)
+        {
+            return a?.Year.CompareTo(b?.Year) == 1 || a?.Year.CompareTo(b?.Year) == 0 && a?.Title.CompareTo(b?.Title) == 1;
+        }
+        if(SortFilesBy == SortBy.Track)
+        {
+            return a?.Track.CompareTo(b?.Track) == 1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == 1;
+        }
+        if(SortFilesBy == SortBy.Genre)
         {
             return a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre.CompareTo(b?.Genre) == 0 && a?.Path.CompareTo(b?.Path) == 1;
         }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -793,14 +793,11 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
         {
             return -1;
         }
-        else if (this > other)
+        if (this > other)
         {
             return 1;
         }
-        else
-        {
-            return 0;
-        }
+        return 0;
     }
 
     /// <summary>
@@ -854,35 +851,18 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if a < b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
-        if(SortFilesBy == SortBy.Path)
+        return SortFilesBy switch
         {
-            return a?.Path.CompareTo(b?.Path) == -1;
-        }
-        if(SortFilesBy == SortBy.Title)
-        {
-            return a?.Title.CompareTo(b?.Title) == -1;
-        }
-        if(SortFilesBy == SortBy.Artist)
-        {
-            return a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist.CompareTo(b?.Artist) == 0 && a?.Track.CompareTo(b?.Track) == -1;
-        }
-        if(SortFilesBy == SortBy.Album)
-        {
-            return a?.Album.CompareTo(b?.Album) == -1 || a?.Album.CompareTo(b?.Album) == 0 && a?.Track.CompareTo(b?.Track) == -1;
-        }
-        if(SortFilesBy == SortBy.Year)
-        {
-            return a?.Year.CompareTo(b?.Year) == -1 || a?.Year.CompareTo(b?.Year) == 0 && a?.Title.CompareTo(b?.Title) == -1;
-        }
-        if(SortFilesBy == SortBy.Track)
-        {
-            return a?.Track.CompareTo(b?.Track) == -1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == -1;
-        }
-        if(SortFilesBy == SortBy.Genre)
-        {
-            return a?.Genre.CompareTo(b?.Genre) == -1 || a?.Genre.CompareTo(b?.Genre) == 0 && a?.Path.CompareTo(b?.Path) == -1;
-        }
-        return a?.Filename.CompareTo(b?.Filename) == -1;
+            SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == -1,
+            SortBy.Path => a?.Path.CompareTo(b?.Path) == -1,
+            SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Track.CompareTo(b?.Track) == -1,
+            SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == -1,
+            SortBy.Year => a?.Year.CompareTo(b?.Year) == -1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Track => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == -1 || a?.Genre == b?.Genre && a?.Path.CompareTo(b?.Path) == -1,
+            _ => false
+        };
     }
 
     /// <summary>
@@ -893,34 +873,17 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if a > b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
-        if(SortFilesBy == SortBy.Path)
+        return SortFilesBy switch
         {
-            return a?.Path.CompareTo(b?.Path) == 1;
-        }
-        if(SortFilesBy == SortBy.Title)
-        {
-            return a?.Title.CompareTo(b?.Title) == 1;
-        }
-        if(SortFilesBy == SortBy.Artist)
-        {
-            return a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist.CompareTo(b?.Artist) == 0 && a?.Track.CompareTo(b?.Track) == 1;
-        }
-        if(SortFilesBy == SortBy.Album)
-        {
-            return a?.Album.CompareTo(b?.Album) == 1 || a?.Album.CompareTo(b?.Album) == 0 && a?.Track.CompareTo(b?.Track) == 1;
-        }
-        if(SortFilesBy == SortBy.Year)
-        {
-            return a?.Year.CompareTo(b?.Year) == 1 || a?.Year.CompareTo(b?.Year) == 0 && a?.Title.CompareTo(b?.Title) == 1;
-        }
-        if(SortFilesBy == SortBy.Track)
-        {
-            return a?.Track.CompareTo(b?.Track) == 1 || a?.Track.CompareTo(b?.Track) == 0 && a?.Title.CompareTo(b?.Title) == 1;
-        }
-        if(SortFilesBy == SortBy.Genre)
-        {
-            return a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre.CompareTo(b?.Genre) == 0 && a?.Path.CompareTo(b?.Path) == 1;
-        }
-        return a?.Filename.CompareTo(b?.Filename) == 1;
+            SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == 1,
+            SortBy.Path => a?.Path.CompareTo(b?.Path) == 1,
+            SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Track.CompareTo(b?.Track) == 1,
+            SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == 1,
+            SortBy.Year => a?.Year.CompareTo(b?.Year) == 1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Track => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre == b?.Genre && a?.Path.CompareTo(b?.Path) == 1,
+            _ => false
+        };
     }
 }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -856,11 +856,11 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == -1,
             SortBy.Path => a?.Path.CompareTo(b?.Path) == -1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
-            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == -1,
-            SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == -1,
-            SortBy.Year => a?.Year.CompareTo(b?.Year) == -1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track < b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track < b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
+            SortBy.Year => a?.Year.CompareTo(b?.Year) == -1 || a?.Year == b?.Year && a?.Album.CompareTo(b?.Album) == -1 || a?.Year == b?.Year && a?.Album == b?.Album && a?.Track < b?.Track || a?.Year == b?.Year && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Track => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
-            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == -1 || a?.Genre == b?.Genre && a?.Path.CompareTo(b?.Path) == -1,
+            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == -1 || a?.Genre == b?.Genre && a?.Album.CompareTo(b?.Album) == -1 || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track < b?.Track || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
             _ => false
         };
     }
@@ -878,11 +878,11 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == 1,
             SortBy.Path => a?.Path.CompareTo(b?.Path) == 1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
-            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == 1,
-            SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track.CompareTo(b?.Track) == 1,
-            SortBy.Year => a?.Year.CompareTo(b?.Year) == 1 || a?.Year == b?.Year && a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track > b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track > b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
+            SortBy.Year => a?.Year.CompareTo(b?.Year) == 1 || a?.Year == b?.Year && a?.Album.CompareTo(b?.Album) == 1 || a?.Year == b?.Year && a?.Album == b?.Album && a?.Track > b?.Track || a?.Year == b?.Year && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Track => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
-            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre == b?.Genre && a?.Path.CompareTo(b?.Path) == 1,
+            SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre == b?.Genre && a?.Album.CompareTo(b?.Album) == 1 || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track > b?.Track || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             _ => false
         };
     }

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-31 13:51+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -73,7 +73,7 @@ msgstr "<ponechat>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -92,42 +92,42 @@ msgstr ""
 "Pokud nezadáte nic, odešle místo toho aplikace metadata vaší značky společně "
 "s otiskem."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "umělecalba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -137,65 +137,65 @@ msgstr "umělec"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "skladatel"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Přispěvatelé na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -203,7 +203,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -211,8 +211,8 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "vlastní"
 
@@ -221,38 +221,38 @@ msgstr "vlastní"
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "popis"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Zrušit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Rušení nepoužitých změn..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
@@ -260,63 +260,63 @@ msgstr "Stahování metadat z MusicBrainz..."
 msgid "ERROR"
 msgstr "CHYBA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exportovat zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "názevsouboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Otisk byl zkopírován do schránky."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Formátový řetězec"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Přední"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -326,24 +326,24 @@ msgstr "žánr"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub repozitář"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Vložit zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
@@ -352,7 +352,7 @@ msgstr "Vložit přední obal alba"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -360,16 +360,16 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -377,24 +377,24 @@ msgstr "Matrix Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -403,95 +403,95 @@ msgstr ""
 "jeden soubor a zkuste to znovu."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Otevřít složku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Vyberte prosím formátový řetězec."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "vydavatel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr "Některé hudební soubory mají stále čekající změny. Co chcete udělat?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Potvrdit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Přepnout na zadní obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Přepnout na přední obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Značka na název souboru"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označte svou hudbu"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Označovač"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Označovač otevřel některé soubory v režimu čtení."
 
@@ -499,55 +499,55 @@ msgstr "Označovač otevřel některé soubory v režimu čtení."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "název"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "stopa"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "celkemstop"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -617,23 +617,35 @@ msgstr "Název souboru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Název"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Stopa"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Cesta k souboru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Název"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Umělec"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Rok"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Stopa"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-31 13:51+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,21 +50,21 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -365,7 +365,7 @@ msgstr[2] "Načteno {0} hudebních souborů."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
 
@@ -611,44 +611,42 @@ msgid "Sort Files By"
 msgstr "Seřadit soubory podle"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Název souboru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Cesta k souboru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Název"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Umělec"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Rok"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Stopa"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Žánr"
 
@@ -842,33 +840,9 @@ msgstr "Žádné vybrané hudební soubory"
 msgid "Select some files"
 msgstr "Vyberte nějaké soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Název souboru"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Hlavní vlastnosti"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Název"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Umělec"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Rok"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Stopa"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -877,10 +851,6 @@ msgstr "Celkem stop"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Umělec alba"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Žánr"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -968,6 +938,36 @@ msgstr "— Snadný převod názvů souborů na značky a značkek na názvy sou
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Vyhledávání informací o souborech pomocí MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Název souboru"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Název"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Umělec"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Rok"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Stopa"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Žánr"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-29 12:14+0000\n"
 "Last-Translator: Jummit <jummit@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%-%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -73,7 +73,7 @@ msgstr "<behalten>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -93,42 +93,42 @@ msgstr ""
 "Wenn du keinen angibst, wird Tagger stattdessen die Metadaten deiner Tags in "
 "Verbindung mit dem Fingerabdruck übermitteln."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "albumkünstler"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -138,80 +138,80 @@ msgstr "künstler"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Zurück"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "Komponist"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Beitragende auf GitHub ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "andere"
 
@@ -220,38 +220,38 @@ msgstr "andere"
 msgid "Custom"
 msgstr "Andere"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "Beschreibung"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
@@ -259,63 +259,63 @@ msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Rücken-Albumcover exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Vorder-Albumcover exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Rücken-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Vorder-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim exportieren des Rücken-Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Formatvorlage"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Vorne"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -325,24 +325,24 @@ msgstr "genre"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Rücken-Albumcover einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vorder-Albumcover einfügen"
@@ -351,23 +351,23 @@ msgstr "Vorder-Albumcover einfügen"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -375,24 +375,24 @@ msgstr "Matrix-Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -401,96 +401,96 @@ msgstr ""
 "nur eine Datei aus und versuche es erneut."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Bitte Formatvorlage auswählen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 "Einige Musikdateien haben ungespeicherte Änderungen. Was möchtest du tun?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Zu AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Zu Rückencover wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Zu vorderem Cover wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Tag zu Dateiname"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tage deine Musik"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 
@@ -498,55 +498,55 @@ msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "songanzahl"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -616,23 +616,35 @@ msgstr "Dateiname"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Titel"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Track"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Dateipfad"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Titel"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Künstler"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Jahr"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Track"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,52 +19,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%-%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -73,7 +73,7 @@ msgstr "<behalten>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -93,42 +93,42 @@ msgstr ""
 "Wenn du keinen angibst, wird Tagger stattdessen die Metadaten deiner Tags in "
 "Verbindung mit dem Fingerabdruck übermitteln."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "albumkünstler"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -138,77 +138,77 @@ msgstr "künstler"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Zurück"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "Komponist"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "andere"
 
@@ -217,37 +217,37 @@ msgstr "andere"
 msgid "Custom"
 msgstr "Andere"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "Beschreibung"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
@@ -255,63 +255,63 @@ msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Rücken-Albumcover exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Vorder-Albumcover exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Rücken-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Vorder-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim exportieren des Rücken-Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Formatvorlage"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Vorne"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -321,24 +321,24 @@ msgstr "genre"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Rücken-Albumcover einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vorder-Albumcover einfügen"
@@ -347,23 +347,23 @@ msgstr "Vorder-Albumcover einfügen"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -371,24 +371,24 @@ msgstr "Matrix-Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -397,96 +397,96 @@ msgstr ""
 "nur eine Datei aus und versuche es erneut."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Bitte Formatvorlage auswählen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 "Einige Musikdateien haben ungespeicherte Änderungen. Was möchtest du tun?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Zu Rückencover wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Zu vorderem Cover wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Tag zu Dateiname"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tage deine Musik"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 
@@ -494,55 +494,55 @@ msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "songanzahl"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -606,32 +606,42 @@ msgid "Sort Files By"
 msgstr "Dateien sortieren nach"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Dateiname"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Title"
-msgstr "Titel"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Track"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Dateipfad"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
+msgid "Title"
+msgstr "Titel"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
+msgid "Artist"
+msgstr "Künstler"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
+msgid "Year"
+msgstr "Jahr"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
+msgid "Track"
+msgstr "Track"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Genre"
 
@@ -822,33 +832,9 @@ msgstr "Keine ausgewählten Musikdateien"
 msgid "Select some files"
 msgstr "Wähle Dateien aus"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Dateiname"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Haupteigenschaften"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Titel"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Künstler"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Jahr"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Track"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -857,10 +843,6 @@ msgstr "Song-Anzahl"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Album-Interpret"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Genre"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -950,6 +932,26 @@ msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Lade Dateinformationen von MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Dateiname"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Titel"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Track"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Genre"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-08-02 13:37+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,21 +50,21 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -359,7 +359,7 @@ msgstr[1] "Cargados {0} archivos de música."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
 
@@ -608,44 +608,42 @@ msgid "Sort Files By"
 msgstr "Ordenar archivos por"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Nombre del archivo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Ruta del archivo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Título"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Artista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Álbum"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Año"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Pista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Género"
 
@@ -839,33 +837,9 @@ msgstr "No hay archivos de música seleccionados"
 msgid "Select some files"
 msgstr "Seleccione algunos archivos"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Nombre del archivo"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Propiedades principales"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Título"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Artista"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Álbum"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Año"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Pista"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -874,10 +848,6 @@ msgstr "Pista total"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Artista del álbum"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Género"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -970,6 +940,36 @@ msgstr ""
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Buscar información de archivos en MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Nombre del archivo"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Título"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Artista"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Álbum"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Año"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Pista"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Género"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-08-02 13:37+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -73,7 +73,7 @@ msgstr "<mantener>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -93,42 +93,42 @@ msgstr ""
 "En caso contrario, Tagger enviará los metadatos de la etiqueta asociados a "
 "la firma."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "álbum"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "artistadelálbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -138,77 +138,77 @@ msgstr "artista"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "compositor"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "personalizado"
 
@@ -217,37 +217,37 @@ msgstr "personalizado"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "descripción"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Descartar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Descartando cambios no aplicados..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
@@ -255,63 +255,63 @@ msgstr "Descargando metadatos de MusicBrainz…"
 msgid "ERROR"
 msgstr "ERROR"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exportar contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "nombredearchivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Cadena de formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Frontal"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -321,24 +321,24 @@ msgstr "género"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Insertar la contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
@@ -347,23 +347,23 @@ msgstr "Insertar la portada del álbum"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
@@ -371,24 +371,24 @@ msgstr "Chat de Matrix"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "Vale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -397,44 +397,44 @@ msgstr ""
 "archivo e inténtelo de nuevo."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Seleccione una cadena de formato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "editor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -442,52 +442,52 @@ msgstr ""
 "Algunos archivos de música aún tienen cambios pendientes de aplicar. ¿Qué le "
 "gustaría hacer?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Enviar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Cambiar a la contraportada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Cambiar a la portada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Etiqueta a nombre de archivo"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Etiquete su música"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha abierto algunos archivos en modo de solo lectura."
 
@@ -495,55 +495,55 @@ msgstr "Tagger ha abierto algunos archivos en modo de solo lectura."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "pista"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "pistatotal"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -614,23 +614,35 @@ msgstr "Nombre del archivo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Título"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Pista"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Ruta del archivo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Título"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Artista"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Álbum"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Año"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Pista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-27 17:43+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -73,7 +73,7 @@ msgstr "<säilytä>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -85,42 +85,42 @@ msgid ""
 "with the fingerprint instead."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "albumi"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -130,80 +130,80 @@ msgstr "esittäjä"
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Peru"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "säveltäjä"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Avustajat GitHubissa ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr ""
 
@@ -212,38 +212,38 @@ msgstr ""
 msgid "Custom"
 msgstr "Mukautettu"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "kuvaus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Hylkää"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Hylätään toteuttamattomat muutokset..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
@@ -251,63 +251,63 @@ msgstr "Ladataan MusicBrainz-metatietoja..."
 msgid "ERROR"
 msgstr "VIRHE"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Vie albumin takakuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "tiedostonimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Etu"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -317,24 +317,24 @@ msgstr "tyylilaji"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ohje"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr ""
@@ -343,23 +343,23 @@ msgstr ""
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
@@ -367,119 +367,119 @@ msgstr "Matrix-keskustelu"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Vaihda takakanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Vaihda etukanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Lisää tagit musiikkiin"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
@@ -487,56 +487,56 @@ msgstr ""
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "nimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -604,23 +604,35 @@ msgstr "Tiedostonimi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Nimi"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Kappale"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Tiedostopolku"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Nimi"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Esittäjä"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Albumi"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Vuosi"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Kappale"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-27 17:43+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,21 +50,21 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -355,7 +355,7 @@ msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
@@ -598,44 +598,42 @@ msgid "Sort Files By"
 msgstr "Järjestä tiedostot"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Tiedostonimi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Tiedostopolku"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Nimi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Esittäjä"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Albumi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Vuosi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Kappale"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Tyylilaji"
 
@@ -824,34 +822,10 @@ msgstr "Ei valittuja musiikkitiedostoja"
 msgid "Select some files"
 msgstr "Valitse joitain tiedostoja"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Tiedostonimi"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 #, fuzzy
 msgid "Main Properties"
 msgstr "Tagin ominaisuudet"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Nimi"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Esittäjä"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Albumi"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Vuosi"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Kappale"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 #, fuzzy
@@ -861,10 +835,6 @@ msgstr "Kappale"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Tyylilaji"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 #, fuzzy
@@ -952,6 +922,36 @@ msgstr ""
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr ""
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Tiedostonimi"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Nimi"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Esittäjä"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Albumi"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Vuosi"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Kappale"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Tyylilaji"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-12 19:29+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,40 +19,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 #, fuzzy
 msgid "%title%"
 msgstr "titre"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -65,7 +63,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -74,7 +74,7 @@ msgstr "<conserver>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -94,42 +94,42 @@ msgstr ""
 "Si aucun identifiant n’est fourni, Tagger enverra vos balises de métadonnées "
 "associées à l’empreinte à la place."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "artiste de l’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -139,81 +139,81 @@ msgstr "artiste"
 msgid "B"
 msgstr "o"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Retour"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 #, fuzzy
 msgid "beatsperminute"
 msgstr "Battements par minute"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "compositeur"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Contributeurs sur GitHub ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr ""
 
@@ -222,38 +222,38 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "description"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Abandonner"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Abandon des changements..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
@@ -261,66 +261,66 @@ msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 msgid "ERROR"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exporter le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "nom de fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Empreinte copiée vers le presse-papiers."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Face"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -330,24 +330,24 @@ msgstr "genre"
 msgid "GiB"
 msgstr "Gio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Insérer le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
@@ -356,23 +356,23 @@ msgstr "Insérer la face de la pochette d’album"
 msgid "KiB"
 msgstr "kio"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
@@ -380,25 +380,25 @@ msgstr "Discussion Matrix"
 msgid "MiB"
 msgstr "Mio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #, fuzzy
 msgid "New Custom Property"
 msgstr "Propriétés supplémentaires"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -407,45 +407,45 @@ msgstr ""
 "fichier et essayez à nouveau."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Sélectionnez un format."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 #, fuzzy
 msgid "Remove Custom Property"
 msgstr "Propriétés supplémentaires"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -453,52 +453,52 @@ msgstr ""
 "Des fichiers de musiques ont encore des modifications en attente d’être "
 "appliquées. Que souhaitez-vous faire ?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Envoyer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Balise vers nom de fichier"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associez des balises à vos musiques"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
@@ -506,56 +506,56 @@ msgstr ""
 msgid "TiB"
 msgstr "Tio"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 #, fuzzy
 msgid "tracktotal"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, fuzzy, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -626,26 +626,38 @@ msgid "File Name"
 msgstr "Nom de fichier"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Title"
-msgstr "Titre"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Piste"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
 msgctxt "Sort"
 msgid "File Path"
 msgstr "Nom de fichier"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Title"
+msgstr "Titre"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Artiste"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
 msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Année"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Piste"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-12 19:29+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -51,21 +51,21 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -368,7 +368,7 @@ msgstr[1] "{0} musiques chargées."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
 
@@ -621,47 +621,42 @@ msgid "Sort Files By"
 msgstr "Trier les fichiers par"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
-msgstr "Nom de fichier"
+msgstr "Nom du fichier"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Nom de fichier"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Titre"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Artiste"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Année"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
-msgstr "Piste"
+msgstr "Morceau"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Genre"
 
@@ -856,34 +851,10 @@ msgstr "Aucun fichier de musique sélectionné"
 msgid "Select some files"
 msgstr "Sélectionnez des fichiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Nom du fichier"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 #, fuzzy
 msgid "Main Properties"
 msgstr "Propriétés de la balise"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Titre"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Artiste"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Année"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Morceau"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 #, fuzzy
@@ -893,10 +864,6 @@ msgstr "Morceau"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Artiste de l'album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Genre"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 #, fuzzy
@@ -993,6 +960,38 @@ msgstr ""
 msgid "— Lookup file information using MusicBrainz"
 msgstr ""
 "— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Nom de fichier"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Titre"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Artiste"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Année"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Piste"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Genre"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-28 12:00+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,39 +20,37 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%אמן%- %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%כותרת%- %אמן%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%רצועה%- %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -65,7 +63,9 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -74,7 +74,7 @@ msgstr "<לשמור>"
 msgid "0 MiB"
 msgstr "0 מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -92,42 +92,42 @@ msgstr ""
 "\n"
 "אם אין ברשותך, המתייג ישלח את נתוני התגיות שלך יחד עם טביעת האצבע במקום."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "אמן האלבום"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -137,66 +137,66 @@ msgstr "אמן"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 #, fuzzy
 msgid "beatsperminute"
 msgstr "פעימות לדקה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "מלחין"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "תורמים ב־GitHub ‏❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -205,7 +205,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -214,8 +214,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -224,38 +224,38 @@ msgstr "מותאם אישית"
 msgid "Custom"
 msgstr "מותאם אישית"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "תיאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "השלכה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
@@ -263,63 +263,63 @@ msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 msgid "ERROR"
 msgstr "תקלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "קדמי"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -329,24 +329,24 @@ msgstr "סוגה"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "עזרה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
@@ -355,7 +355,7 @@ msgstr "הכנסת עטיפת אלבום קדמית"
 msgid "KiB"
 msgstr "קי״ב"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -364,16 +364,16 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -381,24 +381,24 @@ msgstr "צ׳אט במטריקס"
 msgid "MiB"
 msgstr "מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "אישור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -407,95 +407,95 @@ msgstr ""
 "שוב."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "יש לבחור תבנית למחרוזת."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של שינויים עליהם. מה ברצונך לעשות?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "החלפה לכיסוי קדמי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "תג לשם קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "המתייג"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 
@@ -503,58 +503,58 @@ msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 msgid "TiB"
 msgstr "טבי״ב"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 #, fuzzy
 msgid "tracktotal"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -624,23 +624,35 @@ msgstr "שם קובץ"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "כותרת"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "רצועה"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "נתיב הקובץ"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "כותרת"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "אמן"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "אלבום"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "שנה"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "רצועה"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,52 +20,52 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%אמן%- %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%כותרת%- %אמן%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%רצועה%- %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -74,7 +74,7 @@ msgstr "<לשמור>"
 msgid "0 MiB"
 msgstr "0 מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -92,42 +92,42 @@ msgstr ""
 "\n"
 "אם אין ברשותך, המתייג ישלח את נתוני התגיות שלך יחד עם טביעת האצבע במקום."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "אמן האלבום"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -137,62 +137,62 @@ msgstr "אמן"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "מלחין"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub ‏❤️ {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -201,7 +201,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -210,8 +210,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -220,37 +220,37 @@ msgstr "מותאם אישית"
 msgid "Custom"
 msgstr "מותאם אישית"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "תיאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "השלכה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
@@ -258,63 +258,63 @@ msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 msgid "ERROR"
 msgstr "תקלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "קדמי"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -324,24 +324,24 @@ msgstr "סוגה"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "עזרה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
@@ -350,7 +350,7 @@ msgstr "הכנסת עטיפת אלבום קדמית"
 msgid "KiB"
 msgstr "קי״ב"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -359,16 +359,16 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -376,24 +376,24 @@ msgstr "צ׳אט במטריקס"
 msgid "MiB"
 msgstr "מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "אישור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -402,95 +402,95 @@ msgstr ""
 "שוב."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "יש לבחור תבנית למחרוזת."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של שינויים עליהם. מה ברצונך לעשות?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "החלפה לכיסוי קדמי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "תג לשם קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "המתייג"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 
@@ -498,57 +498,57 @@ msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 msgid "TiB"
 msgstr "טבי״ב"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -612,32 +612,42 @@ msgid "Sort Files By"
 msgstr "מיון פריטים לפי"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "שם קובץ"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Title"
-msgstr "כותרת"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "רצועה"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "נתיב הקובץ"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
+msgid "Title"
+msgstr "כותרת"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
+msgid "Artist"
+msgstr "אמן"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "אלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
+msgid "Year"
+msgstr "שנה"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
+msgid "Track"
+msgstr "רצועה"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "סוגה"
 
@@ -828,33 +838,9 @@ msgstr "לא נבחרו קובצי מוזיקה"
 msgid "Select some files"
 msgstr "יש לבחור קבצים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "שם קובץ"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "מאפיינים ראשיים"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "כותרת"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "אמן"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "אלבום"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "שנה"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "רצועה"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -863,10 +849,6 @@ msgstr "מספר רצועות כולל"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "אמן האלבום"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "סוגה"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -956,6 +938,26 @@ msgstr "- המרת שמות קבצים לתגיות ותגיות לשמות קב
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "שם קובץ"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "כותרת"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "רצועה"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "אלבום"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "סוגה"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,43 +16,41 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%izvođač%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%naslov%- %izvođač%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -65,7 +63,9 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -74,7 +74,7 @@ msgstr "<zadrži>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -93,42 +93,42 @@ msgstr ""
 "Ako se ne navede, Tagger će umjesto toga poslati metapodatke tvoje oznake "
 "koje su povezane s digitalnim otiskom."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "izvođač albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -138,65 +138,65 @@ msgstr "izvođač"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "skladatelj"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Doprinositelji na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -204,7 +204,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -212,8 +212,8 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -222,38 +222,38 @@ msgstr "prilagođeno"
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "opis"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Odbaci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Odbacivanje neprimjenjenih promjena …"
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
@@ -261,63 +261,63 @@ msgstr "Preuzmi MusicBrainz metapodatke …"
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Izvezi stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "ime datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Digitalni otisak je kopiran u međuspremnik."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Prednja strana"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -327,24 +327,24 @@ msgstr "žanr"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Umetni stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
@@ -353,7 +353,7 @@ msgstr "Umetni prednju sliku albuma"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -361,16 +361,16 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -378,24 +378,24 @@ msgstr "Matrix Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "ID oznaka MusicBrainz snimke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "U redu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -404,44 +404,44 @@ msgstr ""
 "i pokušaj ponovo."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Odaberi jedan format izraza."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -449,52 +449,52 @@ msgstr ""
 "Neke glazbene datoteke još uvijek sadrže promjene koje još nisu "
 "primijenjene. Želiš li primijeniti te promjene?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Pošalji"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Prikaži stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Prikaži prednju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Oznaka u ime datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označite svoju glazbu"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger je otvorio neke datoteke u modusu „samo čitanje”."
 
@@ -502,55 +502,55 @@ msgstr "Tagger je otvorio neke datoteke u modusu „samo čitanje”."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "naslov"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "broj pjesama"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -620,23 +620,35 @@ msgstr "Ime datoteke"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Naslov"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Pjesma"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Staza do datoteke"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Naslov"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Izvođač"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Godina"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Pjesma"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,21 +51,21 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -366,7 +366,7 @@ msgstr[2] "Učitano je {0} glazbenih datoteka."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
@@ -614,44 +614,42 @@ msgid "Sort Files By"
 msgstr "Redoslijed datoteka"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Ime datoteke"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Staza do datoteke"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Naslov"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Izvođač"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Godina"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Pjesma"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Žanr"
 
@@ -844,33 +842,9 @@ msgstr "Nijedna glazbena datoteka nije odabrana"
 msgid "Select some files"
 msgstr "Odaberi neke datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Ime datoteke"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Glavna svojstva"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Naslov"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Izvođač"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Godina"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Pjesma"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -879,10 +853,6 @@ msgstr "Broj pjesama"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Izvođač albuma"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Žanr"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -971,6 +941,36 @@ msgstr "– Pretvori imena datoteka u oznake i oznake u imena datoteka"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Ime datoteke"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Naslov"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Izvođač"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Godina"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Pjesma"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Žanr"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-08-02 13:37+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -50,21 +50,21 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -359,7 +359,7 @@ msgstr[1] "Brani {0} caricati."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
 
@@ -606,44 +606,42 @@ msgid "Sort Files By"
 msgstr "Ordina file per"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Nome del file"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Percorso del file"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Titolo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Artista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Anno"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
-msgstr "Traccia"
+msgstr "Numero della traccia"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Genere"
 
@@ -836,33 +834,9 @@ msgstr "Nessun brano selezionato"
 msgid "Select some files"
 msgstr "Seleziona dei file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Nome del file"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Proprietà principali"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Titolo"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Artista"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Anno"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Numero della traccia"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -871,10 +845,6 @@ msgstr "Numero delle tracce totali"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Artista dell'album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Genere"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -964,6 +934,36 @@ msgstr "— Converte nomi di file a tag e tag ad etichette con semplicità"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Controlla le informazioni dei brani con MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Nome del file"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Titolo"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Artista"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Anno"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Traccia"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Genere"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-08-02 13:37+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -73,7 +73,7 @@ msgstr "<tieni>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -93,42 +93,42 @@ msgstr ""
 "Se non viene fornito nessun identificativo, Tagger invierà i metadati "
 "associati alla firma di questo brano."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "artistaalbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Vuoi applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -138,77 +138,77 @@ msgstr "artista"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "commento"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "compositore"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr "Hanno collaborato su GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file è stato convertito con successo"
 msgstr[1] "{0} nomi di file sono stati convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
 msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -217,37 +217,37 @@ msgstr "personalizzato/a"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "descrizione"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Scarta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Annullamento modifiche non applicate..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "I metadati per {0} sono stati scaricati con successo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Download dei metadati da MusicBrainz in corso..."
 
@@ -255,63 +255,63 @@ msgstr "Download dei metadati da MusicBrainz in corso..."
 msgid "ERROR"
 msgstr "ERRORE"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Esporta copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Nome del file a etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "nomefile"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma è stata copiata negli appunti."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Stringa di formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Fronte"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -321,24 +321,24 @@ msgstr "genere"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Inserisci copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
@@ -347,23 +347,23 @@ msgstr "Inserisci copertina anteriore"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Brano {0} caricato."
 msgstr[1] "Brani {0} caricati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
@@ -371,24 +371,24 @@ msgstr "Chat Matrix"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "Ok"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -397,96 +397,96 @@ msgstr ""
 "solo brano ed invia nuovamente i dati."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Seleziona un formato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 "Sono presenti alcune modifiche in attesa di essere applicate. Cosa vuoi fare?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Invia"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Scambia a copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Scambia a copertina anteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Etichetta a nome di file"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associa un'etichetta ai tuoi brani"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha aperto dei file in sola lettura."
 
@@ -494,55 +494,55 @@ msgstr "Tagger ha aperto dei file in sola lettura."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "traccia"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "traccetotali"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Federico Marchetti"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Impossibile caricare l'immagine"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossibile salvare {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossibile salvare {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -612,23 +612,35 @@ msgstr "Nome del file"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Titolo"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Traccia"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Percorso del file"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Titolo"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Artista"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Anno"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Traccia"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-01 12:52+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,21 +50,21 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr ""
 
@@ -375,7 +375,7 @@ msgstr[1] "Er zijn %d muziekbestanden geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -636,49 +636,43 @@ msgid "Sort Files By"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 #, fuzzy
-msgctxt "Sort"
 msgid "File Name"
 msgstr "Bestandsnaam"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Bestandsnaam"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Titel"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Artiest"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Jaar"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Volgnummer"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Genre"
 
@@ -887,34 +881,9 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-#, fuzzy
-msgid "File Name"
-msgstr "Bestandsnaam"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Titel"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Artiest"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Album"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Jaar"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Volgnummer"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 #, fuzzy
@@ -924,10 +893,6 @@ msgstr "Volgnummer"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Albumartiest"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Genre"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -1016,6 +981,40 @@ msgstr "Bezig met omzetten van tags in bestandsnamen…"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr ""
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Bestandsnaam"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Titel"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Artiest"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Album"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Jaar"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Volgnummer"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Genre"
 
 #, fuzzy
 #~ msgid "Clear Tags"

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-01 12:52+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -18,40 +18,38 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 #, fuzzy
 msgid "%title%"
 msgstr "Titel"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -94,44 +94,44 @@ msgstr ""
 "Als u geen id opgeeft, zal Tagger de metagegevens op basis van de "
 "controlesom versturen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 #, fuzzy
 msgid "album"
 msgstr "Album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 #, fuzzy
 msgid "albumartist"
 msgstr "Albumartiest"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 #, fuzzy
@@ -142,78 +142,78 @@ msgstr "Artiest"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 #, fuzzy
 msgid "comment"
 msgstr "Opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr ""
 
@@ -222,39 +222,39 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 #, fuzzy
 msgid "description"
 msgstr "Duur"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Verwerpen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Bezig met verwerpen van wijzigingen…"
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 #, fuzzy
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 #, fuzzy
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens ophalen"
@@ -263,68 +263,68 @@ msgstr "MusicBrainz-metagegevens ophalen"
 msgid "ERROR"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 #, fuzzy
 msgid "Export Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 #, fuzzy
 msgid "Export Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 #, fuzzy
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 #, fuzzy
@@ -335,25 +335,25 @@ msgstr "Genre"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 #, fuzzy
 msgid "Insert Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
@@ -363,24 +363,24 @@ msgstr "Albumhoes toevoegen"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr ""
 
@@ -388,24 +388,24 @@ msgstr ""
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "Oké"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 #, fuzzy
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -415,45 +415,45 @@ msgstr ""
 "bestand en probeer het opnieuw."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 #, fuzzy
 msgid "Open Folder"
 msgstr "Muziekmap openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Kies een opmaakmethode."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #, fuzzy
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
@@ -462,55 +462,55 @@ msgstr ""
 "Enkele muziekbestanden zijn gewijzigd, maar nog niet opgeslagen. Wilt u dat "
 "nu doen of de wijzigingen verwerpen?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 #, fuzzy
 msgid "Tag to File Name"
 msgstr "Tag naar bestandsnaam"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
@@ -518,59 +518,59 @@ msgstr ""
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 #, fuzzy
 msgid "title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 #, fuzzy
 msgid "track"
 msgstr "Volgnummer"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 #, fuzzy
 msgid "tracktotal"
 msgstr "Volgnummer"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -642,6 +642,12 @@ msgid "File Name"
 msgstr "Bestandsnaam"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "File Path"
+msgstr "Bestandsnaam"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
 msgid "Title"
 msgstr "Titel"
@@ -649,20 +655,26 @@ msgstr "Titel"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
 msgctxt "Sort"
-msgid "Track"
-msgstr "Volgnummer"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
-msgid "File Path"
-msgstr "Bestandsnaam"
+msgid "Artist"
+msgstr "Artiest"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy
 msgctxt "Sort"
 msgid "Album"
 msgstr "Album"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Jaar"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Track"
+msgstr "Volgnummer"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 #, fuzzy

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,21 +51,21 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -367,7 +367,7 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
 
@@ -615,44 +615,42 @@ msgid "Sort Files By"
 msgstr "Сортировать файлы по"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Имя файла"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Путь к файлу"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Название"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Исполнитель"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Альбом"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Год"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
-msgstr "Трек"
+msgstr "Номер трека"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Жанр"
 
@@ -845,33 +843,9 @@ msgstr "Нет выбранных музыкальных файлов"
 msgid "Select some files"
 msgstr "Выберите несколько файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Имя файла"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Основные свойства"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Название"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Исполнитель"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Альбом"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Год"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Номер трека"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -880,10 +854,6 @@ msgstr "Трек Всего"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Исполнитель альбома"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Жанр"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -973,6 +943,36 @@ msgstr "— Легко конвертируйте имена файлов в т�
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Поиск информации о файлах с помощью MusicBrainz"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Имя файла"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Название"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Исполнитель"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Альбом"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Год"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Трек"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Жанр"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,43 +16,41 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%исполнитель%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%название%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%название%- %исполнитель%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -65,7 +63,9 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -74,7 +74,7 @@ msgstr "<keep>"
 msgid "0 MiB"
 msgstr "0 МиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -94,42 +94,42 @@ msgstr ""
 "Если он не указан, Tagger отправит метаданные вашего тега вместе с "
 "отпечатком."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "альбомартист"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -139,65 +139,65 @@ msgstr "artist"
 msgid "B"
 msgstr "Б"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "композитор"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Участники на GitHub ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -205,7 +205,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -213,8 +213,8 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "пользовательский"
 
@@ -223,38 +223,38 @@ msgstr "пользовательский"
 msgid "Custom"
 msgstr "Пользовательский"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "Давид Лапшин {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "описание"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Отменить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Отмена изменений..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
@@ -262,63 +262,63 @@ msgstr "Загрузка метаданных MusicBrainz..."
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Экспортировать заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "имя файла"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Отпечаток был скопирован в буфер обмена."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Формат строки"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Передняя"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -328,24 +328,24 @@ msgstr "жанр"
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Справка"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Вставить заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
@@ -354,7 +354,7 @@ msgstr "Вставить переднюю обложку альбома"
 msgid "KiB"
 msgstr "КиБ"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -362,16 +362,16 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -379,24 +379,24 @@ msgstr "Чат Matrix"
 msgid "MiB"
 msgstr "МиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "ОК"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -405,44 +405,44 @@ msgstr ""
 "выберите только один файл и повторите попытку."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Выберите формат строки."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "издатель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -450,52 +450,52 @@ msgstr ""
 "Некоторые музыкальные файлы все еще содержат изменения, ожидающие "
 "применения. Что бы вы хотели сделать?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Отправить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Переключиться на переднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Тег в имя файла"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger открыл некоторые файлы в режиме только для чтения."
 
@@ -503,55 +503,55 @@ msgstr "Tagger открыл некоторые файлы в режиме тол
 msgid "TiB"
 msgstr "ТиБ"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "название"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "трек"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "итогтрек"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Давид Лапшин <ddaudix@gmail.com>, 2023"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -621,23 +621,35 @@ msgstr "Имя файла"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Название"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Трек"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Путь к файлу"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Название"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Исполнитель"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Альбом"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Год"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Трек"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
@@ -1078,8 +1090,8 @@ msgstr "— Поиск информации о файлах с помощью Mu
 #~ "\n"
 #~ "            !title=\"\";artist=\"bob\"\n"
 #~ "            Эта команда отфильтрует список таким образом, чтобы он "
-#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя \"bob"
-#~ "\"\n"
+#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя "
+#~ "\"bob\"\n"
 #~ "\n"
 #~ "            [Заметки]\n"
 #~ "            * Продвинутый поиск не чувствителен к регистру\n"

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,39 +18,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -63,7 +61,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr ""
 
@@ -72,7 +72,7 @@ msgstr ""
 msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -84,42 +84,42 @@ msgid ""
 "with the fingerprint instead."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -129,77 +129,77 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr ""
 
@@ -208,37 +208,37 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
@@ -246,63 +246,63 @@ msgstr ""
 msgid "ERROR"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -312,24 +312,24 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr ""
@@ -338,23 +338,23 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr ""
 
@@ -362,119 +362,119 @@ msgstr ""
 msgid "MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
@@ -482,55 +482,55 @@ msgstr ""
 msgid "TiB"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -598,22 +598,32 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Artist"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Year"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,21 +49,21 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr ""
 
@@ -350,7 +350,7 @@ msgstr[1] ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr ""
 
@@ -592,42 +592,41 @@ msgid "Sort Files By"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr ""
 
@@ -816,32 +815,8 @@ msgstr ""
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr ""
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
@@ -850,10 +825,6 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
-msgstr ""
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-01 18:11-0400\n"
+"POT-Creation-Date: 2023-08-02 15:05-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,39 +19,37 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:139
+#: ../../../Controllers/MainWindowController.cs:146
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:278
-#: ../../../Controllers/MainWindowController.cs:287
-#: ../../../Controllers/MainWindowController.cs:292
-#: ../../../Controllers/MainWindowController.cs:297
-#: ../../../Controllers/MainWindowController.cs:302
-#: ../../../Controllers/MainWindowController.cs:314
-#: ../../../Controllers/MainWindowController.cs:326
-#: ../../../Controllers/MainWindowController.cs:338
-#: ../../../Controllers/MainWindowController.cs:343
-#: ../../../Controllers/MainWindowController.cs:348
-#: ../../../Controllers/MainWindowController.cs:353
-#: ../../../Controllers/MainWindowController.cs:358
-#: ../../../Controllers/MainWindowController.cs:370
-#: ../../../Controllers/MainWindowController.cs:375
-#: ../../../Controllers/MainWindowController.cs:384
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:280
+#: ../../../Controllers/MainWindowController.cs:289
+#: ../../../Controllers/MainWindowController.cs:294
+#: ../../../Controllers/MainWindowController.cs:299
+#: ../../../Controllers/MainWindowController.cs:304
+#: ../../../Controllers/MainWindowController.cs:316
+#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:340
+#: ../../../Controllers/MainWindowController.cs:345
+#: ../../../Controllers/MainWindowController.cs:350
+#: ../../../Controllers/MainWindowController.cs:355
+#: ../../../Controllers/MainWindowController.cs:360
+#: ../../../Controllers/MainWindowController.cs:372
+#: ../../../Controllers/MainWindowController.cs:377
+#: ../../../Controllers/MainWindowController.cs:386
 #: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
@@ -64,7 +62,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1388
 #: ../../../Controllers/MainWindowController.cs:1389
 #: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1396
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -73,7 +73,7 @@ msgstr "<koru>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -92,42 +92,42 @@ msgstr ""
 "Hiçbiri sağlanmazsa Tagger, bunun yerine etiketinizin üst verilerini parmak "
 "iziyle ilişkili olarak gönderir."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 #: NickvisionTagger.GNOME/Blueprints/window.blp:434
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:851
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:853
 #: ../../../Models/MusicFile.cs:583 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:687
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:900
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:902
 #: ../../../Models/MusicFile.cs:611 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:703
 msgid "albumartist"
 msgstr "albumartist"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 #: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:847
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:849
 #: ../../../Models/MusicFile.cs:579 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:683
 msgid "artist"
@@ -137,80 +137,80 @@ msgstr "sanatçı"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:30
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:912
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:914
 #: ../../../Models/MusicFile.cs:623 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:715
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:908
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:910
 #: ../../../Models/MusicFile.cs:619 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:711
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:927
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:929
 #: ../../../Models/MusicFile.cs:631 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:719
 msgid "composer"
 msgstr "besteci"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:138
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "GitHub Katkıcıları ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:545
+#: ../../../Controllers/MainWindowController.cs:547
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:568
+#: ../../../Controllers/MainWindowController.cs:570
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:941
 msgid "custom"
 msgstr "özel"
 
@@ -219,38 +219,38 @@ msgstr "özel"
 msgid "Custom"
 msgstr "Özel"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:141
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:133
+#: ../../../Controllers/MainWindowController.cs:142
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:931
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:933
 #: ../../../Models/MusicFile.cs:635 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:723
 msgid "description"
 msgstr "açıklama"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid "Discard"
 msgstr "Gözden Çıkar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 msgid "Discarding unapplied changes..."
 msgstr "Uygulanmayan değişiklikler gözden çıkartılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:777
+#: ../../../Controllers/MainWindowController.cs:779
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:723
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
@@ -258,63 +258,63 @@ msgstr "MusicBrainz üst verileri indiriliyor..."
 msgid "ERROR"
 msgstr "HATA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Albüm Arka Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:686
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:685
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:685
+#: ../../../Controllers/MainWindowController.cs:687
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:671
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
-#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:692
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:676
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:839
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:841
 msgid "filename"
 msgstr "dosya adı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1275
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1274
 msgid "Fingerprint was copied to clipboard."
 msgstr "Parmak izi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Format String"
 msgstr "Biçimlendirme Dizgesi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:118
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:117
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
 #: NickvisionTagger.GNOME/Blueprints/window.blp:22
 msgid "Front"
 msgstr "Ön"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:140
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:904
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:906
 #: ../../../Models/MusicFile.cs:615 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:707
 msgid "genre"
@@ -324,24 +324,24 @@ msgstr "tür"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:399
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:404
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:398
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:403
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Yardım"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Albüm Arka Kapağı Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:654
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
@@ -350,23 +350,23 @@ msgstr "Albüm Ön Kapağı Ekle"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:253
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:385
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:510
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:528
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:553
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:562
-#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:384
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:509
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
+#: ../../../Controllers/MainWindowController.cs:1415
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
 
-#: ../../../Controllers/MainWindowController.cs:127
+#: ../../../Controllers/MainWindowController.cs:136
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
@@ -374,24 +374,24 @@ msgstr "Matrix Sohbet"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz Kayıt Kimliği"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
-#: ../../../Controllers/MainWindowController.cs:128
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:137
+#: ../../../Controllers/MainWindowController.cs:139
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "OK"
 msgstr "Tamam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -400,44 +400,44 @@ msgstr ""
 "dosya seçip tekrar deneyin."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:524
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:523
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
 #: NickvisionTagger.GNOME/Blueprints/window.blp:99
 msgid "Open Folder"
 msgstr "Klasör Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:603
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:602
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 msgid "Please select a format string."
 msgstr "Lütfen biçimlendirme dizgesi seçin."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:705
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:704
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:935
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:937
 #: ../../../Models/MusicFile.cs:639 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:727
 msgid "publisher"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1075
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:479
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:548
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:754
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:796
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:478
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:547
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:573
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:795
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:474
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:749
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:787
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:473
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:542
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -445,52 +445,52 @@ msgstr ""
 "Bazı müzik dosyalarında uygulanmayı bekleyen değişiklikler var. Ne yapmak "
 "istersin?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 msgid "Submit"
 msgstr "Gönder"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:741
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:759
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:758
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 #: NickvisionTagger.GNOME/Blueprints/window.blp:294
 msgid "Switch to Back Cover"
 msgstr "Arka Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
 msgid "Switch to Front Cover"
 msgstr "Ön Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:622
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
 #: NickvisionTagger.GNOME/Blueprints/window.blp:42
 msgid "Tag to File Name"
 msgstr "Etiketten Dosya Adına"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Müziklerinizi etiketleyin"
 
-#: ../../../Controllers/MainWindowController.cs:121
+#: ../../../Controllers/MainWindowController.cs:117
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:259
+#: ../../../Controllers/MainWindowController.cs:261
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger kimi dosyaları salt okunur kipte açdı."
 
@@ -498,55 +498,55 @@ msgstr "Tagger kimi dosyaları salt okunur kipte açdı."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:845
 #: ../../../Models/MusicFile.cs:575 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:679
 msgid "title"
 msgstr "başlık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:736
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:870
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:872
 #: ../../../Models/MusicFile.cs:595 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:695
 msgid "track"
 msgstr "parça"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:885
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:887
 #: ../../../Models/MusicFile.cs:603 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:699
 msgid "tracktotal"
 msgstr "toplam parça"
 
-#: ../../../Controllers/MainWindowController.cs:134
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
-#: ../../../Controllers/MainWindowController.cs:587
+#: ../../../Controllers/MainWindowController.cs:589
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:465
+#: ../../../Controllers/MainWindowController.cs:467
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:428
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:792
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:813
-#: ../../../Controllers/MainWindowController.cs:855
+#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:857
 #: ../../../Models/MusicFile.cs:587 ../../../Models/MusicFile.cs:664
 #: ../../../Models/MusicFile.cs:691
 msgid "year"
@@ -616,23 +616,35 @@ msgstr "Dosya Adı"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
-msgid "Title"
-msgstr "Başlık"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
-msgid "Track"
-msgstr "Parça"
-
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
 msgid "File Path"
 msgstr "Dosya Yolu"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"
+msgid "Title"
+msgstr "Başlık"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Artist"
+msgstr "Sanatçı"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
 msgid "Album"
 msgstr "Albüm"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+#, fuzzy
+msgctxt "Sort"
+msgid "Year"
+msgstr "Yıl"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
+msgctxt "Sort"
+msgid "Track"
+msgstr "Parça"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
 msgctxt "Sort"

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-02 15:05-0400\n"
+"POT-Creation-Date: 2023-08-03 14:14-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,21 +50,21 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:372
 #: ../../../Controllers/MainWindowController.cs:377
 #: ../../../Controllers/MainWindowController.cs:386
-#: ../../../Controllers/MainWindowController.cs:1379
-#: ../../../Controllers/MainWindowController.cs:1380
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1383
-#: ../../../Controllers/MainWindowController.cs:1384
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Controllers/MainWindowController.cs:1387
-#: ../../../Controllers/MainWindowController.cs:1388
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Controllers/MainWindowController.cs:1395
 #: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Controllers/MainWindowController.cs:1397
+#: ../../../Controllers/MainWindowController.cs:1398
+#: ../../../Controllers/MainWindowController.cs:1399
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Controllers/MainWindowController.cs:1401
+#: ../../../Controllers/MainWindowController.cs:1402
+#: ../../../Controllers/MainWindowController.cs:1403
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Controllers/MainWindowController.cs:1405
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Controllers/MainWindowController.cs:1407
+#: ../../../Controllers/MainWindowController.cs:1411
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -362,7 +362,7 @@ msgstr[1] "{0} müzik dosyası yüklendi."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:527
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:552
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:561
-#: ../../../Controllers/MainWindowController.cs:1415
+#: ../../../Controllers/MainWindowController.cs:1430
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
 
@@ -610,44 +610,42 @@ msgid "Sort Files By"
 msgstr "Dosyaları Sırala"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:361
 msgid "File Name"
 msgstr "Dosya Adı"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#, fuzzy
 msgid "File Path"
 msgstr "Dosya Yolu"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:369
 msgid "Title"
 msgstr "Başlık"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:373
 msgid "Artist"
 msgstr "Sanatçı"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "Album"
 msgstr "Albüm"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#, fuzzy
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:381
 msgid "Year"
 msgstr "Yıl"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:385
 msgid "Track"
 msgstr "Parça"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-msgctxt "Sort"
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Genre"
 msgstr "Tür"
 
@@ -841,33 +839,9 @@ msgstr "Seçili Müzik Dosyası Yok"
 msgid "Select some files"
 msgstr "Bazı dosyaları seçin"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:361
-msgid "File Name"
-msgstr "Dosya Adı"
-
 #: NickvisionTagger.GNOME/Blueprints/window.blp:366
 msgid "Main Properties"
 msgstr "Ana Özellikler"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:369
-msgid "Title"
-msgstr "Başlık"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:373
-msgid "Artist"
-msgstr "Sanatçı"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:377
-msgid "Album"
-msgstr "Albüm"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:381
-msgid "Year"
-msgstr "Yıl"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:385
-msgid "Track"
-msgstr "Parça"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:389
 msgid "Track Total"
@@ -876,10 +850,6 @@ msgstr "Toplam Parça"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
-
-#: NickvisionTagger.GNOME/Blueprints/window.blp:397
-msgid "Genre"
-msgstr "Tür"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:402
 msgid "Additional Properties"
@@ -972,6 +942,36 @@ msgstr ""
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
+
+#~ msgctxt "Sort"
+#~ msgid "File Name"
+#~ msgstr "Dosya Adı"
+
+#~ msgctxt "Sort"
+#~ msgid "Title"
+#~ msgstr "Başlık"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Artist"
+#~ msgstr "Sanatçı"
+
+#~ msgctxt "Sort"
+#~ msgid "Album"
+#~ msgstr "Albüm"
+
+#, fuzzy
+#~ msgctxt "Sort"
+#~ msgid "Year"
+#~ msgstr "Yıl"
+
+#~ msgctxt "Sort"
+#~ msgid "Track"
+#~ msgstr "Parça"
+
+#~ msgctxt "Sort"
+#~ msgid "Genre"
+#~ msgstr "Tür"
 
 #, csharp-format
 #~ msgid ""

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -38,6 +38,7 @@
   <releases>
     <release version="2023.8.1-next" date="2023-08-02">
       <description translatable="no">
+        <p>- Added more sorting options</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>


### PR DESCRIPTION
Closes #207 

This does change the order of the `SortBy` enum, meaning some users will have the wrong sorting option selected when first running the new update, but will be fixed once they reselect the right one. This is acceptable to me as we can now have the `SortBy` enum sorted in the right order and displayed in the correct order in Preferences.

I don't plan on adding any more sorting options (just the main properties) and do not plan to support custom property names neither.