### PR TITLE
Lyrics Improvements

### DIFF
--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -93,30 +93,37 @@ Adw.Window _root {
             min-content-width: 300;
             min-content-height: 200;
             
-            Adw.PreferencesGroup _syncGroup {
+            Gtk.Box {
+              orientation: vertical;
+              spacing: 12;
               margin-start: 24;
               margin-end: 24;
-              description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
-              header-suffix: Gtk.Box {
-                orientation: horizontal;
-                spacing: 6;
-                
-                Gtk.Button _addSyncLyricButton {
-                  valign: center;
-                  
-                  Adw.ButtonContent {
-                    label: _("Add");
-                    icon-name: "list-add-symbolic";
+
+              Adw.PreferencesGroup {
+                description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
+                header-suffix: Gtk.Box {
+                  orientation: horizontal;
+                  spacing: 6;
+
+                  Gtk.Button _addSyncLyricButton {
+                    valign: center;
+
+                    Adw.ButtonContent {
+                      label: _("Add");
+                      icon-name: "list-add-symbolic";
+                    }
+
+                    styles ["flat"]
                   }
-                  
-                  styles ["flat"]
+                };
+
+                Adw.EntryRow _syncOffsetRow {
+                  title: _("Offset (in milliseconds)");
+                  show-apply-button: true;
                 }
-              };
-              
-              Adw.EntryRow _syncOffsetRow {
-                title: _("Offset (in milliseconds)");
-                show-apply-button: true;
               }
+
+              Adw.PreferencesGroup _syncGroup { }
             }
           };
         }

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -82,7 +82,7 @@ Adw.Window _root {
                   left-margin: 12;
                   right-margin: 12;
                   bottom-margin: 12;
-    
+                  
                   styles ["card"]
                 }
               }
@@ -99,11 +99,11 @@ Adw.Window _root {
               Gtk.Box {
                 orientation: vertical;
                 spacing: 12;
+                margin-top: 12;
                 margin-start: 24;
                 margin-end: 24;
-                margin-top: 12;
-                margin-bottom: 12;
-  
+                margin-bottom: 24;
+                
                 Gtk.Box {
                   orientation: horizontal;
                   spacing: 6;
@@ -137,7 +137,7 @@ Adw.Window _root {
                     
                     styles ["flat"]
                   }
-                                  
+
                   Gtk.Button _exportSyncButton {
                     icon-name: "folder-download-symbolic";
                     tooltip-text: _("Export to LRC");
@@ -145,16 +145,16 @@ Adw.Window _root {
                     styles ["flat"]
                   }
                 }
-  
+
                 Adw.PreferencesGroup {
                   Adw.EntryRow _syncOffsetRow {
                     title: _("Offset (in milliseconds)");
                     show-apply-button: true;
                   }
                 }
-  
+
                 Gtk.ListBox _syncList { 
-                   selection-mode: none;
+                  selection-mode: none;
                 
                   styles ["boxed-list"]
                 }

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -22,139 +22,141 @@ Adw.Window _root {
       vexpand: true;
       orientation: vertical;
 
-      Adw.ViewStack _viewStack {
+      Adw.ToastOverlay _toast {
         hexpand: true;
         vexpand: true;
-      
-        Adw.ViewStackPage {
-          title: _("Configure");
-          icon-name: "wrench-wide-symbolic";
-          child: Gtk.ScrolledWindow {
-            min-content-width: 300;
-            min-content-height: 200;
-            
-            Adw.PreferencesGroup {
-              margin-start: 24;
-              margin-end: 24;
-              margin-top: 12;
-              margin-bottom: 12;
-              description: _("Information about the provided lyrics. Applies to both unsynchronized and synchronized lyrics.");
-              
-              Adw.EntryRow _languageRow {
-                title: _("Language Code");
-                
-                [prefix]
-                Gtk.Image {
-                  icon-name: "language-symbolic";
-                }
-              }
-              
-              Adw.EntryRow _descriptionRow {
-                title: _("Description");
-                
-                [prefix]
-                Gtk.Image {
-                  icon-name: "note-symbolic";
-                }
-              }
-            }
-          };
-        }
-      
-        Adw.ViewStackPage {
-          title: _("Unsynchronized");
-          icon-name: "notepad-symbolic";
-          child: Gtk.ScrolledWindow {
-            min-content-width: 300;
-            min-content-height: 200;
-          
-            Adw.PreferencesGroup {
-              margin-start: 24;
-              margin-end: 24;
-              margin-top: 12;
-              margin-bottom: 12;
-              description: _("Unsynchronized lyrics are stored as a single string with no time information.");
-              
-              Gtk.TextView _unsyncTextView {
-                vexpand: true;
-                top-margin: 12;
-                left-margin: 12;
-                right-margin: 12;
-                bottom-margin: 12;
-  
-                styles ["card"]
-              }
-            }
-          };
-        }
         
-        Adw.ViewStackPage {
-          title: _("Synchronized");
-          icon-name: "preferences-system-time-symbolic";
-          child: Gtk.ScrolledWindow {
-            min-content-width: 300;
-            min-content-height: 200;
-            
-            Gtk.Box {
-              orientation: vertical;
-              spacing: 12;
-              margin-start: 24;
-              margin-end: 24;
-              margin-top: 12;
-              margin-bottom: 12;
-
+        Adw.ViewStack _viewStack {
+          Adw.ViewStackPage {
+            title: _("Configure");
+            icon-name: "wrench-wide-symbolic";
+            child: Gtk.ScrolledWindow {
+              min-content-width: 300;
+              min-content-height: 200;
+              
               Adw.PreferencesGroup {
-                description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
-                header-suffix: Gtk.Box {
-                  orientation: horizontal;
-                  spacing: 6;
+                margin-start: 24;
+                margin-end: 24;
+                margin-top: 12;
+                margin-bottom: 12;
+                description: _("Information about the provided lyrics. Applies to both unsynchronized and synchronized lyrics.");
+                
+                Adw.EntryRow _languageRow {
+                  title: _("Language Code");
                   
-                  Gtk.Button _addSyncLyricButton {
-                    valign: center;
+                  [prefix]
+                  Gtk.Image {
+                    icon-name: "language-symbolic";
+                  }
+                }
+                
+                Adw.EntryRow _descriptionRow {
+                  title: _("Description");
+                  
+                  [prefix]
+                  Gtk.Image {
+                    icon-name: "note-symbolic";
+                  }
+                }
+              }
+            };
+          }
+        
+          Adw.ViewStackPage {
+            title: _("Unsynchronized");
+            icon-name: "notepad-symbolic";
+            child: Gtk.ScrolledWindow {
+              min-content-width: 300;
+              min-content-height: 200;
+            
+              Adw.PreferencesGroup {
+                margin-start: 24;
+                margin-end: 24;
+                margin-top: 12;
+                margin-bottom: 12;
+                description: _("Unsynchronized lyrics are stored as a single string with no time information.");
+                
+                Gtk.TextView _unsyncTextView {
+                  vexpand: true;
+                  top-margin: 12;
+                  left-margin: 12;
+                  right-margin: 12;
+                  bottom-margin: 12;
+    
+                  styles ["card"]
+                }
+              }
+            };
+          }
+          
+          Adw.ViewStackPage {
+            title: _("Synchronized");
+            icon-name: "preferences-system-time-symbolic";
+            child: Gtk.ScrolledWindow {
+              min-content-width: 300;
+              min-content-height: 200;
+              
+              Gtk.Box {
+                orientation: vertical;
+                spacing: 12;
+                margin-start: 24;
+                margin-end: 24;
+                margin-top: 12;
+                margin-bottom: 12;
+  
+                Adw.PreferencesGroup {
+                  description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
+                  header-suffix: Gtk.Box {
+                    orientation: horizontal;
+                    spacing: 6;
                     
-                    Adw.ButtonContent {
-                      label: _("Add");
-                      icon-name: "list-add-symbolic";
+                    Gtk.Button _addSyncLyricButton {
+                      valign: center;
+                      
+                      Adw.ButtonContent {
+                        label: _("Add");
+                        icon-name: "list-add-symbolic";
+                      }
+                      
+                      styles ["flat"]
                     }
                     
-                    styles ["flat"]
-                  }
-                  
-                  Gtk.Button _clearSyncButton {
-                    valign: center;
-                    icon-name: "user-trash-symbolic";
-                    tooltip-text: _("Clear All Lyrics");
+                    Gtk.Button _clearSyncButton {
+                      valign: center;
+                      icon-name: "user-trash-symbolic";
+                      tooltip-text: _("Clear All Lyrics");
+                      
+                      styles ["flat"]
+                    }
                     
-                    styles ["flat"]
+                    Gtk.Button _importSyncButton {
+                      valign: center;
+                      icon-name: "document-send-symbolic";
+                      tooltip-text: _("Import from LRC");
+                      
+                      styles ["flat"]
+                    }
+                                    
+                    Gtk.Button _exportSyncButton {
+                      valign: center;
+                      icon-name: "folder-download-symbolic";
+                      tooltip-text: _("Export to LRC");
+                      
+                      styles ["flat"]
+                    }
+                  };
+  
+                  Adw.EntryRow _syncOffsetRow {
+                    title: _("Offset (in milliseconds)");
+                    show-apply-button: true;
                   }
-                  
-                  Gtk.Button _importSyncButton {
-                    valign: center;
-                    icon-name: "document-send-symbolic";
-                    tooltip-text: _("Import from LRC");
-                    
-                    styles ["flat"]
-                  }
-                                  
-                  Gtk.Button _exportSyncButton {
-                    valign: center;
-                    icon-name: "folder-download-symbolic";
-                    tooltip-text: _("Export to LRC");
-                    
-                    styles ["flat"]
-                  }
-                };
-
-                Adw.EntryRow _syncOffsetRow {
-                  title: _("Offset (in milliseconds)");
-                  show-apply-button: true;
                 }
+  
+                Adw.PreferencesGroup _syncGroup { }
               }
-
-              Adw.PreferencesGroup _syncGroup { }
-            }
-          };
-        }
+            };
+          }
+        } 
       }
       
       Adw.ViewSwitcherBar {

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -22,20 +22,20 @@ Adw.Window _root {
       vexpand: true;
       orientation: vertical;
 
-      Gtk.ScrolledWindow {        
-        min-content-width: 300;
-        min-content-height: 200;
-        
-        Adw.ViewStack _viewStack {
-          hexpand: true;
-          vexpand: true;
-          margin-top: 12;
-          margin-bottom: 12;
-        
-          Adw.ViewStackPage {
-            title: _("Configure");
-            icon-name: "wrench-wide-symbolic";
-            child: Adw.PreferencesGroup {
+      Adw.ViewStack _viewStack {
+        hexpand: true;
+        vexpand: true;
+        margin-top: 12;
+        margin-bottom: 12;
+      
+        Adw.ViewStackPage {
+          title: _("Configure");
+          icon-name: "wrench-wide-symbolic";
+          child: Gtk.ScrolledWindow {
+            min-content-width: 300;
+            min-content-height: 200;
+            
+            Adw.PreferencesGroup {
               margin-start: 24;
               margin-end: 24;
               description: _("Information about the provided lyrics. Applies to both unsynchronized and synchronized lyrics.");
@@ -57,13 +57,18 @@ Adw.Window _root {
                   icon-name: "note-symbolic";
                 }
               }
-            };
-          }
-        
-          Adw.ViewStackPage {
-            title: _("Unsynchronized");
-            icon-name: "notepad-symbolic";
-            child: Adw.PreferencesGroup {
+            }
+          };
+        }
+      
+        Adw.ViewStackPage {
+          title: _("Unsynchronized");
+          icon-name: "notepad-symbolic";
+          child: Gtk.ScrolledWindow {
+            min-content-width: 300;
+            min-content-height: 200;
+          
+            Adw.PreferencesGroup {
               margin-start: 24;
               margin-end: 24;
               description: _("Unsynchronized lyrics are stored as a single string with no time information.");
@@ -74,16 +79,21 @@ Adw.Window _root {
                 left-margin: 12;
                 right-margin: 12;
                 bottom-margin: 12;
-
+  
                 styles ["card"]
               }
-            };
-          }
-          
-          Adw.ViewStackPage {
-            title: _("Synchronized");
-            icon-name: "preferences-system-time-symbolic";
-            child: Adw.PreferencesGroup _syncGroup {
+            }
+          };
+        }
+        
+        Adw.ViewStackPage {
+          title: _("Synchronized");
+          icon-name: "preferences-system-time-symbolic";
+          child: Gtk.ScrolledWindow {
+            min-content-width: 300;
+            min-content-height: 200;
+            
+            Adw.PreferencesGroup _syncGroup {
               margin-start: 24;
               margin-end: 24;
               description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
@@ -102,8 +112,8 @@ Adw.Window _root {
                   styles ["flat"]
                 }
               };
-            };
-          }
+            }
+          };
         }
       }
       

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -104,48 +104,49 @@ Adw.Window _root {
                 margin-top: 12;
                 margin-bottom: 12;
   
-                Adw.PreferencesGroup {
-                  description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");
-                  header-suffix: Gtk.Box {
-                    orientation: horizontal;
-                    spacing: 6;
-                    
-                    Gtk.Button _addSyncLyricButton {
-                      valign: center;
-                      
-                      Adw.ButtonContent {
-                        label: _("Add");
-                        icon-name: "list-add-symbolic";
-                      }
-                      
-                      styles ["flat"]
+                Gtk.Box {
+                  orientation: horizontal;
+                  spacing: 6;
+                  hexpand: true;
+                  
+                  Gtk.Button _addSyncLyricButton {
+                    Adw.ButtonContent {
+                      label: _("Add");
+                      icon-name: "list-add-symbolic";
                     }
                     
-                    Gtk.Button _clearSyncButton {
-                      valign: center;
-                      icon-name: "user-trash-symbolic";
-                      tooltip-text: _("Clear All Lyrics");
-                      
-                      styles ["flat"]
-                    }
+                    styles ["flat"]
+                  }
+                  
+                  Gtk.Separator {
+                    hexpand: true;
                     
-                    Gtk.Button _importSyncButton {
-                      valign: center;
-                      icon-name: "document-send-symbolic";
-                      tooltip-text: _("Import from LRC");
-                      
-                      styles ["flat"]
-                    }
-                                    
-                    Gtk.Button _exportSyncButton {
-                      valign: center;
-                      icon-name: "folder-download-symbolic";
-                      tooltip-text: _("Export to LRC");
-                      
-                      styles ["flat"]
-                    }
-                  };
+                    styles ["spacer"]
+                  }
+                  
+                  Gtk.Button _clearSyncButton {
+                    icon-name: "user-trash-symbolic";
+                    tooltip-text: _("Clear All Lyrics");
+                    
+                    styles ["flat"]
+                  }
+                  
+                  Gtk.Button _importSyncButton {
+                    icon-name: "document-send-symbolic";
+                    tooltip-text: _("Import from LRC");
+                    
+                    styles ["flat"]
+                  }
+                                  
+                  Gtk.Button _exportSyncButton {
+                    icon-name: "folder-download-symbolic";
+                    tooltip-text: _("Export to LRC");
+                    
+                    styles ["flat"]
+                  }
+                }
   
+                Adw.PreferencesGroup {
                   Adw.EntryRow _syncOffsetRow {
                     title: _("Offset (in milliseconds)");
                     show-apply-button: true;

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -153,7 +153,11 @@ Adw.Window _root {
                   }
                 }
   
-                Adw.PreferencesGroup _syncGroup { }
+                Gtk.ListBox _syncList { 
+                   selection-mode: none;
+                
+                  styles ["boxed-list"]
+                }
               }
             };
           }

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -112,6 +112,11 @@ Adw.Window _root {
                   styles ["flat"]
                 }
               };
+              
+              Adw.EntryRow _syncOffsetRow {
+                title: _("Offset (in milliseconds)");
+                show-apply-button: true;
+              }
             }
           };
         }

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -108,15 +108,39 @@ Adw.Window _root {
                 header-suffix: Gtk.Box {
                   orientation: horizontal;
                   spacing: 6;
-
+                  
                   Gtk.Button _addSyncLyricButton {
                     valign: center;
-
+                    
                     Adw.ButtonContent {
                       label: _("Add");
                       icon-name: "list-add-symbolic";
                     }
-
+                    
+                    styles ["flat"]
+                  }
+                  
+                  Gtk.Button _clearSyncButton {
+                    valign: center;
+                    icon-name: "user-trash-symbolic";
+                    tooltip-text: _("Clear All Lyrics");
+                    
+                    styles ["flat"]
+                  }
+                  
+                  Gtk.Button _importSyncButton {
+                    valign: center;
+                    icon-name: "document-send-symbolic";
+                    tooltip-text: _("Import from LRC");
+                    
+                    styles ["flat"]
+                  }
+                                  
+                  Gtk.Button _exportSyncButton {
+                    valign: center;
+                    icon-name: "folder-download-symbolic";
+                    tooltip-text: _("Export to LRC");
+                    
                     styles ["flat"]
                   }
                 };

--- a/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp
@@ -25,8 +25,6 @@ Adw.Window _root {
       Adw.ViewStack _viewStack {
         hexpand: true;
         vexpand: true;
-        margin-top: 12;
-        margin-bottom: 12;
       
         Adw.ViewStackPage {
           title: _("Configure");
@@ -38,6 +36,8 @@ Adw.Window _root {
             Adw.PreferencesGroup {
               margin-start: 24;
               margin-end: 24;
+              margin-top: 12;
+              margin-bottom: 12;
               description: _("Information about the provided lyrics. Applies to both unsynchronized and synchronized lyrics.");
               
               Adw.EntryRow _languageRow {
@@ -71,6 +71,8 @@ Adw.Window _root {
             Adw.PreferencesGroup {
               margin-start: 24;
               margin-end: 24;
+              margin-top: 12;
+              margin-bottom: 12;
               description: _("Unsynchronized lyrics are stored as a single string with no time information.");
               
               Gtk.TextView _unsyncTextView {
@@ -98,6 +100,8 @@ Adw.Window _root {
               spacing: 12;
               margin-start: 24;
               margin-end: 24;
+              margin-top: 12;
+              margin-bottom: 12;
 
               Adw.PreferencesGroup {
                 description: _("Synchronized lyrics are stored as a dictionary of strings identified by their timestamp in milliseconds.");

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -36,7 +36,7 @@ public partial class Program
         _mainWindowController.AppInfo.Changelog =
             @"* Added offset field to synchronized lyrics page 
               * Added the ability to import and export LRC files in the synchronized lyrics page
-              * Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics
+              * Fixed an issue where synchronized lyrics stored in the LRC format were not displayed correctly
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -34,13 +34,7 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController();
         _mainWindowController.AppInfo.Changelog =
-            @"* Added support for managing a file's lyrics
-              * Tagger will now provide suggestions while typing a genre  
-              * Fixed an issue where downloading MusicBrainz metadata would fail even if metadata was available
-              * Fixed an issue where Web Services were disabled even though network connection was available
-              * Fixed an issue where back album art was not saved correctly
-              * An Info button will appear when MusicBrainz lookup fails and will provide more information about why the process failed
-              * Improved tag panel design
+            @"* Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -35,6 +35,7 @@ public partial class Program
         _mainWindowController = new MainWindowController();
         _mainWindowController.AppInfo.Changelog =
             @"* Added offset field to synchronized lyrics page 
+              * Added the ability to import and export LRC files in the synchronized lyrics page
               * Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -34,7 +34,8 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController();
         _mainWindowController.AppInfo.Changelog =
-            @"* Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics
+            @"* Added offset field to synchronized lyrics page 
+              * Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -48,6 +48,7 @@ public partial class LyricsDialog : Adw.Window
     [Gtk.Connect] private readonly Gtk.TextView _unsyncTextView;
     [Gtk.Connect] private readonly Adw.PreferencesGroup _syncGroup;
     [Gtk.Connect] private readonly Gtk.Button _addSyncLyricButton;
+    [Gtk.Connect] private readonly Adw.EntryRow _syncOffsetRow;
     
     /// <summary>
     /// Constructs a LyricsDialog
@@ -67,6 +68,18 @@ public partial class LyricsDialog : Adw.Window
         SetTransientFor(parent);
         OnCloseRequest += OnClose;
         _addSyncLyricButton.OnClicked += AddSyncLyric;
+        _syncOffsetRow.OnApply += (sender, e) =>
+        {
+            if (int.TryParse(_syncOffsetRow.GetText(), out var offset))
+            {
+                _controller.SynchronizedLyricsOffset = offset;
+            }
+            else
+            {
+                _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
+                _syncOffsetRow.SetPosition(-1);
+            }
+        };
         //Load
         _languageRow.SetText(_controller.LanguageCode);
         _descriptionRow.SetText(_controller.Description);
@@ -75,6 +88,7 @@ public partial class LyricsDialog : Adw.Window
         {
             AddSyncLyricRow(pair.Key, pair.Value);
         }
+        _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
     }
 
     /// <summary>

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -46,6 +46,7 @@ public partial class LyricsDialog : Adw.Window
     private readonly string _iconName;
     private readonly Dictionary<int, Adw.EntryRow> _syncRows;
 
+    [Gtk.Connect] private readonly Adw.ToastOverlay _toast;
     [Gtk.Connect] private readonly Adw.EntryRow _languageRow;
     [Gtk.Connect] private readonly Adw.EntryRow _descriptionRow;
     [Gtk.Connect] private readonly Gtk.TextView _unsyncTextView;
@@ -229,6 +230,11 @@ public partial class LyricsDialog : Adw.Window
     /// <param name="e">EventArgs</param>
     private async void ExportSyncFromLRC(Gtk.Button sender, EventArgs e)
     {
+        if (_controller.SynchronizedLyrics.Count == 0)
+        {
+            _toast.AddToast(Adw.Toast.New(_("Nothing to export.")));
+            return;
+        }
         var saveFileDialog = Gtk.FileDialog.New();
         saveFileDialog.SetTitle(_("Export to LRC"));
         var filterLRC = Gtk.FileFilter.New();
@@ -246,7 +252,14 @@ public partial class LyricsDialog : Adw.Window
             {
                 path += ".lrc";
             }
-            _controller.ExportToLRC(path);
+            if (_controller.ExportToLRC(path))
+            {
+                _toast.AddToast(Adw.Toast.New(string.Format(_("Exported successfully to: {0}"), path)));
+            }
+            else
+            {
+                _toast.AddToast(Adw.Toast.New(_("Unable to export to LRC.")));
+            }
         }
         catch { }
     }

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -220,10 +220,10 @@ public partial class LyricsDialog : Adw.Window
             var file = await openFileDialog.OpenAsync(_parentWindow);
             var messageDialog = Adw.MessageDialog.New(this, _("Existing Lyrics"), _("What would you like Tagger to do with lyrics found from the LRC file that conflict with existing lyrics of the same timestamp?"));
             messageDialog.SetIconName(_iconName);
-            messageDialog.AddResponse("keep", _("Keep Tagger's version"));
+            messageDialog.AddResponse("keep", _("Keep Tagger's lyrics"));
             messageDialog.SetDefaultResponse("keep");
             messageDialog.SetCloseResponse("keep");
-            messageDialog.AddResponse("overwrite", _("Use LRC's version"));
+            messageDialog.AddResponse("overwrite", _("Use LRC's lyrics"));
             messageDialog.SetResponseAppearance("overwrite", Adw.ResponseAppearance.Destructive);
             messageDialog.OnResponse += async (s, ex) =>
             {

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -115,6 +115,7 @@ public partial class LyricsDialog : Adw.Window
         _descriptionRow.SetText(_controller.Description);
         _unsyncTextView.GetBuffer().SetText(_controller.UnsynchronizedLyrics, _controller.UnsynchronizedLyrics.Length);
         _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
+        _syncList.SetVisible(_controller.SynchronizedLyrics.Count > 0);
     }
     
     /// <summary>
@@ -138,6 +139,7 @@ public partial class LyricsDialog : Adw.Window
             delete.OnClicked += (s, ex) => _controller.RemoveSynchronizedLyric(e.Timestamp);
             row.AddSuffix(delete);
             row.OnApply += (s, ex) => _controller.SetSynchronizedLyric(e.Timestamp, s.GetText());
+            _syncList.SetVisible(true);
             _syncList.Insert(row, e.Position);
             _syncRows.Add(e.Timestamp, row);
         }
@@ -154,6 +156,7 @@ public partial class LyricsDialog : Adw.Window
         {
             _syncList.Remove(_syncRows[e.Timestamp]);
             _syncRows.Remove(e.Timestamp);
+            _syncList.SetVisible(_syncRows.Count > 0);
         }
     }
 

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -235,8 +235,16 @@ public partial class LyricsDialog : Adw.Window
                 {
                     _toast.AddToast(Adw.Toast.New(_("Unable to import from LRC.")));
                 }
+                messageDialog.Destroy();
             };
-            messageDialog.Present();
+            if (_controller.SynchronizedLyrics.Count == 0)
+            {
+                messageDialog.Response("overwrite");
+            }
+            else
+            {
+                messageDialog.Present();
+            }
         }
         catch { }
     }

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -50,7 +50,7 @@ public partial class LyricsDialog : Adw.Window
     [Gtk.Connect] private readonly Adw.EntryRow _languageRow;
     [Gtk.Connect] private readonly Adw.EntryRow _descriptionRow;
     [Gtk.Connect] private readonly Gtk.TextView _unsyncTextView;
-    [Gtk.Connect] private readonly Adw.PreferencesGroup _syncGroup;
+    [Gtk.Connect] private readonly Gtk.ListBox _syncList;
     [Gtk.Connect] private readonly Gtk.Button _addSyncLyricButton;
     [Gtk.Connect] private readonly Gtk.Button _clearSyncButton;
     [Gtk.Connect] private readonly Gtk.Button _importSyncButton;
@@ -138,7 +138,7 @@ public partial class LyricsDialog : Adw.Window
             delete.OnClicked += (s, ex) => _controller.RemoveSynchronizedLyric(e.Timestamp);
             row.AddSuffix(delete);
             row.OnApply += (s, ex) => _controller.SetSynchronizedLyric(e.Timestamp, s.GetText());
-            _syncGroup.Add(row);
+            _syncList.Insert(row, e.Position);
             _syncRows.Add(e.Timestamp, row);
         }
     }
@@ -152,7 +152,7 @@ public partial class LyricsDialog : Adw.Window
     {
         if (_syncRows.ContainsKey(e.Timestamp))
         {
-            _syncGroup.Remove(_syncRows[e.Timestamp]);
+            _syncList.Remove(_syncRows[e.Timestamp]);
             _syncRows.Remove(e.Timestamp);
         }
     }

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -218,7 +218,25 @@ public partial class LyricsDialog : Adw.Window
         try
         {
             var file = await openFileDialog.OpenAsync(_parentWindow);
-            _controller.ImportFromLRC(file!.GetPath()!);
+            var messageDialog = Adw.MessageDialog.New(this, _("Existing Lyrics"), _("What would you like Tagger to do with lyrics found from the LRC file that conflict with existing lyrics of the same timestamp?"));
+            messageDialog.SetIconName(_iconName);
+            messageDialog.AddResponse("keep", _("Keep Tagger's version"));
+            messageDialog.SetDefaultResponse("keep");
+            messageDialog.SetCloseResponse("keep");
+            messageDialog.AddResponse("overwrite", _("Use LRC's version"));
+            messageDialog.SetResponseAppearance("overwrite", Adw.ResponseAppearance.Destructive);
+            messageDialog.OnResponse += async (s, ex) =>
+            {
+                if (_controller.ImportFromLRC(file!.GetPath()!, ex.Response == "overwrite"))
+                {
+                    _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
+                }
+                else
+                {
+                    _toast.AddToast(Adw.Toast.New(_("Unable to import from LRC.")));
+                }
+            };
+            messageDialog.Present();
         }
         catch { }
     }

--- a/NickvisionTagger.GNOME/Views/LyricsDialog.cs
+++ b/NickvisionTagger.GNOME/Views/LyricsDialog.cs
@@ -1,10 +1,12 @@
+using Nickvision.GirExt;
 using NickvisionTagger.GNOME.Controls;
 using NickvisionTagger.GNOME.Helpers;
 using NickvisionTagger.Shared.Controllers;
+using NickvisionTagger.Shared.Events;
 using NickvisionTagger.Shared.Helpers;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Runtime.InteropServices;
 using static NickvisionTagger.Shared.Helpers.Gettext;
 
@@ -40,8 +42,9 @@ public partial class LyricsDialog : Adw.Window
     private static partial string gtk_text_buffer_get_text(nint buffer, ref TextIter startIter, ref TextIter endIter, [MarshalAs(UnmanagedType.I1)]bool include_hidden_chars);
     
     private readonly LyricsDialogController _controller;
+    private readonly Gtk.Window _parentWindow;
     private readonly string _iconName;
-    private readonly List<Adw.EntryRow> _syncRows;
+    private readonly Dictionary<int, Adw.EntryRow> _syncRows;
 
     [Gtk.Connect] private readonly Adw.EntryRow _languageRow;
     [Gtk.Connect] private readonly Adw.EntryRow _descriptionRow;
@@ -63,15 +66,16 @@ public partial class LyricsDialog : Adw.Window
     private LyricsDialog(Gtk.Builder builder, LyricsDialogController controller, Gtk.Window parent, string iconName) : base(builder.GetPointer("_root"), false)
     {
         _controller = controller;
+        _parentWindow = parent;
         _iconName = iconName;
-        _syncRows = new List<Adw.EntryRow>();
+        _syncRows = new Dictionary<int, Adw.EntryRow>();
         builder.Connect(this);
         //Dialog Settings
         SetIconName(iconName);
         SetTransientFor(parent);
         OnCloseRequest += OnClose;
         _addSyncLyricButton.OnClicked += AddSyncLyric;
-        _clearSyncButton.OnClicked += ClearSyncLyrics;
+        _clearSyncButton.OnClicked += (sender, e) => _controller.ClearSynchronizedLyrics();;
         _importSyncButton.OnClicked += ImportSyncFromLRC;
         _exportSyncButton.OnClicked += ExportSyncFromLRC;
         _syncOffsetRow.OnApply += (sender, e) =>
@@ -86,15 +90,9 @@ public partial class LyricsDialog : Adw.Window
                 _syncOffsetRow.SetPosition(-1);
             }
         };
-        //Load
-        _languageRow.SetText(_controller.LanguageCode);
-        _descriptionRow.SetText(_controller.Description);
-        _unsyncTextView.GetBuffer().SetText(_controller.UnsynchronizedLyrics, _controller.UnsynchronizedLyrics.Length);
-        foreach (var pair in _controller.SynchronizedLyrics.OrderBy(x => x.Key))
-        {
-            AddSyncLyricRow(pair.Key, pair.Value);
-        }
-        _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
+        //Events
+        _controller.SynchronizedLyricCreated += CreateSyncRow;
+        _controller.SynchronizedLyricRemoved += RemoveSyncRow;
     }
 
     /// <summary>
@@ -107,35 +105,55 @@ public partial class LyricsDialog : Adw.Window
     {
         
     }
+
+    public new void Present()
+    {
+        base.Present();
+        _controller.Startup();
+        _languageRow.SetText(_controller.LanguageCode);
+        _descriptionRow.SetText(_controller.Description);
+        _unsyncTextView.GetBuffer().SetText(_controller.UnsynchronizedLyrics, _controller.UnsynchronizedLyrics.Length);
+        _syncOffsetRow.SetText(_controller.SynchronizedLyricsOffset.ToString());
+    }
     
     /// <summary>
-    /// Adds a sync lyric row
+    /// Occurs when a sync lyric is created
     /// </summary>
-    /// <param name="key">The time of the lyric in ms</param>
-    /// <param name="value">The string lyric</param>
-    private void AddSyncLyricRow(int key, string value)
+    /// <param name="sender">object?</param>
+    /// <param name="e">SynchronizedLyricsEventArgs</param>
+    private void CreateSyncRow(object? sender, SynchronizedLyricsEventArgs e)
     {
-        var row = new Adw.EntryRow();
-        row.SetTitle(((int)TimeSpan.FromMilliseconds(key).TotalSeconds).ToDurationString());
-        row.SetText(value);
-        row.SetShowApplyButton(true);
-        var delete = new Gtk.Button();
-        delete.SetValign(Gtk.Align.Center);
-        delete.SetIconName("list-remove-symbolic");
-        delete.SetTooltipText(_("Remove Lyric"));
-        delete.AddCssClass("flat");
-        delete.OnClicked += (sender, e) =>
+        if (!_syncRows.ContainsKey(e.Timestamp))
         {
-            if (_controller.SynchronizedLyrics.Remove(key))
-            {
-                _syncGroup.Remove(row);
-                _syncRows.Remove(row);
-            }
-        };
-        row.AddSuffix(delete);
-        row.OnApply += (sender, e) => _controller.SynchronizedLyrics[key] = sender.GetText();
-        _syncGroup.Add(row);
-        _syncRows.Add(row);
+            var row = new Adw.EntryRow();
+            row.SetTitle(((int)TimeSpan.FromMilliseconds(e.Timestamp).TotalSeconds).ToDurationString());
+            row.SetText(e.Lyric);
+            row.SetShowApplyButton(true);
+            var delete = new Gtk.Button();
+            delete.SetValign(Gtk.Align.Center);
+            delete.SetIconName("list-remove-symbolic");
+            delete.SetTooltipText(_("Remove Lyric"));
+            delete.AddCssClass("flat");
+            delete.OnClicked += (s, ex) => _controller.RemoveSynchronizedLyric(e.Timestamp);
+            row.AddSuffix(delete);
+            row.OnApply += (s, ex) => _controller.SetSynchronizedLyric(e.Timestamp, s.GetText());
+            _syncGroup.Add(row);
+            _syncRows.Add(e.Timestamp, row);
+        }
+    }
+
+    /// <summary>
+    /// Occurs when a sync lyric is removed
+    /// </summary>
+    /// <param name="sender">object?</param>
+    /// <param name="e">SynchronizedLyricsEventArgs</param>
+    private void RemoveSyncRow(object? sender, SynchronizedLyricsEventArgs e)
+    {
+        if (_syncRows.ContainsKey(e.Timestamp))
+        {
+            _syncGroup.Remove(_syncRows[e.Timestamp]);
+            _syncRows.Remove(e.Timestamp);
+        }
     }
 
     /// <summary>
@@ -172,28 +190,12 @@ public partial class LyricsDialog : Adw.Window
                 var res = TimeSpan.TryParse(entryDialog.Response, out var span);
                 if (res)
                 {
-                    _controller.SynchronizedLyrics[(int)span.TotalMilliseconds] = "";
-                    AddSyncLyricRow((int)span.TotalMilliseconds, "");
+                    _controller.AddSynchronizedLyric((int)span.TotalMilliseconds);
                 }
             }
             entryDialog.Destroy();
         };
         entryDialog.Present();
-    }
-    
-    /// <summary>
-    /// Occurs when the clear synchronized lyrics button is clicked
-    /// </summary>
-    /// <param name="sender">Gtk.Button</param>
-    /// <param name="e">EventArgs</param>
-    private void ClearSyncLyrics(Gtk.Button sender, EventArgs e)
-    {
-        _controller.SynchronizedLyrics.Clear();
-        foreach (var row in _syncRows)
-        {
-            _syncGroup.Remove(row);
-        }
-        _syncRows.Clear();
     }
 
     /// <summary>
@@ -201,9 +203,23 @@ public partial class LyricsDialog : Adw.Window
     /// </summary>
     /// <param name="sender">Gtk.Button</param>
     /// <param name="e">EventArgs</param>
-    private void ImportSyncFromLRC(Gtk.Button sender, EventArgs e)
+    private async void ImportSyncFromLRC(Gtk.Button sender, EventArgs e)
     {
-        
+        var openFileDialog = Gtk.FileDialog.New();
+        openFileDialog.SetTitle(_("Import from LRC"));
+        var filterLRC = Gtk.FileFilter.New();
+        filterLRC.SetName($"LRC (*.lrc)");
+        filterLRC.AddPattern("*.lrc");
+        filterLRC.AddPattern("*.LRC");
+        var filters = Gio.ListStore.New(Gtk.FileFilter.GetGType());
+        filters.Append(filterLRC);
+        openFileDialog.SetFilters(filters);
+        try
+        {
+            var file = await openFileDialog.OpenAsync(_parentWindow);
+            _controller.ImportFromLRC(file!.GetPath()!);
+        }
+        catch { }
     }
     
     /// <summary>
@@ -211,8 +227,27 @@ public partial class LyricsDialog : Adw.Window
     /// </summary>
     /// <param name="sender">Gtk.Button</param>
     /// <param name="e">EventArgs</param>
-    private void ExportSyncFromLRC(Gtk.Button sender, EventArgs e)
+    private async void ExportSyncFromLRC(Gtk.Button sender, EventArgs e)
     {
-        
+        var saveFileDialog = Gtk.FileDialog.New();
+        saveFileDialog.SetTitle(_("Export to LRC"));
+        var filterLRC = Gtk.FileFilter.New();
+        filterLRC.SetName($"LRC (*.lrc)");
+        filterLRC.AddPattern("*.lrc");
+        filterLRC.AddPattern("*.LRC");
+        var filters = Gio.ListStore.New(Gtk.FileFilter.GetGType());
+        filters.Append(filterLRC);
+        saveFileDialog.SetFilters(filters);
+        try
+        {
+            var file = await saveFileDialog.SaveAsync(_parentWindow);
+            var path = file!.GetPath()!;
+            if (Path.GetExtension(path).ToLower() != ".lrc")
+            {
+                path += ".lrc";
+            }
+            _controller.ExportToLRC(path);
+        }
+        catch { }
     }
 }

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -770,9 +770,9 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         var controller = _controller.CreateLyricsDialogController();
         var lyricsDialog = new LyricsDialog(controller, this, _controller.AppInfo.ID);
-        lyricsDialog.OnHide += (sender, e) =>
+        lyricsDialog.OnHide += (s, ex) =>
         {
-            _controller.UpdateLyrics(controller.LanguageCode, controller.Description, controller.UnsynchronizedLyrics, controller.SynchronizedLyrics);
+            _controller.UpdateLyrics(controller.LanguageCode, controller.Description, controller.UnsynchronizedLyrics, controller.SynchronizedLyrics, controller.SynchronizedLyricsOffset);
             lyricsDialog.Destroy();
         };
         lyricsDialog.Present();

--- a/NickvisionTagger.GNOME/nuget-sources.json
+++ b/NickvisionTagger.GNOME/nuget-sources.json
@@ -575,10 +575,17 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/4.36.0/z440.atl.core.4.36.0.nupkg",
-    "sha512": "57f2163ea43d63072ae0cb0fa7d208a00fad16d1aa93a20304607342dd8fd0a45cb3f346f647ea2a8e61549fc910c9ab161d741bf08506db9176870fc32a1357",
+    "url": "https://api.nuget.org/v3-flatcontainer/z440.atl.core/5.0.0/z440.atl.core.5.0.0.nupkg",
+    "sha512": "04afe82788eba24b940a07edb20f1fbe7f0d463d778e6c858a152d308ed08aed5660916f0bdec7cc546ced2a56b317d4524c770e591a3a18d0e46875e3efb34b",
     "dest": "nuget-sources",
-    "dest-filename": "z440.atl.core.4.36.0.nupkg"
+    "dest-filename": "z440.atl.core.5.0.0.nupkg"
+  },
+  {
+    "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/zomp.syncmethodgenerator/1.0.12/zomp.syncmethodgenerator.1.0.12.nupkg",
+    "sha512": "9f9c903760cb100310bef3423ac6438bdfbccee8b1831cf02448750cfc92264f0716d34638c0345742f6d16553992454588a4638451b0612321c8b296e9c05b8",
+    "dest": "nuget-sources",
+    "dest-filename": "zomp.syncmethodgenerator.1.0.12.nupkg"
   },
   {
     "type": "file",

--- a/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
+++ b/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
@@ -1,7 +1,11 @@
+using ATL;
+using Microsoft.VisualBasic.CompilerServices;
 using NickvisionTagger.Shared.Events;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace NickvisionTagger.Shared.Controllers;
 
@@ -100,13 +104,36 @@ public class LyricsDialogController
         SynchronizedLyrics.Clear();
     }
 
-    public void ImportFromLRC(string path)
+    public bool ImportFromLRC(string path)
     {
+        if (string.IsNullOrEmpty(path) || Path.GetExtension(path).ToLower() != ".lrc")
+        {
+            return false;
+        }
         
+        return false;
     }
 
-    public void ExportToLRC(string path)
+    public bool ExportToLRC(string path)
     {
-        
+        if (string.IsNullOrEmpty(path) || SynchronizedLyrics.Count == 0)
+        {
+            return false;
+        }
+        if (Path.GetExtension(path).ToLower() != ".lrc")
+        {
+            path += ".lrc";
+        }
+        var lyricsInfo = new LyricsInfo()
+        {
+            SynchronizedLyrics = SynchronizedLyrics.Select(x => new LyricsInfo.LyricsPhrase(x.Key, x.Value)).ToList(),
+            Metadata = new Dictionary<string, string>()
+        };
+        if (SynchronizedLyricsOffset != 0)
+        {
+            lyricsInfo.Metadata["offset"] = SynchronizedLyricsOffset.ToString();
+        }
+        File.WriteAllText(path, lyricsInfo.FormatSynchToLRC());
+        return true;
     }
 }

--- a/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
+++ b/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
@@ -63,7 +63,7 @@ public class LyricsDialogController
 
     public void Startup()
     {
-        foreach (var pair in SynchronizedLyrics)
+        foreach (var pair in SynchronizedLyrics.OrderBy(x => x.Key))
         {
             SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(pair.Key, pair.Value));
         }
@@ -74,7 +74,8 @@ public class LyricsDialogController
         if (!SynchronizedLyrics.ContainsKey(timestamp))
         {
             SynchronizedLyrics[timestamp] = "";
-            SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(timestamp, ""));
+            var lyrics = SynchronizedLyrics.Keys.OrderBy(x => x).ToList();
+            SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(timestamp, "", lyrics.IndexOf(timestamp)));
         }
     }
 
@@ -119,12 +120,14 @@ public class LyricsDialogController
             {
                 SynchronizedLyricRemoved?.Invoke(this, new SynchronizedLyricsEventArgs(phase.TimestampMs, SynchronizedLyrics[phase.TimestampMs]));
                 SynchronizedLyrics[phase.TimestampMs] = phase.Text;
-                SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(phase.TimestampMs, phase.Text));
+                var lyrics = SynchronizedLyrics.Keys.OrderBy(x => x).ToList();
+                SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(phase.TimestampMs, phase.Text, lyrics.IndexOf(phase.TimestampMs)));
             }
             else if (!SynchronizedLyrics.ContainsKey(phase.TimestampMs))
             {
                 SynchronizedLyrics.Add(phase.TimestampMs, phase.Text);
-                SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(phase.TimestampMs, phase.Text));
+                var lyrics = SynchronizedLyrics.Keys.OrderBy(x => x).ToList();
+                SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(phase.TimestampMs, phase.Text, lyrics.IndexOf(phase.TimestampMs)));
             }
         }
         var offset = lyricsInfo.Metadata.TryGetValue("offset", out var o) ? (int.TryParse(o, out var offsetInt) ? offsetInt : 0) : 0;
@@ -132,7 +135,7 @@ public class LyricsDialogController
         {
             SynchronizedLyricsOffset = offset;
         }
-        return false;
+        return true;
     }
 
     public bool ExportToLRC(string path)

--- a/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
+++ b/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
@@ -1,3 +1,5 @@
+using NickvisionTagger.Shared.Events;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -30,6 +32,15 @@ public class LyricsDialogController
     public int SynchronizedLyricsOffset { get; set; }
     
     /// <summary>
+    /// Occurs when a sync lyric is created
+    /// </summary>
+    public event EventHandler<SynchronizedLyricsEventArgs>? SynchronizedLyricCreated;
+    /// <summary>
+    /// Occurs when a sync lyric is removed
+    /// </summary>
+    public event EventHandler<SynchronizedLyricsEventArgs>? SynchronizedLyricRemoved;
+    
+    /// <summary>
     /// Constructs a LyricsDialogController
     /// </summary>
     /// <param name="langCode">The language code of the lyrics</param>
@@ -44,5 +55,58 @@ public class LyricsDialogController
         UnsynchronizedLyrics = unsync;
         SynchronizedLyrics = sync.ToDictionary(x => x.Key, x => x.Value);
         SynchronizedLyricsOffset = offset;
+    }
+
+    public void Startup()
+    {
+        foreach (var pair in SynchronizedLyrics)
+        {
+            SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(pair.Key, pair.Value));
+        }
+    }
+    
+    public void AddSynchronizedLyric(int timestamp)
+    {
+        if (!SynchronizedLyrics.ContainsKey(timestamp))
+        {
+            SynchronizedLyrics[timestamp] = "";
+            SynchronizedLyricCreated?.Invoke(this, new SynchronizedLyricsEventArgs(timestamp, ""));
+        }
+    }
+
+    public void SetSynchronizedLyric(int timestamp, string lyric)
+    {
+        if (SynchronizedLyrics.ContainsKey(timestamp))
+        {
+            SynchronizedLyrics[timestamp] = lyric;
+        }
+    }
+
+    public void RemoveSynchronizedLyric(int timestamp)
+    {
+        if (SynchronizedLyrics.ContainsKey(timestamp))
+        {
+            SynchronizedLyricRemoved?.Invoke(this, new SynchronizedLyricsEventArgs(timestamp, SynchronizedLyrics[timestamp]));
+            SynchronizedLyrics.Remove(timestamp);
+        }
+    }
+    
+    public void ClearSynchronizedLyrics()
+    {
+        foreach (var pair in SynchronizedLyrics)
+        {
+            SynchronizedLyricRemoved?.Invoke(this, new SynchronizedLyricsEventArgs(pair.Key, pair.Value));
+        }
+        SynchronizedLyrics.Clear();
+    }
+
+    public void ImportFromLRC(string path)
+    {
+        
+    }
+
+    public void ExportToLRC(string path)
+    {
+        
     }
 }

--- a/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
+++ b/NickvisionTagger.Shared/Controllers/LyricsDialogController.cs
@@ -24,6 +24,10 @@ public class LyricsDialogController
     /// The set of synchronized lyrics
     /// </summary>
     public Dictionary<int, string> SynchronizedLyrics { get; init; }
+    /// <summary>
+    /// The offset for SynchronizedLyrics (in milliseconds)
+    /// </summary>
+    public int SynchronizedLyricsOffset { get; set; }
     
     /// <summary>
     /// Constructs a LyricsDialogController
@@ -32,11 +36,13 @@ public class LyricsDialogController
     /// <param name="description">The description of the lyrics</param>
     /// <param name="unsync">The unsynchronized lyrics</param>
     /// <param name="sync">The set of synchronized lyrics</param>
-    public LyricsDialogController(string langCode, string description, string unsync, Dictionary<int, string> sync)
+    /// <param name="offset">The offset of synchronized lyrics (in milliseconds)</param>
+    public LyricsDialogController(string langCode, string description, string unsync, Dictionary<int, string> sync, int offset)
     {
         LanguageCode = langCode;
         Description = description;
         UnsynchronizedLyrics = unsync;
         SynchronizedLyrics = sync.ToDictionary(x => x.Key, x => x.Value);
+        SynchronizedLyricsOffset = offset;
     }
 }

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -254,9 +254,9 @@ public class MainWindowController : IDisposable
         if (SelectedMusicFiles.Count == 1)
         {
             var first = SelectedMusicFiles.First().Value;
-            return new LyricsDialogController(first.LyricsLanguageCode, first.LyricsDescription, first.UnsynchronizedLyrics, first.SynchronizedLyrics);
+            return new LyricsDialogController(first.LyricsLanguageCode, first.LyricsDescription, first.UnsynchronizedLyrics, first.SynchronizedLyrics, first.SynchronizedLyricsOffset);
         }
-        return new LyricsDialogController("", "", "", new Dictionary<int, string>());
+        return new LyricsDialogController("", "", "", new Dictionary<int, string>(), 0);
     }
 
     /// <summary>
@@ -489,7 +489,8 @@ public class MainWindowController : IDisposable
     /// <param name="description">The description of the lyrics</param>
     /// <param name="unsync">The unsynchronized lyrics</param>
     /// <param name="sync">The set of synchronized lyrics</param>
-    public void UpdateLyrics(string langCode, string description, string unsync, Dictionary<int, string> sync)
+    /// <param name="offset">The offset of synchronized lyrics (in milliseconds)</param>
+    public void UpdateLyrics(string langCode, string description, string unsync, Dictionary<int, string> sync, int offset)
     {
         if (SelectedMusicFiles.Count == 1)
         {
@@ -513,6 +514,11 @@ public class MainWindowController : IDisposable
             if (!sync.SequenceEqual(first.Value.SynchronizedLyrics))
             {
                 first.Value.SynchronizedLyrics = sync;
+                updated = true;
+            }
+            if (offset != first.Value.SynchronizedLyricsOffset)
+            {
+                first.Value.SynchronizedLyricsOffset = offset;
                 updated = true;
             }
             MusicFileSaveStates[first.Key] = !updated && MusicFileSaveStates[first.Key];

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -139,7 +139,7 @@ public class MainWindowController : IDisposable
         }
         Aura.Active.SetConfig<Configuration>("config");
         Configuration.Current.Saved += ConfigurationSaved;
-        AppInfo.Version = "2023.8.2";
+        AppInfo.Version = "2023.8.3-next";
         AppInfo.SourceRepo = new Uri("https://github.com/NickvisionApps/Tagger");
         AppInfo.IssueTracker = new Uri("https://github.com/NickvisionApps/Tagger/issues/new");
         AppInfo.SupportUrl = new Uri("https://github.com/NickvisionApps/Tagger/discussions");

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -822,6 +822,10 @@ public class MainWindowController : IDisposable
     /// <param name="name">The name of the property to add</param>
     public void AddCustomProperty(string name)
     {
+        if (name.ToLower() == "lyrics")
+        {
+            return;
+        }
         foreach(var pair in SelectedMusicFiles)
         {
             pair.Value.SetCustomProperty(name, "");

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -926,6 +926,7 @@ public class MainWindowController : IDisposable
                 MusicBrainzLoadStatus.NoAcoustIdResult => _("No AcoustId entry found for the file's fingerprint"),
                 MusicBrainzLoadStatus.NoAcoustIdRecordingId => _("No MusicBrainz RecordingId was provided for the AcoustId entry"),
                 MusicBrainzLoadStatus.InvalidMusicBrainzRecordingId => _("An invalid RecordingId was provided to MusicBrainz"),
+                MusicBrainzLoadStatus.InvalidFingerprint => _("This file does not have a valid fingerprint"),
                 _ => _("Error")
             }}\n\n";
         }

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -822,20 +822,20 @@ public class MainWindowController : IDisposable
     /// <param name="name">The name of the property to add</param>
     public void AddCustomProperty(string name)
     {
-        if (name.ToLower() == "lyrics")
-        {
-            return;
-        }
+        var set = false;
         foreach(var pair in SelectedMusicFiles)
         {
-            pair.Value.SetCustomProperty(name, "");
-            MusicFileSaveStates[pair.Key] = false;
+            if (pair.Value.SetCustomProperty(name, ""))
+            {
+                MusicFileSaveStates[pair.Key] = false;
+                set = true;
+            }
         }
-        if(SelectedMusicFiles.Count > 0)
+        if(set)
         {
             UpdateSelectedMusicFilesProperties();
         }
-        MusicFileSaveStatesChanged?.Invoke(this, true);
+        MusicFileSaveStatesChanged?.Invoke(this, set);
     }
 
     /// <summary>
@@ -857,7 +857,7 @@ public class MainWindowController : IDisposable
         {
             UpdateSelectedMusicFilesProperties();
         }
-        MusicFileSaveStatesChanged?.Invoke(this, true);
+        MusicFileSaveStatesChanged?.Invoke(this, removed);
     }
 
     /// <summary>

--- a/NickvisionTagger.Shared/Docs/html/de/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/de/configuration.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<title>Configuration</title>
+<title>Konfiguration</title>
 <link rel="stylesheet" type="text/css" href="../C/C.css">
 <script type="text/javascript" src="../C/highlight.pack.js"></script><script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -15,45 +15,45 @@ document.addEventListener('DOMContentLoaded', function() {
 </head>
 <body lang="de" dir="ltr"><main><div class="page">
 <header><div class="inner pagewide"><div class="trails" role="navigation"><div class="trail">
-<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Configuration</span></h1></div>
+<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Konfiguration</span></h1></div>
 <div class="region">
 <div class="contents pagewide">
-<p class="p">This page describes what you can change in the application configuration.</p>
+<p class="p">Diese Seite beschreibt, was du in der Anwendungskonfiguration ändern kannst.</p>
 <div class="terms"><div class="inner"><div class="region"><dl class="terms">
-<dt class="terms">Theme</dt>
-<dd class="terms"><p class="p">Set light or dark theme, or make <span class="app">Tagger</span> follow your system theme.</p></dd>
-<dt class="terms">Remember Last Opened Folder</dt>
-<dd class="terms"><p class="p">Whether or not to remember the previously used music folder and reopen it when Tagger starts the next time.</p></dd>
-<dt class="terms">Include Subfolders</dt>
-<dd class="terms"><p class="p">Whether or not to scan for music files into subdirectories of a music folder.</p></dd>
-<dt class="terms">Sort Files By</dt>
+<dt class="terms">Farbschema</dt>
+<dd class="terms"><p class="p">Setzt ein helles oder dunkles Farbschema, oder lässt <span class="app">Tagger</span> der Systemeinstellung folgen.</p></dd>
+<dt class="terms">Zuletzt geöffneten Ordner merken</dt>
+<dd class="terms"><p class="p">Legt fest, ob der zuletzt geöffnete Musik-Ordner gemerkt und bei nächsten Öffnen von <span class="app">Tagger</span> erneut geöffnet werden soll.</p></dd>
+<dt class="terms">Unterordner mit einbeziehen</dt>
+<dd class="terms"><p class="p">Legt fest, ob Unterordner auch nach Audiodateien durchsucht werden sollen.</p></dd>
+<dt class="terms">Dateien sortieren nach</dt>
 <dd class="terms">
-<p class="p">The property to use when sorting and displaying music files. It can be one of the following options:</p>
+<p class="p">Legt fest welche Eigenschaft beim Sortieren und Anzeigen von Audiodateien verwendet werden soll. Die folgenden Optionen sind verfügbar:</p>
 <div class="list"><div class="inner"><div class="region"><ul class="list">
-<li class="list"><p class="p"><span class="code">File Name</span></p></li>
-<li class="list"><p class="p"><span class="code">Title</span></p></li>
+<li class="list"><p class="p"><span class="code">Dateiname</span></p></li>
+<li class="list"><p class="p"><span class="code">Titel</span></p></li>
 <li class="list"><p class="p"><span class="code">Track</span></p></li>
-<li class="list"><p class="p"><span class="code">File Path</span></p></li>
+<li class="list"><p class="p"><span class="code">Dateipfad</span></p></li>
 <li class="list"><p class="p"><span class="code">Album</span></p></li>
 <li class="list"><p class="p"><span class="code">Genre</span></p></li>
 </ul></div></div></div>
 </dd>
-<dt class="terms">Preserve Modification Timestamp</dt>
-<dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
-<dt class="terms">Overwrite Tag With MusicBrainz</dt>
-<dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
-<dt class="terms">Overwrite Album Art With MusicBrainz</dt>
-<dd class="terms"><p class="p">Whether or not to overwrite overwrite existing album art with art found from MusicBrainz.</p></dd>
-<dt class="terms">AcoustId User API Key</dt>
+<dt class="terms">Änderungs-Zeitstempel erhalten</dt>
+<dd class="terms"><p class="p">Legt fest, ob das Änderungsdatem der Datei aktualisiert werden soll wenn ein Tag gespeichert wird.</p></dd>
+<dt class="terms">Tag mit MusicBrainz überschreiben</dt>
+<dd class="terms"><p class="p">Legt fest of existierende Metadaten mit Daten von MusicBrainz überschrieben werden sollen. Wenn die Option deaktiviert ist werden nur leere Tag-Felder gefüllt.</p></dd>
+<dt class="terms">Albumcover mit MusicBrainz überschreiben</dt>
+<dd class="terms"><p class="p">Legt fest, ob ein existierendes Albumcover mit Daten von MusicBrainz überschrieben werden soll.</p></dd>
+<dt class="terms">AcoustId Nutzer-API-Key</dt>
 <dd class="terms">
-<p class="p">An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
+<p class="p">Ein AcoustId Nutzer-API-Key, der beim Fingerprinting von Audiodateien und bei der Suche nach Songinformationen verwendet wird.</p>
 <div class="note" title="Anmerkung">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">A key can be obtained <span class="link"><a href="https://acoustid.org/api-key" title="https://acoustid.org/api-key">here</a></span></p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Ein API-Key kann man <span class="link"><a href="https://acoustid.org/api-key" title="https://acoustid.org/api-key">hier</a></span> erhalten.</p></div></div></div>
 </div>
 </dd>
 </dl></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/de/corrupted.html
+++ b/NickvisionTagger.Shared/Docs/html/de/corrupted.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<title>Corrupted Files</title>
+<title>Korrupte Dateien</title>
 <link rel="stylesheet" type="text/css" href="../C/C.css">
 <script type="text/javascript" src="../C/highlight.pack.js"></script><script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -15,14 +15,14 @@ document.addEventListener('DOMContentLoaded', function() {
 </head>
 <body lang="de" dir="ltr"><main><div class="page">
 <header><div class="inner pagewide"><div class="trails" role="navigation"><div class="trail">
-<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Corrupted Files</span></h1></div>
+<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Korrupte Dateien</span></h1></div>
 <div class="region">
-<div class="contents pagewide"><p class="p">This page explains music files with corrupted data.</p></div>
+<div class="contents pagewide"><p class="p">Diese Seite erklärt Audiodateien mit korrupten Daten.</p></div>
 <section id=""><div class="inner">
-<div class="hgroup pagewide"><h2 class="title"><span class="title">Invalid Data</span></h2></div>
+<div class="hgroup pagewide"><h2 class="title"><span class="title">Ungültige Daten</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">An invalid tag header or junk data in a file can cause issues when reading information about a file and even cause playback issues. Some websites add extra junk data in files which in turn causes corruption.</p>
-<p class="p">If <span class="app">Tagger</span> is unable to read a file, it will be ignored and a dialog will be displayed listing corrupted files for you to manage and fix accordingly.</p>
+<p class="p">Ein ungültiger Tag-Header oder Junk-Daten in einer Datei können zu Problemen beim Lesen von Informationen über eine Datei und sogar zu Wiedergabeproblemen führen. Einige Websites fügen zusätzliche Junk-Daten in Dateien ein, die wiederum zu Beschädigungen führen.</p>
+<p class="p">Wenn <span class="app">Tagger</span> nicht in der Lage ist, eine Datei zu lesen, wird sie ignoriert. Die beschädigten Dateien werden in einem Dialogfeld aufgelistet, damit du sie entsprechend verwalten und reparieren kannst.</p>
 <div class="note note-advanced" title="Erweitert">
 <svg height="24" width="24" version="1.1">
  <g>
@@ -38,9 +38,9 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
 </svg><div class="inner"><div class="region"><div class="contents">
-<p class="p">FFmpeg can be used to fix corruption issues. Run the following command to re-encode a file's tag and remove junk data:</p>
+<p class="p">FFmpeg kann genutzt werden um beschädigte Dateien zu reparieren. Führe dazu den folgenden Befehl aus um die Datei neu zu enkodieren und Junk-Daten zu entfernen:</p>
 <div class="code"><pre class="contents"><code>ffmpeg -i in.mp3 out.mp3</code></pre></div>
-<p class="p">where <span class="code">in.mp3</span> is the file path of the corrupted file and <span class="code">out.mp3</span> is the path to export the re-encoded file.</p>
+<p class="p">wobei <span class="code">in.mp3</span> der Dateipfad zur beschädigten Datei ist und <span class="code">out.mp3</span> der Pfad an dem die reparierte Datei gespeichert werden soll.</p>
 </div></div></div>
 </div>
 <div class="note note-advanced" title="Erweitert">
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m8.2435 7.0719-1.9004-3.3145 1.4143-1.4143 3.1596 1.7457z"></path>
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">You can also use <span class="link"><a href="https://www.freac.org" title="https://www.freac.org">fre:ac</a></span> to re-encode files without convertion to another format.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Die kannst alternativ <span class="link"><a href="https://www.freac.org" title="https://www.freac.org">fre:ac</a></span> nutzen um Dateien neu zu enkodieren, ohne sie in ein anderes Format umzuwandeln.</p></div></div></div>
 </div>
 </div></div>
 </div></section><section class="links" role="navigation"><div class="inner">

--- a/NickvisionTagger.Shared/Docs/html/de/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/de/format-strings.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<title>Format Strings</title>
+<title>Formatvorlagen</title>
 <link rel="stylesheet" type="text/css" href="../C/C.css">
 <script type="text/javascript" src="../C/highlight.pack.js"></script><script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -15,9 +15,9 @@ document.addEventListener('DOMContentLoaded', function() {
 </head>
 <body lang="de" dir="ltr"><main><div class="page">
 <header><div class="inner pagewide"><div class="trails" role="navigation"><div class="trail">
-<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Format Strings</span></h1></div>
+<a class="trail" href="index.html" title="Tagger Help">Tagger Help</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Formatvorlagen</span></h1></div>
 <div class="region">
-<div class="contents pagewide"><p class="p">This page explains the use of format strings for <span class="code">File Name to Tag</span> and <span class="code">Tag to File Name</span> conversions.</p></div>
+<div class="contents pagewide"><p class="p">Diese Seite erklärt die Nutzung von Formatvorlagen für die Konvertierungen <span class="code">Dateiname zu Tag</span> und <span class="code">Tag zu Dateiname</span>.</p></div>
 <section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Format</span></h2></div>
 <div class="region"><div class="contents pagewide">

--- a/NickvisionTagger.Shared/Docs/html/de/index.html
+++ b/NickvisionTagger.Shared/Docs/html/de/index.html
@@ -22,9 +22,9 @@ document.addEventListener('DOMContentLoaded', function() {
 <p class="p"></p>
 <div class="links topiclinks"><div class="inner"><div class="region"><div class="links-divs">
 <div class="linkdiv "><a class="linkdiv" href="search.html" title="Advanced Search"><span class="title">Advanced Search 🔍</span></a></div>
-<div class="linkdiv "><a class="linkdiv" href="configuration.html" title="Configuration"><span class="title">Configuration 🔧</span></a></div>
-<div class="linkdiv "><a class="linkdiv" href="corrupted.html" title="Corrupted Files"><span class="title">Corrupted Files 🪲</span></a></div>
-<div class="linkdiv "><a class="linkdiv" href="format-strings.html" title="Format Strings"><span class="title">Format Strings ✍️</span></a></div>
+<div class="linkdiv "><a class="linkdiv" href="format-strings.html" title="Formatvorlagen"><span class="title">Formatvorlagen ✍️</span></a></div>
+<div class="linkdiv "><a class="linkdiv" href="configuration.html" title="Konfiguration"><span class="title">Konfiguration 🔧</span></a></div>
+<div class="linkdiv "><a class="linkdiv" href="corrupted.html" title="Korrupte Dateien"><span class="title">Korrupte Dateien 🪲</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="unsupported.html" title="Unsupported Files"><span class="title">Unsupported Files 🚫</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="web-services.html" title="Web Services"><span class="title">Web Services 🌐</span></a></div>
 </div></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/fi/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/fi/configuration.html
@@ -38,13 +38,13 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">Genre</span></p></li>
 </ul></div></div></div>
 </dd>
-<dt class="terms">Preserve Modification Timestamp</dt>
+<dt class="terms">Säilytä muokkauksen aikaleima</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
 <dt class="terms">Overwrite Tag With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">Overwrite Album Art With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite overwrite existing album art with art found from MusicBrainz.</p></dd>
-<dt class="terms">AcoustId User API Key</dt>
+<dt class="terms">AcoustId:n käyttäjän API-avain</dt>
 <dd class="terms">
 <p class="p">An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
 <div class="note" title="Huomautus">

--- a/NickvisionTagger.Shared/Docs/html/fr/index.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/index.html
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="linkdiv "><a class="linkdiv" href="corrupted.html" title="Fichiers corrompus"><span class="title">Fichiers corrompus 🪲</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="unsupported.html" title="Fichiers non pris en charge"><span class="title">Fichiers non pris en charge 🚫</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="search.html" title="Recherche avancée"><span class="title">Recherche avancée 🔍</span></a></div>
-<div class="linkdiv "><a class="linkdiv" href="web-services.html" title="Services Web"><span class="title">Web Services 🌐</span></a></div>
+<div class="linkdiv "><a class="linkdiv" href="web-services.html" title="Services Web"><span class="title">Services Web 🌐</span></a></div>
 </div></div></div></div>
 </div>
 <section id=""><div class="inner">

--- a/NickvisionTagger.Shared/Docs/html/fr/unsupported.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/unsupported.html
@@ -34,8 +34,8 @@ document.addEventListener('DOMContentLoaded', function() {
  </g>
 </svg><div class="inner"><div class="region"><div class="contents">
 <p class="p">Veuillez confirmer que vous recevez une erreur « permission refusée » avant d’essayer cela.</p>
-<p class="p">Run <span class="app">Tagger</span> in the terminal via <span class="code">flatpak run org.nickvision.tagger</span>, then try to apply changes again, and you will find an error message in the terminal.</p>
-<p class="p">If it is not a "permission denied" error, please <span class="link"><a href="https://github.com/NickvisionApps/Tagger/issues/174" title="https://github.com/NickvisionApps/Tagger/issues/174">report a new issue</a></span>.</p>
+<p class="p">Exécutez <span class="app">Tagger</span> dans un terminal avec la commande <span class="code">flatpak run org.nickvision.tagger</span>, puis essayez d’appliquer à nouveau les changements, vous trouverez le message d’erreur dans le terminal.</p>
+<p class="p">S’il ne s’egit pas d’une erreur « permission refusée », merci de <span class="link"><a href="https://github.com/NickvisionApps/Tagger/issues/174" title="https://github.com/NickvisionApps/Tagger/issues/174">signaler un nouveau problème</a></span>.</p>
 </div></div></div>
 </div>
 </div></div>

--- a/NickvisionTagger.Shared/Docs/html/fr/web-services.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/web-services.html
@@ -17,33 +17,33 @@ document.addEventListener('DOMContentLoaded', function() {
 <header><div class="inner pagewide"><div class="trails" role="navigation"><div class="trail">
 <a class="trail" href="index.html" title="Aide de Tagger">Aide de Tagger</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Services Web</span></h1></div>
 <div class="region">
-<div class="contents pagewide"><p class="p">This page describes the web services available in Tagger</p></div>
+<div class="contents pagewide"><p class="p">Cette page traite des services web disponibles dans Tagger</p></div>
 <section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Télécharger les métadonnées depuis MusicBrainz</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">Identifies a music file through MusicBrainz and downloads its metadata to use in Tagger.</p>
-<p class="p">This service utilizies the AcoustId fingerprint of the file (generated with <span class="code">fpcalc</span>) to determine MusicBrainz recording and release IDs. If IDs are found, metadata such as title, artist, album, and art will be downloaded and set in Tagger.</p>
+<p class="p">Identifie un fichier musical via MusicBrainz et télécharge ses métadonnées pour les utiliser dans Tagger.</p>
+<p class="p">Ce service utilise l’empreinte AcoustId du fichier (générée avec <span class="code">fpcalc</span>) pour déterminer les identifiants d’enregistrement et de sortie MusicBrainz. Si les identifiants sont trouvés, les métadonnées telles que le titre, l’artiste, l’album et la pochette seront téléchargées et utilisées dans Tagger.</p>
 <div class="note" title="Note">
 <svg height="24" width="24" version="1.1">
  <g>
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Finding metadata through MusicBrainz isn't 100% realiable and may not be available for uncommom songs.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">La recherche de métadonnées dans MusicBrainz n’est pas fiable à 100 % et peut ne pas être disponible pour des chansons peu connues.</p></div></div></div>
 </div>
 </div></div>
 </div></section><section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Envoyer à AcoustId</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">Submits data about a music file (identified via its fingerprint) to AcoustId's database. There are two things that can be submitted about a music file:</p>
+<p class="p">Soumet des données sur un fichier musical (identifié par son empreinte digitale) à la base de données d’AcoustId. Deux choses peuvent être soumises à propos d’un fichier musical :</p>
 <div class="list"><div class="inner"><div class="region"><ul class="list">
 <li class="list">
-<div class="title title-item"><h3><span class="title">MusicBrainz Recording ID</span></h3></div>
-<p class="p">A user can submit a MusicBrainz Recording ID to submit to AcoustId. This will pull all data from the associated recording id and use that for sending metadata to AcoustId.</p>
+<div class="title title-item"><h3><span class="title">Identifiant d’enregistrement MusicBrainz</span></h3></div>
+<p class="p">Un utilisateur peut soumettre un identifiant d’enregistrement MusicBrainz à AcoustId. Cela permettra d’extraire toutes les données de l’identifiant d’enregistrement associé et de les utiliser pour envoyer des métadonnées à AcoustId.</p>
 </li>
 <li class="list">
-<div class="title title-item"><h3><span class="title">User Metadata</span></h3></div>
-<p class="p">A user can submit their metadata from Tagger to AcoustId.</p>
+<div class="title title-item"><h3><span class="title">Métadonnées utilisateur</span></h3></div>
+<p class="p">Un utilisateur peut soumettre ses métadonnées de Tagger à AcoustId.</p>
 </li>
 </ul></div></div></div>
 <div class="note" title="Note">
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
   <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
  </g>
-</svg><div class="inner"><div class="region"><div class="contents"><p class="p">A proper <span class="code">AcoustId User API Key</span> must be set in <span class="code">Preferences</span> for this service to work.</p></div></div></div>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">Une <span class="code">Clé d’API de l’utilisateur AcoustId</span> appropriée doit être définie dans les <span class="code">Préférences</span> pour que ce service fonctionne.</p></div></div></div>
 </div>
 </div></div>
 </div></section><section class="links" role="navigation"><div class="inner">

--- a/NickvisionTagger.Shared/Docs/html/nl/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/nl/configuration.html
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Whether or not to remember the previously used music folder and reopen it when Tagger starts the next time.</p></dd>
 <dt class="terms">Include Subfolders</dt>
 <dd class="terms"><p class="p">Whether or not to scan for music files into subdirectories of a music folder.</p></dd>
-<dt class="terms">Sort Files By</dt>
+<dt class="terms">Bestanden sorteren op</dt>
 <dd class="terms">
 <p class="p">The property to use when sorting and displaying music files. It can be one of the following options:</p>
 <div class="list"><div class="inner"><div class="region"><ul class="list">

--- a/NickvisionTagger.Shared/Docs/yelp/de/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/configuration.page
@@ -2,7 +2,7 @@
 <page xmlns="http://projectmallard.org/1.0/" xmlns:its="http://www.w3.org/2005/11/its" type="topic" id="configuration" its:version="2.0" xml:lang="de">
 <info>
 	<link type="guide" xref="index"/>
-	<title type="link">Configuration 🔧</title>
+	<title type="link">Konfiguration 🔧</title>
 	<credit type="author copyright">
 		<name>Nicholas Logozzo</name>
 		<years its:translate="no">2023</years>
@@ -14,50 +14,50 @@
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
 </info>
 
-<title>Configuration</title>
-<p>This page describes what you can change in the application configuration.</p>
+<title>Konfiguration</title>
+<p>Diese Seite beschreibt, was du in der Anwendungskonfiguration ändern kannst.</p>
 <terms>
     <item>
-		<title>Theme</title>
-		<p>Set light or dark theme, or make <app>Tagger</app> follow your system theme.</p>
+		<title>Farbschema</title>
+		<p>Setzt ein helles oder dunkles Farbschema, oder lässt <app>Tagger</app> der Systemeinstellung folgen.</p>
 	</item>
     <item>
-		<title>Remember Last Opened Folder</title>
-		<p>Whether or not to remember the previously used music folder and reopen it when Tagger starts the next time.</p>
+		<title>Zuletzt geöffneten Ordner merken</title>
+		<p>Legt fest, ob der zuletzt geöffnete Musik-Ordner gemerkt und bei nächsten Öffnen von <app>Tagger</app> erneut geöffnet werden soll.</p>
 	</item>
     <item>
-		<title>Include Subfolders</title>
-		<p>Whether or not to scan for music files into subdirectories of a music folder.</p>
+		<title>Unterordner mit einbeziehen</title>
+		<p>Legt fest, ob Unterordner auch nach Audiodateien durchsucht werden sollen.</p>
 	</item>
     <item>
-		<title>Sort Files By</title>
-		<p>The property to use when sorting and displaying music files. It can be one of the following options:</p>
+		<title>Dateien sortieren nach</title>
+		<p>Legt fest welche Eigenschaft beim Sortieren und Anzeigen von Audiodateien verwendet werden soll. Die folgenden Optionen sind verfügbar:</p>
         <list>
-            <item><p><code>File Name</code></p></item>
-            <item><p><code>Title</code></p></item>
+            <item><p><code>Dateiname</code></p></item>
+            <item><p><code>Titel</code></p></item>
             <item><p><code>Track</code></p></item>
-            <item><p><code>File Path</code></p></item>
+            <item><p><code>Dateipfad</code></p></item>
             <item><p><code>Album</code></p></item>
             <item><p><code>Genre</code></p></item>
         </list>
 	</item>
     <item>
-		<title>Preserve Modification Timestamp</title>
-		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
+		<title>Änderungs-Zeitstempel erhalten</title>
+		<p>Legt fest, ob das Änderungsdatem der Datei aktualisiert werden soll wenn ein Tag gespeichert wird.</p>
 	</item>
     <item>
-		<title>Overwrite Tag With MusicBrainz</title>
-		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
+		<title>Tag mit MusicBrainz überschreiben</title>
+		<p>Legt fest of existierende Metadaten mit Daten von MusicBrainz überschrieben werden sollen. Wenn die Option deaktiviert ist werden nur leere Tag-Felder gefüllt.</p>
 	</item>
     <item>
-		<title>Overwrite Album Art With MusicBrainz</title>
-		<p>Whether or not to overwrite overwrite existing album art with art found from MusicBrainz.</p>
+		<title>Albumcover mit MusicBrainz überschreiben</title>
+		<p>Legt fest, ob ein existierendes Albumcover mit Daten von MusicBrainz überschrieben werden soll.</p>
 	</item>
     <item>
-		<title>AcoustId User API Key</title>
-		<p>An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
+		<title>AcoustId Nutzer-API-Key</title>
+		<p>Ein AcoustId Nutzer-API-Key, der beim Fingerprinting von Audiodateien und bei der Suche nach Songinformationen verwendet wird.</p>
 		<note>
-			<p>A key can be obtained <link href="https://acoustid.org/api-key">here</link></p>
+			<p>Ein API-Key kann man <link href="https://acoustid.org/api-key">hier</link> erhalten.</p>
 		</note>
 	</item>
 </terms>

--- a/NickvisionTagger.Shared/Docs/yelp/de/corrupted.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/corrupted.page
@@ -2,7 +2,7 @@
 <page xmlns="http://projectmallard.org/1.0/" xmlns:its="http://www.w3.org/2005/11/its" type="topic" id="corrupted" its:version="2.0" xml:lang="de">
 <info>
 	<link type="guide" xref="index"/>
-	<title type="link">Corrupted Files 🪲</title>
+	<title type="link">Korrupte Dateien 🪲</title>
 	<credit type="author copyright">
 		<name>Nicholas Logozzo</name>
 		<years its:translate="no">2023</years>
@@ -14,19 +14,19 @@
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
 </info>
 
-<title>Corrupted Files</title>
-<p>This page explains music files with corrupted data.</p>
+<title>Korrupte Dateien</title>
+<p>Diese Seite erklärt Audiodateien mit korrupten Daten.</p>
 <section>
-    <title>Invalid Data</title>
-    <p>An invalid tag header or junk data in a file can cause issues when reading information about a file and even cause playback issues. Some websites add extra junk data in files which in turn causes corruption.</p>
-    <p>If <app>Tagger</app> is unable to read a file, it will be ignored and a dialog will be displayed listing corrupted files for you to manage and fix accordingly.</p>
+    <title>Ungültige Daten</title>
+    <p>Ein ungültiger Tag-Header oder Junk-Daten in einer Datei können zu Problemen beim Lesen von Informationen über eine Datei und sogar zu Wiedergabeproblemen führen. Einige Websites fügen zusätzliche Junk-Daten in Dateien ein, die wiederum zu Beschädigungen führen.</p>
+    <p>Wenn <app>Tagger</app> nicht in der Lage ist, eine Datei zu lesen, wird sie ignoriert. Die beschädigten Dateien werden in einem Dialogfeld aufgelistet, damit du sie entsprechend verwalten und reparieren kannst.</p>
     <note style="advanced">
-        <p>FFmpeg can be used to fix corruption issues. Run the following command to re-encode a file's tag and remove junk data:</p>
+        <p>FFmpeg kann genutzt werden um beschädigte Dateien zu reparieren. Führe dazu den folgenden Befehl aus um die Datei neu zu enkodieren und Junk-Daten zu entfernen:</p>
         <code>ffmpeg -i in.mp3 out.mp3</code>
-        <p>where <code>in.mp3</code> is the file path of the corrupted file and <code>out.mp3</code> is the path to export the re-encoded file.</p>
+        <p>wobei <code>in.mp3</code> der Dateipfad zur beschädigten Datei ist und <code>out.mp3</code> der Pfad an dem die reparierte Datei gespeichert werden soll.</p>
     </note>
     <note style="advanced">
-         <p>You can also use <link href="https://www.freac.org">fre:ac</link> to re-encode files without convertion to another format.</p>
+         <p>Die kannst alternativ <link href="https://www.freac.org">fre:ac</link> nutzen um Dateien neu zu enkodieren, ohne sie in ein anderes Format umzuwandeln.</p>
     </note>
 </section>
 </page>

--- a/NickvisionTagger.Shared/Docs/yelp/de/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/format-strings.page
@@ -2,7 +2,7 @@
 <page xmlns="http://projectmallard.org/1.0/" xmlns:its="http://www.w3.org/2005/11/its" type="topic" id="format-strings" its:version="2.0" xml:lang="de">
 <info>
 	<link type="guide" xref="index"/>
-	<title type="link">Format Strings ✍️</title>
+	<title type="link">Formatvorlagen ✍️</title>
 	<credit type="author copyright">
 		<name>Nicholas Logozzo</name>
 		<years its:translate="no">2023</years>
@@ -14,8 +14,8 @@
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
 </info>
 
-<title>Format Strings</title>
-<p>This page explains the use of format strings for <code>File Name to Tag</code> and <code>Tag to File Name</code> conversions.</p>
+<title>Formatvorlagen</title>
+<p>Diese Seite erklärt die Nutzung von Formatvorlagen für die Konvertierungen <code>Dateiname zu Tag</code> und <code>Tag zu Dateiname</code>.</p>
 <section>
     <title>Format</title>
     <p>Strings of any format with properties wrapped in percent signs (%).</p>

--- a/NickvisionTagger.Shared/Docs/yelp/fi/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fi/configuration.page
@@ -42,7 +42,7 @@
         </list>
 	</item>
     <item>
-		<title>Preserve Modification Timestamp</title>
+		<title>Säilytä muokkauksen aikaleima</title>
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
@@ -54,7 +54,7 @@
 		<p>Whether or not to overwrite overwrite existing album art with art found from MusicBrainz.</p>
 	</item>
     <item>
-		<title>AcoustId User API Key</title>
+		<title>AcoustId:n käyttäjän API-avain</title>
 		<p>An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
 		<note>
 			<p>A key can be obtained <link href="https://acoustid.org/api-key">here</link></p>

--- a/NickvisionTagger.Shared/Docs/yelp/fr/unsupported.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fr/unsupported.page
@@ -29,8 +29,8 @@
     <p>Consulter ce lien pour une solution : <link href="https://github.com/NickvisionApps/Tagger/issues/174"/></p>
     <note>
         <p>Veuillez confirmer que vous recevez une erreur « permission refusée » avant d’essayer cela.</p>
-        <p>Run <app>Tagger</app> in the terminal via <code>flatpak run org.nickvision.tagger</code>, then try to apply changes again, and you will find an error message in the terminal.</p>
-        <p>If it is not a "permission denied" error, please <link href="https://github.com/NickvisionApps/Tagger/issues/174">report a new issue</link>.</p>
+        <p>Exécutez <app>Tagger</app> dans un terminal avec la commande <code>flatpak run org.nickvision.tagger</code>, puis essayez d’appliquer à nouveau les changements, vous trouverez le message d’erreur dans le terminal.</p>
+        <p>S’il ne s’egit pas d’une erreur « permission refusée », merci de <link href="https://github.com/NickvisionApps/Tagger/issues/174">signaler un nouveau problème</link>.</p>
     </note>
 </section>
 </page>

--- a/NickvisionTagger.Shared/Docs/yelp/fr/web-services.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fr/web-services.page
@@ -2,7 +2,7 @@
 <page xmlns="http://projectmallard.org/1.0/" xmlns:its="http://www.w3.org/2005/11/its" type="topic" id="web-services" its:version="2.0" xml:lang="fr">
 <info>
 	<link type="guide" xref="index"/>
-	<title type="link">Web Services 🌐</title>
+	<title type="link">Services Web 🌐</title>
 	<credit type="author copyright">
 		<name>Nicholas Logozzo</name>
 		<years its:translate="no">2023</years>
@@ -21,30 +21,30 @@
   </info>
 
 <title>Services Web</title>
-<p>This page describes the web services available in Tagger</p>
+<p>Cette page traite des services web disponibles dans Tagger</p>
 <section>
     <title>Télécharger les métadonnées depuis MusicBrainz</title>
-    <p>Identifies a music file through MusicBrainz and downloads its metadata to use in Tagger.</p>
-    <p>This service utilizies the AcoustId fingerprint of the file (generated with <code>fpcalc</code>) to determine MusicBrainz recording and release IDs. If IDs are found, metadata such as title, artist, album, and art will be downloaded and set in Tagger.</p>
+    <p>Identifie un fichier musical via MusicBrainz et télécharge ses métadonnées pour les utiliser dans Tagger.</p>
+    <p>Ce service utilise l’empreinte AcoustId du fichier (générée avec <code>fpcalc</code>) pour déterminer les identifiants d’enregistrement et de sortie MusicBrainz. Si les identifiants sont trouvés, les métadonnées telles que le titre, l’artiste, l’album et la pochette seront téléchargées et utilisées dans Tagger.</p>
     <note>
-        <p>Finding metadata through MusicBrainz isn't 100% realiable and may not be available for uncommom songs.</p>
+        <p>La recherche de métadonnées dans MusicBrainz n’est pas fiable à 100 % et peut ne pas être disponible pour des chansons peu connues.</p>
     </note>
 </section>
 <section>
     <title>Envoyer à AcoustId</title>
-    <p>Submits data about a music file (identified via its fingerprint) to AcoustId's database. There are two things that can be submitted about a music file:</p>
+    <p>Soumet des données sur un fichier musical (identifié par son empreinte digitale) à la base de données d’AcoustId. Deux choses peuvent être soumises à propos d’un fichier musical :</p>
         <list>
             <item>
-        		<title>MusicBrainz Recording ID</title>
-        		<p>A user can submit a MusicBrainz Recording ID to submit to AcoustId. This will pull all data from the associated recording id and use that for sending metadata to AcoustId.</p>
+        		<title>Identifiant d’enregistrement MusicBrainz</title>
+        		<p>Un utilisateur peut soumettre un identifiant d’enregistrement MusicBrainz à AcoustId. Cela permettra d’extraire toutes les données de l’identifiant d’enregistrement associé et de les utiliser pour envoyer des métadonnées à AcoustId.</p>
         	</item>
             <item>
-        		<title>User Metadata</title>
-        		<p>A user can submit their metadata from Tagger to AcoustId.</p>
+        		<title>Métadonnées utilisateur</title>
+        		<p>Un utilisateur peut soumettre ses métadonnées de Tagger à AcoustId.</p>
         	</item>
         </list>
     <note>
-        <p>A proper <code>AcoustId User API Key</code> must be set in <code>Preferences</code> for this service to work.</p>
+        <p>Une <code>Clé d’API de l’utilisateur AcoustId</code> appropriée doit être définie dans les <code>Préférences</code> pour que ce service fonctionne.</p>
     </note>
 </section>
 </page>

--- a/NickvisionTagger.Shared/Docs/yelp/nl/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/nl/configuration.page
@@ -30,7 +30,7 @@
 		<p>Whether or not to scan for music files into subdirectories of a music folder.</p>
 	</item>
     <item>
-		<title>Sort Files By</title>
+		<title>Bestanden sorteren op</title>
 		<p>The property to use when sorting and displaying music files. It can be one of the following options:</p>
         <list>
             <item><p><code>File Name</code></p></item>

--- a/NickvisionTagger.Shared/Events/SynchronizedLyricsEventArgs.cs
+++ b/NickvisionTagger.Shared/Events/SynchronizedLyricsEventArgs.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace NickvisionTagger.Shared.Events;
+
+/// <summary>
+/// Event args when working with synchronized lyrics
+/// </summary>
+public class SynchronizedLyricsEventArgs : EventArgs
+{
+    /// <summary>
+    /// The timestamp of the sync lyric in milliseconds
+    /// </summary>
+    public int Timestamp { get; set; }
+    /// <summary>
+    /// The string lyric
+    /// </summary>
+    public string Lyric { get; set; }
+
+    /// <summary>
+    /// Constructs a SynchronizedLyricsEventArgs
+    /// </summary>
+    /// <param name="timestamp">The timestamp of the sync lyric in milliseconds</param>
+    /// <param name="lyric">The string lyric</param>
+    public SynchronizedLyricsEventArgs(int timestamp, string lyric)
+    {
+        Timestamp = timestamp;
+        Lyric = lyric;
+    }
+}

--- a/NickvisionTagger.Shared/Events/SynchronizedLyricsEventArgs.cs
+++ b/NickvisionTagger.Shared/Events/SynchronizedLyricsEventArgs.cs
@@ -15,15 +15,21 @@ public class SynchronizedLyricsEventArgs : EventArgs
     /// The string lyric
     /// </summary>
     public string Lyric { get; set; }
+    /// <summary>
+    /// A position to place the synced lyric
+    /// </summary>
+    public int Position { get; set; }
 
     /// <summary>
     /// Constructs a SynchronizedLyricsEventArgs
     /// </summary>
     /// <param name="timestamp">The timestamp of the sync lyric in milliseconds</param>
     /// <param name="lyric">The string lyric</param>
-    public SynchronizedLyricsEventArgs(int timestamp, string lyric)
+    /// <param name="position">A position to place the synced lyric</param>
+    public SynchronizedLyricsEventArgs(int timestamp, string lyric, int position = -1)
     {
         Timestamp = timestamp;
         Lyric = lyric;
+        Position = position;
     }
 }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -21,7 +21,8 @@ public enum MusicBrainzLoadStatus
     Success = 0,
     NoAcoustIdResult,
     NoAcoustIdRecordingId,
-    InvalidMusicBrainzRecordingId
+    InvalidMusicBrainzRecordingId,
+    InvalidFingerprint
 }
 
 /// <summary>
@@ -340,6 +341,10 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>MusicBrainzLoadStatus</returns>
     public async Task<MusicBrainzLoadStatus> LoadTagFromMusicBrainzAsync(string acoustIdClientKey, string version, bool overwriteTagWithMusicBrainz, bool overwriteAlbumArtWithMusicBrainz)
     {
+        if (Fingerprint == _("ERROR"))
+        {
+            return MusicBrainzLoadStatus.InvalidFingerprint;
+        }
         //Use AcoustID to get MBID
         AcoustID.Configuration.ClientKey = acoustIdClientKey;
         var service = new AcoustID.Web.LookupService();
@@ -835,6 +840,10 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if successful, else false</returns>
     public async Task<bool> SubmitToAcoustIdAsync(string acoustIdClientKey, string acoustIdUserKey, string? musicBrainzRecordingId)
     {
+        if (Fingerprint == _("ERROR"))
+        {
+            return false;
+        }
         AcoustID.Configuration.ClientKey = acoustIdClientKey;
         var service = new AcoustID.Web.SubmitService(acoustIdUserKey);
         if(!string.IsNullOrEmpty(musicBrainzRecordingId))

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -511,13 +511,9 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             LanguageCode = LyricsLanguageCode,
             Description = LyricsDescription,
             UnsynchronizedLyrics = UnsynchronizedLyrics,
-            SynchronizedLyrics = new List<LyricsInfo.LyricsPhrase>(),
+            SynchronizedLyrics = SynchronizedLyrics.Select(x => new LyricsInfo.LyricsPhrase(x.Key, x.Value)).ToList(),
             Metadata = new Dictionary<string, string>()
         };
-        foreach (var pair in SynchronizedLyrics)
-        {
-            track.Lyrics.SynchronizedLyrics.Add(new LyricsInfo.LyricsPhrase(pair.Key, pair.Value));
-        }
         if (SynchronizedLyricsOffset != 0)
         {
             track.Lyrics.Metadata["offset"] = SynchronizedLyricsOffset.ToString();

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -516,8 +516,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             LanguageCode = LyricsLanguageCode,
             Description = LyricsDescription,
             UnsynchronizedLyrics = UnsynchronizedLyrics,
-            SynchronizedLyrics = SynchronizedLyrics.Select(x => new LyricsInfo.LyricsPhrase(x.Key, x.Value)).ToList(),
-            Metadata = new Dictionary<string, string>()
+            SynchronizedLyrics = SynchronizedLyrics.Select(x => new LyricsInfo.LyricsPhrase(x.Key, x.Value)).ToList()
         };
         if (SynchronizedLyricsOffset != 0)
         {

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -313,7 +313,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             LyricsLanguageCode = track.Lyrics.LanguageCode;
             LyricsDescription = track.Lyrics.Description;
             UnsynchronizedLyrics = track.Lyrics.UnsynchronizedLyrics;
-            foreach (var phase in track.Lyrics.SynchronizedLyrics.OrderBy(x => x.TimestampMs))
+            foreach (var phase in track.Lyrics.SynchronizedLyrics)
             {
                 SynchronizedLyrics.Add(phase.TimestampMs, phase.Text);
             }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -123,6 +123,10 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// </summary>
     public Dictionary<int, string> SynchronizedLyrics { get; set; }
     /// <summary>
+    /// The offset for SynchronizedLyrics (in milliseconds)
+    /// </summary>
+    public int SynchronizedLyricsOffset { get; set; }
+    /// <summary>
     /// The duration of the music file
     /// </summary>
     public int Duration { get; private set; }
@@ -181,6 +185,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
         LyricsDescription = "";
         UnsynchronizedLyrics = "";
         SynchronizedLyrics = new Dictionary<int, string>();
+        SynchronizedLyricsOffset = 0;
         Duration = 0;
         IsReadOnly = false;
         LoadTagFromDisk();
@@ -311,6 +316,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             {
                 SynchronizedLyrics.Add(phase.TimestampMs, phase.Text);
             }
+            SynchronizedLyricsOffset = track.Lyrics.Metadata.TryGetValue("offset", out var offset) ? (int.TryParse(offset, out var offsetInt) ? offsetInt : 0) : 0;
             foreach(var pair in track.AdditionalFields)
             {
                 _customProperties.Add(pair.Key, pair.Value);
@@ -505,11 +511,16 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
             LanguageCode = LyricsLanguageCode,
             Description = LyricsDescription,
             UnsynchronizedLyrics = UnsynchronizedLyrics,
-            SynchronizedLyrics = new List<LyricsInfo.LyricsPhrase>()
+            SynchronizedLyrics = new List<LyricsInfo.LyricsPhrase>(),
+            Metadata = new Dictionary<string, string>()
         };
         foreach (var pair in SynchronizedLyrics)
         {
             track.Lyrics.SynchronizedLyrics.Add(new LyricsInfo.LyricsPhrase(pair.Key, pair.Value));
+        }
+        if (SynchronizedLyricsOffset != 0)
+        {
+            track.Lyrics.Metadata["offset"] = SynchronizedLyricsOffset.ToString();
         }
         foreach(var pair in _customProperties)
         {

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -29,6 +29,8 @@ public enum MusicBrainzLoadStatus
 /// </summary>
 public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
 {
+    private static string[] _validProperties;
+    
     private string _dotExtension;
     private string _filename;
     private DateTime _modificationTimestamp;
@@ -143,6 +145,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// </summary>
     static MusicFile()
     {
+        _validProperties = new string[] { "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "publisher", _("publisher"), "lyrics", _("lyrics") };
         ATL.Settings.UseFileNameWhenNoTitle = false;
         SortFilesBy = SortBy.Filename;
     }
@@ -574,7 +577,16 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// </summary>
     /// <param name="name">The name of the custom property</param>
     /// <param name="value">The value of the custom property</param>
-    public void SetCustomProperty(string name, string value) => _customProperties[name] = value;
+    /// <returns>True if set, else false</returns>
+    public bool SetCustomProperty(string name, string value)
+    {
+        if (_validProperties.Contains(name))
+        {
+            return false;
+        }
+        _customProperties[name] = value;
+        return true;
+    }
 
     /// <summary>
     /// Removes a custom property
@@ -726,7 +738,6 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
         {
             return false;
         }
-        var validProperties = new string[] { "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "publisher", _("publisher") };
         var customProps = _customProperties.Keys.ToList();
         var matches = Regex.Matches(formatString, @"%(\w+)%", RegexOptions.IgnoreCase); //wrapped in %%
         if(matches.Count == 0)
@@ -737,7 +748,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
         {
             string value = match.Value.Remove(0, 1); //remove first %
             value = value.Remove(value.Length - 1, 1); //remove last %;
-            if(validProperties.Contains(value.ToLower()))
+            if(_validProperties.Contains(value.ToLower()))
             {
                 value = value.ToLower();
                 var replace = "";

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -580,7 +580,7 @@ public class MusicFile : IComparable<MusicFile>, IEquatable<MusicFile>
     /// <returns>True if set, else false</returns>
     public bool SetCustomProperty(string name, string value)
     {
-        if (_validProperties.Contains(name))
+        if (_validProperties.Contains(name.ToLower()))
         {
             return false;
         }

--- a/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
+++ b/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     <PackageReference Include="AcoustID.NET" Version="1.3.3" />
     <PackageReference Include="Nickvision.Aura" Version="2023.8.2" />
-    <PackageReference Include="z440.atl.core" Version="4.36.0" />
+    <PackageReference Include="z440.atl.core" Version="5.0.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz" Version="5.0.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="5.0.0" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-10 02:47+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,10 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -93,26 +93,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "umělecalba"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
@@ -131,10 +131,10 @@ msgstr "Použít"
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "umělec"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -174,17 +174,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "skladatel"
 
@@ -214,8 +214,8 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "vlastní"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "popis"
 
@@ -250,7 +250,7 @@ msgstr "Zrušit"
 msgid "Discarding unapplied changes..."
 msgstr "Rušení nepoužitých změn..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
@@ -259,11 +259,11 @@ msgstr "Metadata pro {0} souborů úspěšně stažena"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -302,8 +302,8 @@ msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "názevsouboru"
 
@@ -326,10 +326,10 @@ msgstr "Přední"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "žánr"
 
@@ -380,9 +380,14 @@ msgstr[2] "Načteno {0} hudebních souborů."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Texty"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -409,15 +414,15 @@ msgstr "Nový synchronizovaný řádek"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
@@ -449,10 +454,10 @@ msgstr "Vyberte prosím formátový řetězec."
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -491,7 +496,7 @@ msgstr "Potvrdit"
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
@@ -538,10 +543,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Čas (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "název"
 
@@ -549,17 +554,17 @@ msgstr "název"
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "stopa"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -581,14 +586,14 @@ msgstr "Nepodařilo se uložit soubor {0}"
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "rok"
 
@@ -613,7 +618,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Texty"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Nastavit"
 
@@ -634,22 +639,22 @@ msgstr "Kód jazyka"
 msgid "Description"
 msgstr "Popis"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Nesynchronizované"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Nesynchronizované texty jsou ukládány jako jeden řetězec bez informací o "
 "čase."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Synchronizované"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-10 02:47+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,12 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -64,7 +58,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -92,27 +92,27 @@ msgstr ""
 "s otiskem."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "umělecalba"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
@@ -131,10 +131,10 @@ msgstr "Použít"
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "umělec"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -170,21 +170,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "skladatel"
 
@@ -198,7 +198,7 @@ msgstr "Přispěvatelé na GitHubu ❤️"
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -206,7 +206,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -214,8 +214,8 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "vlastní"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "popis"
 
@@ -250,7 +250,7 @@ msgstr "Zrušit"
 msgid "Discarding unapplied changes..."
 msgstr "Rušení nepoužitých změn..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
@@ -259,11 +259,11 @@ msgstr "Metadata pro {0} souborů úspěšně stažena"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -277,23 +277,33 @@ msgstr "Exportovat zadní obal alba"
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Exportovat"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
@@ -302,8 +312,8 @@ msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "názevsouboru"
 
@@ -326,10 +336,10 @@ msgstr "Přední"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "žánr"
 
@@ -348,6 +358,11 @@ msgstr "GitHub repozitář"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Nápověda"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -380,11 +395,11 @@ msgstr[2] "Načteno {0} hudebních souborů."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Texty"
@@ -405,7 +420,7 @@ msgstr "ID nahrávky MusicBrainz"
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
@@ -414,17 +429,21 @@ msgstr "Nový synchronizovaný řádek"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -454,10 +473,10 @@ msgstr "Vyberte prosím formátový řetězec."
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -465,7 +484,7 @@ msgstr "vydavatel"
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
@@ -496,7 +515,7 @@ msgstr "Potvrdit"
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
@@ -539,14 +558,14 @@ msgstr "Označovač otevřel některé soubory v režimu čtení."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Čas (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "název"
 
@@ -554,17 +573,17 @@ msgstr "název"
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "stopa"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -572,28 +591,33 @@ msgstr "celkemstop"
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Nepodařilo se uložit {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "rok"
 
@@ -618,11 +642,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Texty"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Nastavit"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -630,37 +654,37 @@ msgstr ""
 "Informace o poskytnutých textech. Platí pro nesynchronizované i "
 "synchronizované texty."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Kód jazyka"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Popis"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Nesynchronizované"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Nesynchronizované texty jsou ukládány jako jeden řetězec bez informací o "
 "čase."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Synchronizované"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Synchronizované texty jsou ukládány jako slovník řetězců identifikovatelných "
-"jejich časem v milisekundách."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1028,6 +1052,13 @@ msgstr "— Snadný převod názvů souborů na značky a značkek na názvy sou
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Vyhledávání informací o souborech pomocí MusicBrainz"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Synchronizované texty jsou ukládány jako slovník řetězců "
+#~ "identifikovatelných jejich časem v milisekundách."
 
 #~ msgid "Duration"
 #~ msgstr "Doba trvání"

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-10 02:47+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,7 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -98,17 +98,17 @@ msgstr ""
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "umělecalba"
 
@@ -131,10 +131,10 @@ msgstr "Použít"
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "umělec"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -174,17 +174,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "skladatel"
 
@@ -214,8 +214,8 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "vlastní"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "popis"
 
@@ -250,7 +250,7 @@ msgstr "Zrušit"
 msgid "Discarding unapplied changes..."
 msgstr "Rušení nepoužitých změn..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
@@ -259,11 +259,12 @@ msgstr "Metadata pro {0} souborů úspěšně stažena"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -312,8 +313,8 @@ msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "názevsouboru"
 
@@ -336,10 +337,10 @@ msgstr "Přední"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "žánr"
 
@@ -395,11 +396,11 @@ msgstr[2] "Načteno {0} hudebních souborů."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Texty"
@@ -433,7 +434,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
@@ -473,10 +474,10 @@ msgstr "Vyberte prosím formátový řetězec."
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -515,7 +516,7 @@ msgstr "Potvrdit"
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
@@ -554,6 +555,10 @@ msgstr "Označovač"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Označovač otevřel některé soubory v režimu čtení."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -562,10 +567,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Čas (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "název"
 
@@ -573,17 +578,17 @@ msgstr "název"
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "stopa"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -610,14 +615,14 @@ msgstr "Nepodařilo se uložit soubor {0}"
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "rok"
 

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-10 02:47+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -385,7 +385,7 @@ msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -634,7 +634,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-10 02:47+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -100,15 +100,15 @@ msgstr "Přidat"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "umělecalba"
 
@@ -133,8 +133,8 @@ msgstr "Použít změny?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "umělec"
 
@@ -150,15 +150,15 @@ msgstr "Zadní"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -176,15 +176,15 @@ msgstr "Zrušit"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "komentář"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "skladatel"
 
@@ -234,8 +234,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "popis"
 
@@ -264,9 +264,14 @@ msgid "Error"
 msgstr "Chyba"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "CHYBA"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Spravovat texty"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -278,7 +283,7 @@ msgstr "Exportovat zadní obal alba"
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -292,7 +297,7 @@ msgstr "Zadní obal alba úspěšně exportován do souboru"
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -339,8 +344,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "žánr"
 
@@ -378,6 +383,10 @@ msgstr "Vložit zadní obal alba"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -442,7 +451,7 @@ msgstr "Nebyla stažena žádná metadata"
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -476,8 +485,8 @@ msgstr "Název vlastnosti"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -569,8 +578,8 @@ msgstr "Čas (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "název"
 
@@ -580,15 +589,15 @@ msgstr "Vybráno příliš mnoho souborů"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "stopa"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -596,9 +605,14 @@ msgstr "celkemstop"
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Nepodařilo se uložit {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Nepodařilo se uložit {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -619,10 +633,20 @@ msgstr "Nepodařilo se uložit {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "rok"
 

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-13 23:36+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,10 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -94,26 +94,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "albumkünstler"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
@@ -132,10 +132,10 @@ msgstr "Anwenden"
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "künstler"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zurück"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "Komponist"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "andere"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "Beschreibung"
 
@@ -249,7 +249,7 @@ msgstr "Verwerfen"
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
@@ -258,11 +258,11 @@ msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -301,8 +301,8 @@ msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "Dateiname"
 
@@ -325,10 +325,10 @@ msgstr "Vorne"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "genre"
 
@@ -378,9 +378,14 @@ msgstr[1] "{0} Musikdateien geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Songtext"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -407,15 +412,15 @@ msgstr "Neuer Synchronisierter Text"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
@@ -447,10 +452,10 @@ msgstr "Bitte Formatvorlage auswählen."
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "Verlag"
 
@@ -490,7 +495,7 @@ msgstr "Senden"
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
@@ -537,10 +542,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zeitstempel (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "titel"
 
@@ -548,17 +553,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -580,14 +585,14 @@ msgstr "Konnte {0} nicht speichern"
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "Jahr"
 
@@ -612,7 +617,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Songtext"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Konfigurieren"
 
@@ -633,22 +638,22 @@ msgstr "Sprachcode"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Nicht Synchronisiert"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Nicht synchronisierte Songtexte werden als einzelne Zeichenkette ohne "
 "Zeitinformation gespeichert."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Synchronisiert"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-15 16:47+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,7 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "albumkünstler"
 
@@ -132,10 +132,10 @@ msgstr "Anwenden"
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "künstler"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zurück"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "Komponist"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "andere"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "Beschreibung"
 
@@ -249,7 +249,7 @@ msgstr "Verwerfen"
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
@@ -258,11 +258,12 @@ msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -311,8 +312,8 @@ msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "Dateiname"
 
@@ -335,10 +336,10 @@ msgstr "Vorne"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "genre"
 
@@ -393,11 +394,11 @@ msgstr[1] "{0} Musikdateien geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtext"
@@ -431,7 +432,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
@@ -471,10 +472,10 @@ msgstr "Bitte Formatvorlage auswählen."
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "Verlag"
 
@@ -514,7 +515,7 @@ msgstr "Senden"
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
@@ -553,6 +554,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -561,10 +566,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zeitstempel (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "titel"
 
@@ -572,17 +577,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -609,14 +614,14 @@ msgstr "Konnte {0} nicht speichern"
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "Jahr"
 

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-15 16:47+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,21 +50,21 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
+#: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -93,27 +93,27 @@ msgstr ""
 "Verbindung mit dem Fingerabdruck übermitteln."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "albumkünstler"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
@@ -132,10 +132,10 @@ msgstr "Anwenden"
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "künstler"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Zurück"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -171,21 +171,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "Komponist"
 
@@ -199,22 +199,22 @@ msgstr "Mitwirkende auf GitHub ❤️"
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "andere"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "Beschreibung"
 
@@ -249,7 +249,7 @@ msgstr "Verwerfen"
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
@@ -258,11 +258,11 @@ msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -276,23 +276,33 @@ msgstr "Rücken-Albumcover exportieren"
 msgid "Export Front Album Art"
 msgstr "Vorder-Albumcover exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Exportieren"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Rücken-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Vorder-Albumcover erfolgreich zu Datei exportiert"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim exportieren des Rücken-Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 
@@ -301,8 +311,8 @@ msgstr "Fehler beim exportieren des Vorder-Albumcovers zur Datei"
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "Dateiname"
 
@@ -325,10 +335,10 @@ msgstr "Vorne"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "genre"
 
@@ -347,6 +357,11 @@ msgstr "GitHub-Repo"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hilfe"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -378,9 +393,14 @@ msgstr[1] "{0} Musikdateien geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
+
+#: ../../../Models/MusicFile.cs:152
+#, fuzzy
+msgid "lyrics"
+msgstr "Songtext"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -398,7 +418,7 @@ msgstr "MusicBrainz-Aufnahme-ID"
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
@@ -407,17 +427,21 @@ msgstr "Neuer Synchronisierter Text"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -447,10 +471,10 @@ msgstr "Bitte Formatvorlage auswählen."
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "Verlag"
 
@@ -458,7 +482,7 @@ msgstr "Verlag"
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
@@ -490,7 +514,7 @@ msgstr "Senden"
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
@@ -533,14 +557,14 @@ msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zeitstempel (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "titel"
 
@@ -548,17 +572,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -566,28 +590,33 @@ msgstr "songanzahl"
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Konnte {0} nicht speichern."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "Jahr"
 
@@ -612,11 +641,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Songtext"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -624,37 +653,37 @@ msgstr ""
 "Information über den bereitgestellten Songtext. Wird auf nicht "
 "synchronisierte und synchronisierte Songtexte angewandt."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Sprachcode"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Beschreibung"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Nicht Synchronisiert"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Nicht synchronisierte Songtexte werden als einzelne Zeichenkette ohne "
 "Zeitinformation gespeichert."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Synchronisiert"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Synchronisierte Songtexte werden als Schlüssel-Wert-Liste von Zeichenketten "
-"identifiziert durch deren Zeitstempel in Millisekunden gespeichert."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1021,6 +1050,14 @@ msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Lade Dateinformationen von MusicBrainz"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Synchronisierte Songtexte werden als Schlüssel-Wert-Liste von "
+#~ "Zeichenketten identifiziert durch deren Zeitstempel in Millisekunden "
+#~ "gespeichert."
 
 #~ msgid "Duration"
 #~ msgstr "Länge"

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-15 16:47+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -384,7 +384,7 @@ msgid "Insert Front Album Art"
 msgstr "Vorder-Albumcover einfügen"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -633,7 +633,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-15 16:47+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -101,15 +101,15 @@ msgstr "Hinzufügen"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "albumkünstler"
 
@@ -134,8 +134,8 @@ msgstr "Änderungen anwenden?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "künstler"
 
@@ -151,15 +151,15 @@ msgstr "Zurück"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -177,15 +177,15 @@ msgstr "Abbrechen"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "kommentar"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "Komponist"
 
@@ -233,8 +233,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "Beschreibung"
 
@@ -263,9 +263,14 @@ msgid "Error"
 msgstr "Fehler"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "FEHLER"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Songtexte Verwalten"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -277,7 +282,7 @@ msgstr "Rücken-Albumcover exportieren"
 msgid "Export Front Album Art"
 msgstr "Vorder-Albumcover exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -291,7 +296,7 @@ msgstr "Rücken-Albumcover erfolgreich zu Datei exportiert"
 msgid "Exported front album art to file successfully"
 msgstr "Vorder-Albumcover erfolgreich zu Datei exportiert"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -338,8 +343,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "genre"
 
@@ -377,6 +382,10 @@ msgstr "Rücken-Albumcover einfügen"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vorder-Albumcover einfügen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -440,7 +449,7 @@ msgstr "Keine Metadaten heruntergeladen"
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -474,8 +483,8 @@ msgstr "Eigenschaft-Name"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "Verlag"
 
@@ -568,8 +577,8 @@ msgstr "Zeitstempel (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "titel"
 
@@ -579,15 +588,15 @@ msgstr "Zu viele Dateien ausgewählt"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "nummer"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -595,9 +604,14 @@ msgstr "songanzahl"
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Konnte {0} nicht speichern."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Konnte {0} nicht speichern."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -618,10 +632,20 @@ msgstr "Konnte {0} nicht speichern."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "Jahr"
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,12 +7,12 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
-"Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted.weblate"
-".org>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/es/>\n"
+"Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
+"weblate.org>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,10 +51,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -65,7 +61,11 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -95,26 +95,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "álbum"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "artistadelálbum"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
@@ -133,10 +133,10 @@ msgstr "Aplicar"
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "artista"
 
@@ -150,17 +150,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "ppm"
 
@@ -176,17 +176,17 @@ msgstr "ppm"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "compositor"
 
@@ -214,8 +214,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "personalizado"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "descripción"
 
@@ -250,7 +250,7 @@ msgstr "Descartar"
 msgid "Discarding unapplied changes..."
 msgstr "Descartando cambios no aplicados..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
@@ -259,11 +259,11 @@ msgstr "Descargados correctamente los metadatos de los {0} archivos"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -302,8 +302,8 @@ msgstr "Error al exportar portada del álbum a un archivo"
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "nombredearchivo"
 
@@ -326,10 +326,10 @@ msgstr "Frontal"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "género"
 
@@ -379,9 +379,14 @@ msgstr[1] "Cargados {0} archivos de música."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Letras"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -408,15 +413,15 @@ msgstr "Nueva letra sincronizada"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
@@ -450,10 +455,10 @@ msgstr "Seleccione una cadena de formato."
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "editor"
 
@@ -494,7 +499,7 @@ msgstr "Enviar"
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
@@ -541,10 +546,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Marca de tiempo (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "título"
 
@@ -552,17 +557,17 @@ msgstr "título"
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "pista"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -584,14 +589,14 @@ msgstr "No se ha podido guardar {0}"
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "año"
 
@@ -617,7 +622,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Letras"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Configurar"
 
@@ -638,22 +643,22 @@ msgstr "Código de idioma"
 msgid "Description"
 msgstr "Descripción"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Desincronizado"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Las letras desincronizadas se almacenan como una única cadena sin "
 "información horaria."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Sincronizado"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -51,12 +51,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -65,7 +59,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -94,27 +94,27 @@ msgstr ""
 "la firma."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "álbum"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "artistadelálbum"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
@@ -133,10 +133,10 @@ msgstr "Aplicar"
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "artista"
 
@@ -150,17 +150,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "ppm"
 
@@ -172,21 +172,21 @@ msgstr "ppm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "compositor"
 
@@ -200,22 +200,22 @@ msgstr "Colaboradores en GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "personalizado"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "descripción"
 
@@ -250,7 +250,7 @@ msgstr "Descartar"
 msgid "Discarding unapplied changes..."
 msgstr "Descartando cambios no aplicados..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
@@ -259,11 +259,11 @@ msgstr "Descargados correctamente los metadatos de los {0} archivos"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -277,23 +277,33 @@ msgstr "Exportar contraportada del álbum"
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Exportar"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
@@ -302,8 +312,8 @@ msgstr "Error al exportar portada del álbum a un archivo"
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "nombredearchivo"
 
@@ -326,10 +336,10 @@ msgstr "Frontal"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "género"
 
@@ -348,6 +358,11 @@ msgstr "Repo de GitHub"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ayuda"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -379,11 +394,11 @@ msgstr[1] "Cargados {0} archivos de música."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Letras"
@@ -404,7 +419,7 @@ msgstr "Id de grabación MusicBrainz"
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
@@ -413,19 +428,23 @@ msgstr "Nueva letra sincronizada"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
 "AcoustId"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -455,10 +474,10 @@ msgstr "Seleccione una cadena de formato."
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "editor"
 
@@ -466,7 +485,7 @@ msgstr "editor"
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
@@ -499,7 +518,7 @@ msgstr "Enviar"
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
@@ -542,14 +561,14 @@ msgstr "Tagger ha abierto algunos archivos en modo de solo lectura."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Marca de tiempo (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "título"
 
@@ -557,17 +576,17 @@ msgstr "título"
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "pista"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -575,28 +594,33 @@ msgstr "pistatotal"
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "No se ha podido guardar {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "año"
 
@@ -622,11 +646,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Letras"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Configurar"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -634,37 +658,37 @@ msgstr ""
 "Información sobre la letra proporcionada. Se aplica tanto a las letras no "
 "sincronizadas como a las sincronizadas."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Código de idioma"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Descripción"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Desincronizado"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Las letras desincronizadas se almacenan como una única cadena sin "
 "información horaria."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Sincronizado"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Las letras sincronizadas se almacenan como un diccionario de cadenas "
-"identificadas por su marca de tiempo en milisegundos."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1037,6 +1061,13 @@ msgstr ""
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Buscar información de archivos en MusicBrainz"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Las letras sincronizadas se almacenan como un diccionario de cadenas "
+#~ "identificadas por su marca de tiempo en milisegundos."
 
 #~ msgid "Duration"
 #~ msgstr "Duración"

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -385,7 +385,7 @@ msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -637,7 +637,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -102,15 +102,15 @@ msgstr "Añadir"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "álbum"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "artistadelálbum"
 
@@ -135,8 +135,8 @@ msgstr "¿Aplicar cambios?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "artista"
 
@@ -152,15 +152,15 @@ msgstr "Trasera"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "ppm"
 
@@ -178,15 +178,15 @@ msgstr "Cancelar"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "comentario"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "compositor"
 
@@ -234,8 +234,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "descripción"
 
@@ -264,9 +264,14 @@ msgid "Error"
 msgstr "Error"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "ERROR"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Gestionar letras"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -278,7 +283,7 @@ msgstr "Exportar contraportada del álbum"
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -292,7 +297,7 @@ msgstr "Exportada correctamente contraportada del álbum al archivo"
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -339,8 +344,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "género"
 
@@ -378,6 +383,10 @@ msgstr "Insertar la contraportada del álbum"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -443,7 +452,7 @@ msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
 "AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -477,8 +486,8 @@ msgstr "Nombre de la propiedad"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "editor"
 
@@ -572,8 +581,8 @@ msgstr "Marca de tiempo (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "título"
 
@@ -583,15 +592,15 @@ msgstr "Demasiados archivos seleccionados"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "pista"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -599,9 +608,14 @@ msgstr "pistatotal"
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "No se ha podido guardar {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "No se ha podido guardar {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -622,10 +636,20 @@ msgstr "No se ha podido guardar {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "año"
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -51,7 +51,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -65,7 +64,8 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -100,17 +100,17 @@ msgstr ""
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "álbum"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "artistadelálbum"
 
@@ -133,10 +133,10 @@ msgstr "Aplicar"
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "artista"
 
@@ -150,17 +150,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "ppm"
 
@@ -176,17 +176,17 @@ msgstr "ppm"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "compositor"
 
@@ -214,8 +214,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "personalizado"
 
@@ -232,10 +232,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "descripción"
 
@@ -250,7 +250,7 @@ msgstr "Descartar"
 msgid "Discarding unapplied changes..."
 msgstr "Descartando cambios no aplicados..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
@@ -259,11 +259,12 @@ msgstr "Descargados correctamente los metadatos de los {0} archivos"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -312,8 +313,8 @@ msgstr "Error al exportar portada del álbum a un archivo"
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "nombredearchivo"
 
@@ -336,10 +337,10 @@ msgstr "Frontal"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "género"
 
@@ -394,11 +395,11 @@ msgstr[1] "Cargados {0} archivos de música."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Letras"
@@ -432,7 +433,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
@@ -474,10 +475,10 @@ msgstr "Seleccione una cadena de formato."
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "editor"
 
@@ -518,7 +519,7 @@ msgstr "Enviar"
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
@@ -557,6 +558,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha abierto algunos archivos en modo de solo lectura."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -565,10 +570,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Marca de tiempo (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "título"
 
@@ -576,17 +581,17 @@ msgstr "título"
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "pista"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -613,14 +618,14 @@ msgstr "No se ha podido guardar {0}"
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "año"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-10 15:59+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,7 +50,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -91,17 +91,17 @@ msgstr ""
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "albumi"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr ""
 
@@ -124,10 +124,10 @@ msgstr "Toteuta"
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "esittäjä"
 
@@ -141,17 +141,17 @@ msgstr ""
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr ""
 
@@ -167,17 +167,17 @@ msgstr ""
 msgid "Cancel"
 msgstr "Peru"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -205,8 +205,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr ""
 
@@ -223,10 +223,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "kuvaus"
 
@@ -241,7 +241,7 @@ msgstr "Hylkää"
 msgid "Discarding unapplied changes..."
 msgstr "Hylätään toteuttamattomat muutokset..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
@@ -250,11 +250,12 @@ msgstr "Ladattiin metatiedot {0} tiedostolle"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -303,8 +304,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "tiedostonimi"
 
@@ -327,10 +328,10 @@ msgstr "Etu"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -385,11 +386,11 @@ msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -423,7 +424,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -461,10 +462,10 @@ msgstr ""
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -503,7 +504,7 @@ msgstr "Lähetä"
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
@@ -542,6 +543,10 @@ msgstr ""
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -550,10 +555,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "nimi"
 
@@ -561,17 +566,17 @@ msgstr "nimi"
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -599,14 +604,14 @@ msgstr "Ei voi tallentaa {0}"
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "vuosi"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-10 15:59+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
-"Language-Team: Finnish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/fi/>\n"
+"Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/fi/>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,10 +50,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -86,26 +86,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "albumi"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -124,10 +124,10 @@ msgstr "Toteuta"
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "esittäjä"
 
@@ -141,17 +141,17 @@ msgstr ""
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr ""
 
@@ -167,17 +167,17 @@ msgstr ""
 msgid "Cancel"
 msgstr "Peru"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -205,8 +205,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr ""
 
@@ -223,10 +223,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "kuvaus"
 
@@ -241,7 +241,7 @@ msgstr "Hylkää"
 msgid "Discarding unapplied changes..."
 msgstr "Hylätään toteuttamattomat muutokset..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
@@ -250,11 +250,11 @@ msgstr "Ladattiin metatiedot {0} tiedostolle"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -293,8 +293,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "tiedostonimi"
 
@@ -317,10 +317,10 @@ msgstr "Etu"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -370,9 +370,14 @@ msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Sanoitukset"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -399,15 +404,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -437,10 +442,10 @@ msgstr ""
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -479,7 +484,7 @@ msgstr "Lähetä"
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
@@ -526,10 +531,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "nimi"
 
@@ -537,17 +542,17 @@ msgstr "nimi"
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -570,14 +575,14 @@ msgstr "Ei voi tallentaa {0}"
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "vuosi"
 
@@ -600,7 +605,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Sanoitukset"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Määritä"
 
@@ -619,20 +624,20 @@ msgstr "Kielikoodi"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Synkronoimaton"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Synkronoitu"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-10 15:59+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,12 +50,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -64,7 +58,13 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -85,27 +85,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "albumi"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -124,10 +124,10 @@ msgstr "Toteuta"
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "esittäjä"
 
@@ -141,17 +141,17 @@ msgstr ""
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr ""
 
@@ -163,21 +163,21 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Peru"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -191,22 +191,22 @@ msgstr "Avustajat GitHubissa ❤️"
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr ""
 
@@ -223,10 +223,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "kuvaus"
 
@@ -241,7 +241,7 @@ msgstr "Hylkää"
 msgid "Discarding unapplied changes..."
 msgstr "Hylätään toteuttamattomat muutokset..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
@@ -250,11 +250,11 @@ msgstr "Ladattiin metatiedot {0} tiedostolle"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -268,23 +268,33 @@ msgstr "Vie albumin takakuvitus"
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Vie"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -293,8 +303,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "tiedostonimi"
 
@@ -317,10 +327,10 @@ msgstr "Etu"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -339,6 +349,11 @@ msgstr "GitHub-tietovarasto"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ohje"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -370,11 +385,11 @@ msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -395,7 +410,7 @@ msgstr ""
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -404,16 +419,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -442,10 +461,10 @@ msgstr ""
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -453,7 +472,7 @@ msgstr "julkaisija"
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
@@ -484,7 +503,7 @@ msgstr "Lähetä"
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
@@ -527,14 +546,14 @@ msgstr ""
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "nimi"
 
@@ -542,17 +561,17 @@ msgstr "nimi"
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -561,28 +580,33 @@ msgstr "kappale"
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Ei voi tallentaa {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "vuosi"
 
@@ -605,42 +629,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Sanoitukset"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Määritä"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Kielikoodi"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Kuvaus"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Synkronoimaton"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Synkronoitu"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-10 15:59+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -93,15 +93,15 @@ msgstr "Lisää"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "albumi"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr ""
 
@@ -126,8 +126,8 @@ msgstr "Toteutetaanko muutokset?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "esittäjä"
 
@@ -143,15 +143,15 @@ msgstr "Takaisin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr ""
 
@@ -169,15 +169,15 @@ msgstr "Peru"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "kommentti"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -225,8 +225,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "kuvaus"
 
@@ -255,9 +255,14 @@ msgid "Error"
 msgstr "Virhe"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "VIRHE"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Hallitse sanoituksia"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -269,7 +274,7 @@ msgstr "Vie albumin takakuvitus"
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -283,7 +288,7 @@ msgstr ""
 msgid "Exported front album art to file successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -330,8 +335,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -368,6 +373,10 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -432,7 +441,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -464,8 +473,8 @@ msgstr "Ominaisuuden nimi"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -557,8 +566,8 @@ msgstr "Aikaleima (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "nimi"
 
@@ -568,15 +577,15 @@ msgstr "Liian monta tiedostoa valittu"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "kappale"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -585,9 +594,14 @@ msgstr "kappale"
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Ei voi tallentaa {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Ei voi tallentaa {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -608,10 +622,20 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "vuosi"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-10 15:59+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -376,7 +376,7 @@ msgid "Insert Front Album Art"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -623,7 +623,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -101,15 +101,15 @@ msgstr "Ajouter"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "artiste de l’album"
 
@@ -134,8 +134,8 @@ msgstr "Appliquer les changements ?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "artiste"
 
@@ -151,15 +151,15 @@ msgstr "Dos"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -177,15 +177,15 @@ msgstr "Annuler"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "commentaire"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "compositeur"
 
@@ -233,8 +233,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "description"
 
@@ -263,9 +263,14 @@ msgid "Error"
 msgstr "Erreur"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "ERREUR"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Gérer les paroles"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -277,7 +282,7 @@ msgstr "Exporter le dos de la pochette d’album"
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -293,7 +298,7 @@ msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -341,8 +346,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "genre"
 
@@ -380,6 +385,10 @@ msgstr "Insérer le dos de la pochette d’album"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -444,7 +453,7 @@ msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -478,8 +487,8 @@ msgstr "Nom de la propriété"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -573,8 +582,8 @@ msgstr "Horodatage (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "titre"
 
@@ -584,15 +593,15 @@ msgstr "Trop de fichiers sélectionnés"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "piste"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -600,9 +609,14 @@ msgstr "pistestotal"
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Impossible d’enregistrer {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Impossible d’enregistrer {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -623,10 +637,20 @@ msgstr "Impossible d’enregistrer {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "année"
 

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,12 +50,6 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -64,7 +58,13 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -93,27 +93,27 @@ msgstr ""
 "associées à l’empreinte à la place."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "artiste de l’album"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
@@ -132,10 +132,10 @@ msgstr "Appliquer"
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "artiste"
 
@@ -149,17 +149,17 @@ msgstr "o"
 msgid "Back"
 msgstr "Dos"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -171,21 +171,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "compositeur"
 
@@ -199,22 +199,22 @@ msgstr "Contributeurs sur GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "personnalisé"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "description"
 
@@ -249,7 +249,7 @@ msgstr "Abandonner"
 msgid "Discarding unapplied changes..."
 msgstr "Abandon des changements..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
@@ -258,11 +258,11 @@ msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -276,25 +276,35 @@ msgstr "Exporter le dos de la pochette d’album"
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Exporter"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
@@ -304,8 +314,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "nom de fichier"
 
@@ -328,10 +338,10 @@ msgstr "Face"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "genre"
 
@@ -350,6 +360,11 @@ msgstr "Dépôt GitHub"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aide"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -381,11 +396,11 @@ msgstr[1] "{0} musiques chargées."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Paroles"
@@ -406,7 +421,7 @@ msgstr "Identifiant MusicBrainz"
 msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
@@ -415,18 +430,22 @@ msgstr "Nouvelles paroles synchronisées"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -456,10 +475,10 @@ msgstr "Sélectionnez un format."
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -467,7 +486,7 @@ msgstr "maison de disques"
 msgid "Remove Custom Property"
 msgstr "Supprimer la propriété personnalisée"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
@@ -500,7 +519,7 @@ msgstr "Envoyer"
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
@@ -543,14 +562,14 @@ msgstr "Tagger a ouvert des fichiers en mode lecture seule."
 msgid "TiB"
 msgstr "Tio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Horodatage (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "titre"
 
@@ -558,17 +577,17 @@ msgstr "titre"
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -576,28 +595,33 @@ msgstr "pistestotal"
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Impossible d’enregistrer {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "année"
 
@@ -623,11 +647,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Paroles"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Configurer"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -635,37 +659,37 @@ msgstr ""
 "Informations sur les paroles fournies. S'appliquent aux paroles, "
 "synchronisées ou non."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Code de langage"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Description"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Non synchronisées"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Les paroles non synchronisées sont enregistrées comme une simple chaîne de "
 "caractères, sans informations temporelles."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Synchronisées"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Les paroles synchronisées sont enregistrées comme un dictionnaire de chaînes "
-"de caractères identifiées par leur horodatage en millisecondes."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1040,6 +1064,13 @@ msgstr ""
 msgid "— Lookup file information using MusicBrainz"
 msgstr ""
 "— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Les paroles synchronisées sont enregistrées comme un dictionnaire de "
+#~ "chaînes de caractères identifiées par leur horodatage en millisecondes."
 
 #~ msgid "Duration"
 #~ msgstr "Durée"

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,10 +50,6 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -94,26 +94,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "artiste de l’album"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
@@ -132,10 +132,10 @@ msgstr "Appliquer"
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "artiste"
 
@@ -149,17 +149,17 @@ msgstr "o"
 msgid "Back"
 msgstr "Dos"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "compositeur"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "personnalisé"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "description"
 
@@ -249,7 +249,7 @@ msgstr "Abandonner"
 msgid "Discarding unapplied changes..."
 msgstr "Abandon des changements..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
@@ -258,11 +258,11 @@ msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -304,8 +304,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "nom de fichier"
 
@@ -328,10 +328,10 @@ msgstr "Face"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "genre"
 
@@ -381,9 +381,14 @@ msgstr[1] "{0} musiques chargées."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Paroles"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -410,15 +415,15 @@ msgstr "Nouvelles paroles synchronisées"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
@@ -451,10 +456,10 @@ msgstr "Sélectionnez un format."
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -495,7 +500,7 @@ msgstr "Envoyer"
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
@@ -542,10 +547,10 @@ msgstr "Tio"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Horodatage (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "titre"
 
@@ -553,17 +558,17 @@ msgstr "titre"
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -585,14 +590,14 @@ msgstr "Impossible d’enregistrer {0}"
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "année"
 
@@ -618,7 +623,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Paroles"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Configurer"
 
@@ -639,22 +644,22 @@ msgstr "Code de langage"
 msgid "Description"
 msgstr "Description"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Non synchronisées"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Les paroles non synchronisées sont enregistrées comme une simple chaîne de "
 "caractères, sans informations temporelles."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Synchronisées"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -50,7 +50,6 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "artiste de l’album"
 
@@ -132,10 +132,10 @@ msgstr "Appliquer"
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "artiste"
 
@@ -149,17 +149,17 @@ msgstr "o"
 msgid "Back"
 msgstr "Dos"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "compositeur"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "personnalisé"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "description"
 
@@ -249,7 +249,7 @@ msgstr "Abandonner"
 msgid "Discarding unapplied changes..."
 msgstr "Abandon des changements..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
@@ -258,11 +258,12 @@ msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -314,8 +315,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "nom de fichier"
 
@@ -338,10 +339,10 @@ msgstr "Face"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "genre"
 
@@ -396,11 +397,11 @@ msgstr[1] "{0} musiques chargées."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Paroles"
@@ -434,7 +435,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
@@ -475,10 +476,10 @@ msgstr "Sélectionnez un format."
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -519,7 +520,7 @@ msgstr "Envoyer"
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
@@ -558,6 +559,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger a ouvert des fichiers en mode lecture seule."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "Tio"
@@ -566,10 +571,10 @@ msgstr "Tio"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Horodatage (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "titre"
 
@@ -577,17 +582,17 @@ msgstr "titre"
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -614,14 +619,14 @@ msgstr "Impossible d’enregistrer {0}"
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "année"
 

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -387,7 +387,7 @@ msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -638,7 +638,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -386,7 +386,7 @@ msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -638,7 +638,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -100,15 +100,15 @@ msgstr "הוספה"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "אלבום"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "אמן האלבום"
 
@@ -133,8 +133,8 @@ msgstr "להחיל שינויים?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "אמן"
 
@@ -150,15 +150,15 @@ msgstr "אחורי"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
@@ -176,15 +176,15 @@ msgstr "ביטול"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "הערכה"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "מלחין"
 
@@ -236,8 +236,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "תיאור"
 
@@ -266,9 +266,13 @@ msgid "Error"
 msgstr ""
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "תקלה"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid "Existing Lyrics"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -280,7 +284,7 @@ msgstr "ייצוא עטיפת אלבום אחורית"
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -294,7 +298,7 @@ msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -341,8 +345,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "סוגה"
 
@@ -380,6 +384,10 @@ msgstr "הכנסת עטיפת אלבום אחורית"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -444,7 +452,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -478,8 +486,8 @@ msgstr "שם מאפיין"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -572,8 +580,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "כותרת"
 
@@ -583,15 +591,15 @@ msgstr "נבחרו יותר מדי קבצים"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "רצועה"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -601,9 +609,14 @@ msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "לא ניתן לשמור את {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "לא ניתן לשמור את {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -624,10 +637,20 @@ msgstr "לא ניתן לשמור את {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "שנה"
 

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -51,7 +51,6 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -65,7 +64,8 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -98,17 +98,17 @@ msgstr ""
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "אמן האלבום"
 
@@ -131,10 +131,10 @@ msgstr "החלה"
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "אמן"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
@@ -174,17 +174,17 @@ msgstr "פעימות בדקה (bpm)"
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "מלחין"
 
@@ -216,8 +216,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -234,10 +234,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "תיאור"
 
@@ -252,7 +252,7 @@ msgstr "השלכה"
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
@@ -261,11 +261,12 @@ msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -314,8 +315,8 @@ msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "שם קובץ"
 
@@ -338,10 +339,10 @@ msgstr "קדמי"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "סוגה"
 
@@ -398,11 +399,11 @@ msgstr[3] "נטענו {0} קובצי מוזיקה."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 msgid "lyrics"
 msgstr ""
 
@@ -435,7 +436,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -475,10 +476,10 @@ msgstr "יש לבחור תבנית למחרוזת."
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -518,7 +519,7 @@ msgstr "שליחה"
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
@@ -557,6 +558,10 @@ msgstr "המתייג"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "טבי״ב"
@@ -565,10 +570,10 @@ msgstr "טבי״ב"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "כותרת"
 
@@ -576,17 +581,17 @@ msgstr "כותרת"
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -615,14 +620,14 @@ msgstr "לא ניתן לשמור את {0}"
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "שנה"
 

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -51,10 +51,6 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -65,7 +61,11 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -93,26 +93,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "אמן האלבום"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -131,10 +131,10 @@ msgstr "החלה"
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "אמן"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
@@ -174,17 +174,17 @@ msgstr "פעימות בדקה (bpm)"
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "מלחין"
 
@@ -216,8 +216,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -234,10 +234,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "תיאור"
 
@@ -252,7 +252,7 @@ msgstr "השלכה"
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
@@ -261,11 +261,11 @@ msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -304,8 +304,8 @@ msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "שם קובץ"
 
@@ -328,10 +328,10 @@ msgstr "קדמי"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "סוגה"
 
@@ -383,9 +383,13 @@ msgstr[3] "נטענו {0} קובצי מוזיקה."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
+
+#: ../../../Models/MusicFile.cs:148
+msgid "lyrics"
+msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -412,15 +416,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -452,10 +456,10 @@ msgstr "יש לבחור תבנית למחרוזת."
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -495,7 +499,7 @@ msgstr "שליחה"
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
@@ -542,10 +546,10 @@ msgstr "טבי״ב"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "כותרת"
 
@@ -553,17 +557,17 @@ msgstr "כותרת"
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -587,14 +591,14 @@ msgstr "לא ניתן לשמור את {0}"
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "שנה"
 
@@ -619,7 +623,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr ""
 
@@ -638,20 +642,20 @@ msgstr ""
 msgid "Description"
 msgstr "תיאור"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -51,12 +51,6 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -65,7 +59,13 @@ msgstr "%רצועה%- %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -92,27 +92,27 @@ msgstr ""
 "אם אין ברשותך, המתייג ישלח את נתוני התגיות שלך יחד עם טביעת האצבע במקום."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "אמן האלבום"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -131,10 +131,10 @@ msgstr "החלה"
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "אמן"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
@@ -170,21 +170,21 @@ msgstr "פעימות בדקה (bpm)"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "מלחין"
 
@@ -198,7 +198,7 @@ msgstr "תורמים ב־GitHub ‏❤️ {0}"
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -207,7 +207,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -216,8 +216,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -234,10 +234,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "תיאור"
 
@@ -252,7 +252,7 @@ msgstr "השלכה"
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
@@ -261,11 +261,11 @@ msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -279,23 +279,33 @@ msgstr "ייצוא עטיפת אלבום אחורית"
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "ייצוא"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
@@ -304,8 +314,8 @@ msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "שם קובץ"
 
@@ -328,10 +338,10 @@ msgstr "קדמי"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "סוגה"
 
@@ -350,6 +360,11 @@ msgstr "מאגר GitHub"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "עזרה"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -383,11 +398,11 @@ msgstr[3] "נטענו {0} קובצי מוזיקה."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 msgid "lyrics"
 msgstr ""
 
@@ -407,7 +422,7 @@ msgstr "מזהה ההקלטות MusicBrainz"
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -416,16 +431,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -456,10 +475,10 @@ msgstr "יש לבחור תבנית למחרוזת."
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -467,7 +486,7 @@ msgstr "מוציא לאור"
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 #, fuzzy
 msgid "Remove Lyric"
 msgstr "הסרה"
@@ -499,7 +518,7 @@ msgstr "שליחה"
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
@@ -542,14 +561,14 @@ msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 msgid "TiB"
 msgstr "טבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "כותרת"
 
@@ -557,17 +576,17 @@ msgstr "כותרת"
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -577,28 +596,33 @@ msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "לא ניתן לשמור את {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "שנה"
 
@@ -623,42 +647,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "תיאור"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -101,15 +101,15 @@ msgstr "Dodaj"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "izvođač albuma"
 
@@ -134,8 +134,8 @@ msgstr "Primijeniti promjene?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "izvođač"
 
@@ -151,15 +151,15 @@ msgstr "Natrag"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -177,15 +177,15 @@ msgstr "Odustani"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "komentar"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "skladatelj"
 
@@ -239,8 +239,8 @@ msgstr "David Lapshin {0}"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "opis"
 
@@ -269,9 +269,13 @@ msgid "Error"
 msgstr ""
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "GREŠKA"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid "Existing Lyrics"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -283,7 +287,7 @@ msgstr "Izvezi stražnju sliku albuma"
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -297,7 +301,7 @@ msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -344,8 +348,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "žanr"
 
@@ -383,6 +387,10 @@ msgstr "Umetni stražnju sliku albuma"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -446,7 +454,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -480,8 +488,8 @@ msgstr "Ime svojstva"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "izdavač"
 
@@ -576,8 +584,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "naslov"
 
@@ -587,15 +595,15 @@ msgstr "Odabrano je previše datoteka"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "pjesma"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -603,9 +611,14 @@ msgstr "broj pjesama"
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Neuspjelo spremanje datoteke {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -626,10 +639,20 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "godina"
 

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,7 +51,6 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -65,7 +64,8 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "izvođač albuma"
 
@@ -132,10 +132,10 @@ msgstr "Primijeni"
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "izvođač"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "skladatelj"
 
@@ -218,8 +218,8 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -237,10 +237,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "opis"
 
@@ -255,7 +255,7 @@ msgstr "Odbaci"
 msgid "Discarding unapplied changes..."
 msgstr "Odbacivanje neprimjenjenih promjena …"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
@@ -264,11 +264,12 @@ msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -317,8 +318,8 @@ msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "ime datoteke"
 
@@ -341,10 +342,10 @@ msgstr "Prednja strana"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "žanr"
 
@@ -400,11 +401,11 @@ msgstr[2] "Učitano je {0} glazbenih datoteka."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 msgid "lyrics"
 msgstr ""
 
@@ -437,7 +438,7 @@ msgstr ""
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -477,10 +478,10 @@ msgstr "Odaberi jedan format izraza."
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "izdavač"
 
@@ -522,7 +523,7 @@ msgstr "Pošalji"
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
@@ -561,6 +562,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger je otvorio neke datoteke u modusu „samo čitanje”."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -569,10 +574,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "naslov"
 
@@ -580,17 +585,17 @@ msgstr "naslov"
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -617,14 +622,14 @@ msgstr "Neuspjelo spremanje datoteke {0}"
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "godina"
 

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../Controllers/MainWindowController.cs:169
@@ -51,10 +51,6 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -65,7 +61,11 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -94,26 +94,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "izvođač albuma"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -132,10 +132,10 @@ msgstr "Primijeni"
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "izvođač"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "skladatelj"
 
@@ -218,8 +218,8 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -237,10 +237,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "opis"
 
@@ -255,7 +255,7 @@ msgstr "Odbaci"
 msgid "Discarding unapplied changes..."
 msgstr "Odbacivanje neprimjenjenih promjena …"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
@@ -264,11 +264,11 @@ msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -307,8 +307,8 @@ msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "ime datoteke"
 
@@ -331,10 +331,10 @@ msgstr "Prednja strana"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "žanr"
 
@@ -385,9 +385,13 @@ msgstr[2] "Učitano je {0} glazbenih datoteka."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
+
+#: ../../../Models/MusicFile.cs:148
+msgid "lyrics"
+msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -414,15 +418,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -454,10 +458,10 @@ msgstr "Odaberi jedan format izraza."
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "izdavač"
 
@@ -499,7 +503,7 @@ msgstr "Pošalji"
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
@@ -546,10 +550,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "naslov"
 
@@ -557,17 +561,17 @@ msgstr "naslov"
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -589,14 +593,14 @@ msgstr "Neuspjelo spremanje datoteke {0}"
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "godina"
 
@@ -621,7 +625,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr ""
 
@@ -640,20 +644,20 @@ msgstr ""
 msgid "Description"
 msgstr "Opis"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -389,7 +389,7 @@ msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -640,7 +640,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,12 +51,6 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -65,7 +59,13 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -93,27 +93,27 @@ msgstr ""
 "koje su povezane s digitalnim otiskom."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "izvođač albuma"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -132,10 +132,10 @@ msgstr "Primijeni"
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "izvođač"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -171,21 +171,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "skladatelj"
 
@@ -202,7 +202,7 @@ msgstr ""
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -210,7 +210,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -218,8 +218,8 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -237,10 +237,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "opis"
 
@@ -255,7 +255,7 @@ msgstr "Odbaci"
 msgid "Discarding unapplied changes..."
 msgstr "Odbacivanje neprimjenjenih promjena …"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
@@ -264,11 +264,11 @@ msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -282,23 +282,33 @@ msgstr "Izvezi stražnju sliku albuma"
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Izvezi"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
@@ -307,8 +317,8 @@ msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "ime datoteke"
 
@@ -331,10 +341,10 @@ msgstr "Prednja strana"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "žanr"
 
@@ -353,6 +363,11 @@ msgstr "GitHub repozitorij"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoć"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -385,11 +400,11 @@ msgstr[2] "Učitano je {0} glazbenih datoteka."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 msgid "lyrics"
 msgstr ""
 
@@ -409,7 +424,7 @@ msgstr "ID oznaka MusicBrainz snimke"
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -418,16 +433,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -458,10 +477,10 @@ msgstr "Odaberi jedan format izraza."
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "izdavač"
 
@@ -469,7 +488,7 @@ msgstr "izdavač"
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 #, fuzzy
 msgid "Remove Lyric"
 msgstr "Ukloni"
@@ -503,7 +522,7 @@ msgstr "Pošalji"
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
@@ -546,14 +565,14 @@ msgstr "Tagger je otvorio neke datoteke u modusu „samo čitanje”."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "naslov"
 
@@ -561,17 +580,17 @@ msgstr "naslov"
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -579,28 +598,33 @@ msgstr "broj pjesama"
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Neuspjelo spremanje datoteke {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "godina"
 
@@ -625,42 +649,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Opis"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -101,15 +101,15 @@ msgstr "Aggiungi"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "artistaalbum"
 
@@ -134,8 +134,8 @@ msgstr "Vuoi applicare le modifiche?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "artista"
 
@@ -151,15 +151,15 @@ msgstr "Indietro"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -177,15 +177,15 @@ msgstr "Annulla"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "commento"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "compositore"
 
@@ -233,8 +233,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "descrizione"
 
@@ -263,9 +263,14 @@ msgid "Error"
 msgstr "Errore"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "ERRORE"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Gestisci testo"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -277,7 +282,7 @@ msgstr "Esporta copertina"
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -291,7 +296,7 @@ msgstr "La copertina posteriore è stata esportata correttamente"
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -338,8 +343,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "genere"
 
@@ -377,6 +382,10 @@ msgstr "Inserisci copertina posteriore"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -441,7 +450,7 @@ msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -475,8 +484,8 @@ msgstr "Nome della proprietà"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "etichetta"
 
@@ -569,8 +578,8 @@ msgstr "Istante temporale (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "titolo"
 
@@ -580,15 +589,15 @@ msgstr "Sono stati selezionati troppi file"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "traccia"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -596,9 +605,14 @@ msgstr "traccetotali"
 msgid "translator-credits"
 msgstr "Federico Marchetti"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Impossibile salvare {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Impossibile salvare {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -619,10 +633,20 @@ msgstr "Impossibile salvare {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "anno"
 

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -50,7 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "artistaalbum"
 
@@ -132,10 +132,10 @@ msgstr "Applica"
 msgid "Apply Changes?"
 msgstr "Vuoi applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "artista"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "commento"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "compositore"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
 msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "descrizione"
 
@@ -249,7 +249,7 @@ msgstr "Scarta"
 msgid "Discarding unapplied changes..."
 msgstr "Annullamento modifiche non applicate..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "I metadati per {0} sono stati scaricati con successo"
@@ -258,11 +258,12 @@ msgstr "I metadati per {0} sono stati scaricati con successo"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Download dei metadati da MusicBrainz in corso..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -311,8 +312,8 @@ msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 msgid "File Name to Tag"
 msgstr "Nome del file a etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "nomefile"
 
@@ -335,10 +336,10 @@ msgstr "Fronte"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "genere"
 
@@ -393,11 +394,11 @@ msgstr[1] "Brani {0} caricati."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Testo"
@@ -431,7 +432,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovato alcun AcoustId per il file"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
@@ -472,10 +473,10 @@ msgstr "Seleziona un formato."
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "etichetta"
 
@@ -515,7 +516,7 @@ msgstr "Invia"
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
@@ -554,6 +555,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha aperto dei file in sola lettura."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -562,10 +567,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Istante temporale (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "titolo"
 
@@ -573,17 +578,17 @@ msgstr "titolo"
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "traccia"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -610,14 +615,14 @@ msgstr "Impossibile salvare {0}"
 msgid "Unable to save {0}."
 msgstr "Impossibile salvare {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "anno"
 

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -50,12 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -64,7 +58,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -93,27 +93,27 @@ msgstr ""
 "associati alla firma di questo brano."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "artistaalbum"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un Id non valido a MusicBrainz"
 
@@ -132,10 +132,10 @@ msgstr "Applica"
 msgid "Apply Changes?"
 msgstr "Vuoi applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "artista"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -171,21 +171,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "commento"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "compositore"
 
@@ -199,22 +199,22 @@ msgstr "Hanno collaborato su GitHub ❤️"
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file è stato convertito con successo"
 msgstr[1] "{0} nomi di file sono stati convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
 msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "descrizione"
 
@@ -249,7 +249,7 @@ msgstr "Scarta"
 msgid "Discarding unapplied changes..."
 msgstr "Annullamento modifiche non applicate..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "I metadati per {0} sono stati scaricati con successo"
@@ -258,11 +258,11 @@ msgstr "I metadati per {0} sono stati scaricati con successo"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Download dei metadati da MusicBrainz in corso..."
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -276,23 +276,33 @@ msgstr "Esporta copertina"
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Esporta"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo fallito su MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 
@@ -301,8 +311,8 @@ msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 msgid "File Name to Tag"
 msgstr "Nome del file a etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "nomefile"
 
@@ -325,10 +335,10 @@ msgstr "Fronte"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "genere"
 
@@ -347,6 +357,11 @@ msgstr "Repository GitHub"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aiuto"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -378,11 +393,11 @@ msgstr[1] "Brani {0} caricati."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Testo"
@@ -403,7 +418,7 @@ msgstr "MusicBrainz RecordingId"
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
@@ -412,18 +427,22 @@ msgstr "Nuovo testo sincronizzato"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovato alcun AcoustId per il file"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -453,10 +472,10 @@ msgstr "Seleziona un formato."
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "etichetta"
 
@@ -464,7 +483,7 @@ msgstr "etichetta"
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
@@ -496,7 +515,7 @@ msgstr "Invia"
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
@@ -539,14 +558,14 @@ msgstr "Tagger ha aperto dei file in sola lettura."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Istante temporale (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "titolo"
 
@@ -554,17 +573,17 @@ msgstr "titolo"
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "traccia"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -572,28 +591,33 @@ msgstr "traccetotali"
 msgid "translator-credits"
 msgstr "Federico Marchetti"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Impossibile salvare {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Impossibile caricare l'immagine"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossibile salvare {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossibile salvare {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "anno"
 
@@ -618,11 +642,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Testo"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Configura"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -630,37 +654,37 @@ msgstr ""
 "Informazioni sul testo fornito. Viene applicato sia per il testo "
 "sincronizzato che per il testo non sincronizzato."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Codice della lingua"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Descrizione"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Non sincronizzato"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Il testo non sincronizzato viene salvato come una singola stringa senza "
 "informazioni temporali."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Sincronizzato"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Il testo sincronizzato è salvato come un dizionario di stringhe identificato "
-"dal loro istante temporale in millisecondi."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1029,6 +1053,13 @@ msgstr "— Converte nomi di file a tag e tag ad etichette con semplicità"
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— Controlla le informazioni dei brani con MusicBrainz"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Il testo sincronizzato è salvato come un dizionario di stringhe "
+#~ "identificato dal loro istante temporale in millisecondi."
 
 #~ msgid "Duration"
 #~ msgstr "Durata"

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,10 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -94,26 +94,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "artistaalbum"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un Id non valido a MusicBrainz"
 
@@ -132,10 +132,10 @@ msgstr "Applica"
 msgid "Apply Changes?"
 msgstr "Vuoi applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "artista"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "commento"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "compositore"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
 msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "descrizione"
 
@@ -249,7 +249,7 @@ msgstr "Scarta"
 msgid "Discarding unapplied changes..."
 msgstr "Annullamento modifiche non applicate..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "I metadati per {0} sono stati scaricati con successo"
@@ -258,11 +258,11 @@ msgstr "I metadati per {0} sono stati scaricati con successo"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Download dei metadati da MusicBrainz in corso..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -301,8 +301,8 @@ msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 msgid "File Name to Tag"
 msgstr "Nome del file a etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "nomefile"
 
@@ -325,10 +325,10 @@ msgstr "Fronte"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "genere"
 
@@ -378,9 +378,14 @@ msgstr[1] "Brani {0} caricati."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Testo"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -407,15 +412,15 @@ msgstr "Nuovo testo sincronizzato"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovato alcun AcoustId per il file"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
@@ -448,10 +453,10 @@ msgstr "Seleziona un formato."
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "etichetta"
 
@@ -491,7 +496,7 @@ msgstr "Invia"
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
@@ -538,10 +543,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Istante temporale (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "titolo"
 
@@ -549,17 +554,17 @@ msgstr "titolo"
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "traccia"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -581,14 +586,14 @@ msgstr "Impossibile salvare {0}"
 msgid "Unable to save {0}."
 msgstr "Impossibile salvare {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "anno"
 
@@ -613,7 +618,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Testo"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Configura"
 
@@ -634,22 +639,22 @@ msgstr "Codice della lingua"
 msgid "Description"
 msgstr "Descrizione"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Non sincronizzato"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Il testo non sincronizzato viene salvato come una singola stringa senza "
 "informazioni temporali."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Sincronizzato"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-09 12:22+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -384,7 +384,7 @@ msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -634,7 +634,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -49,12 +49,6 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -63,7 +57,13 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<behouden>"
 
@@ -93,27 +93,27 @@ msgstr ""
 "controlesom versturen."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "albumartiest"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -132,10 +132,10 @@ msgstr "Toepassen"
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "artiest"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Achterkant"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -171,21 +171,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "componist"
 
@@ -199,22 +199,22 @@ msgstr ""
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "aangepast"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "omschrijving"
 
@@ -249,7 +249,7 @@ msgstr "Verwerpen"
 msgid "Discarding unapplied changes..."
 msgstr "Bezig met verwerpen van wijzigingen…"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
@@ -258,11 +258,11 @@ msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -278,25 +278,35 @@ msgstr "Albumhoes toevoegen"
 msgid "Export Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Exporteren"
+
+#: ../../../Controllers/MainWindowController.cs:814
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -306,8 +316,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "bestandsnaam"
 
@@ -330,10 +340,10 @@ msgstr "Voorkant"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "genre"
 
@@ -352,6 +362,11 @@ msgstr "GitHub-repo"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hulp"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -385,12 +400,12 @@ msgstr[1] "Er zijn %d muziekbestanden geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -411,7 +426,7 @@ msgstr "MusicBrainz-opname-id"
 msgid "New Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -420,16 +435,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -461,10 +480,10 @@ msgstr "Kies een opmaakmethode."
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "uitgever"
 
@@ -472,7 +491,7 @@ msgstr "uitgever"
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
@@ -506,7 +525,7 @@ msgstr "Inzenden"
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
@@ -552,14 +571,14 @@ msgstr ""
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "titel"
 
@@ -567,17 +586,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -585,29 +604,33 @@ msgstr "aantalnummers"
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+msgid "Unable to export to LRC."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "jaar"
 
@@ -634,42 +657,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Songtekst"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Configureren"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Taalcode"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Omschrijving"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Gesynchroniseerd"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -49,10 +49,6 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -63,7 +59,11 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<behouden>"
 
@@ -94,26 +94,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "albumartiest"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -132,10 +132,10 @@ msgstr "Toepassen"
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "artiest"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Achterkant"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "componist"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "aangepast"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "omschrijving"
 
@@ -249,7 +249,7 @@ msgstr "Verwerpen"
 msgid "Discarding unapplied changes..."
 msgstr "Bezig met verwerpen van wijzigingen…"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
@@ -258,11 +258,11 @@ msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -306,8 +306,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "bestandsnaam"
 
@@ -330,10 +330,10 @@ msgstr "Voorkant"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "genre"
 
@@ -385,10 +385,15 @@ msgstr[1] "Er zijn %d muziekbestanden geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Songtekst"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -415,15 +420,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -456,10 +461,10 @@ msgstr "Kies een opmaakmethode."
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "uitgever"
 
@@ -501,7 +506,7 @@ msgstr "Inzenden"
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
@@ -551,10 +556,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "titel"
 
@@ -562,17 +567,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -594,15 +599,15 @@ msgstr ""
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "jaar"
 
@@ -629,7 +634,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Songtekst"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Configureren"
 
@@ -648,20 +653,20 @@ msgstr "Taalcode"
 msgid "Description"
 msgstr "Omschrijving"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Gesynchroniseerd"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -391,7 +391,7 @@ msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -646,7 +646,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -49,7 +49,6 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -63,7 +62,8 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<behouden>"
 
@@ -99,17 +99,17 @@ msgstr ""
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "albumartiest"
 
@@ -132,10 +132,10 @@ msgstr "Toepassen"
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "artiest"
 
@@ -149,17 +149,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Achterkant"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -175,17 +175,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "componist"
 
@@ -213,8 +213,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "aangepast"
 
@@ -231,10 +231,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "omschrijving"
 
@@ -249,7 +249,7 @@ msgstr "Verwerpen"
 msgid "Discarding unapplied changes..."
 msgstr "Bezig met verwerpen van wijzigingen…"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
@@ -258,11 +258,12 @@ msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -316,8 +317,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "bestandsnaam"
 
@@ -340,10 +341,10 @@ msgstr "Voorkant"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "genre"
 
@@ -400,12 +401,12 @@ msgstr[1] "Er zijn %d muziekbestanden geladen."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -439,7 +440,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -480,10 +481,10 @@ msgstr "Kies een opmaakmethode."
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "uitgever"
 
@@ -525,7 +526,7 @@ msgstr "Inzenden"
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
@@ -567,6 +568,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -575,10 +580,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "titel"
 
@@ -586,17 +591,17 @@ msgstr "titel"
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -622,15 +627,15 @@ msgstr ""
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "jaar"
 

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -101,15 +101,15 @@ msgstr "Toevoegen"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "albumartiest"
 
@@ -134,8 +134,8 @@ msgstr "Wijzigingen toepassen?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "artiest"
 
@@ -151,15 +151,15 @@ msgstr "Achterkant"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -177,15 +177,15 @@ msgstr "Annuleren"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "opmerking"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "componist"
 
@@ -233,8 +233,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "omschrijving"
 
@@ -263,9 +263,14 @@ msgid "Error"
 msgstr "Fout"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "FOUT"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Songtekst beheren"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -279,7 +284,7 @@ msgstr "Albumhoes toevoegen"
 msgid "Export Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -295,7 +300,7 @@ msgstr "Er zijn %d tags omgezet in bestandsnamen"
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -343,8 +348,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "genre"
 
@@ -384,6 +389,10 @@ msgstr "Albumhoes toevoegen"
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -448,7 +457,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -483,8 +492,8 @@ msgstr "Eigenschaps­naam"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "uitgever"
 
@@ -582,8 +591,8 @@ msgstr "Tijdstempel (uu:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "titel"
 
@@ -593,15 +602,15 @@ msgstr "Teveel bestanden geselecteerd"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "nummer"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -609,8 +618,12 @@ msgstr "aantalnummers"
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 msgid "Unable to export to LRC."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+msgid "Unable to import from LRC."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -632,10 +645,20 @@ msgstr ""
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "jaar"
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -390,7 +390,7 @@ msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -641,7 +641,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
 #: ../../../Controllers/MainWindowController.cs:169
@@ -51,10 +51,6 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -65,7 +61,11 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -95,26 +95,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "альбомартист"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -133,10 +133,10 @@ msgstr "Применить"
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "artist"
 
@@ -150,17 +150,17 @@ msgstr "Б"
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -176,17 +176,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "композитор"
 
@@ -219,8 +219,8 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "пользовательский"
 
@@ -238,10 +238,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "Давид Лапшин {0}"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "описание"
 
@@ -256,7 +256,7 @@ msgstr "Отменить"
 msgid "Discarding unapplied changes..."
 msgstr "Отмена изменений..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
@@ -265,11 +265,11 @@ msgstr "Метаданные для {0} файлов загружены успе
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -308,8 +308,8 @@ msgstr "Не удалось экспортировать обложки альб
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "имя файла"
 
@@ -332,10 +332,10 @@ msgstr "Передняя"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "жанр"
 
@@ -386,9 +386,13 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
+
+#: ../../../Models/MusicFile.cs:148
+msgid "lyrics"
+msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -415,15 +419,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -455,10 +459,10 @@ msgstr "Выберите формат строки."
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "издатель"
 
@@ -500,7 +504,7 @@ msgstr "Отправить"
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
@@ -547,10 +551,10 @@ msgstr "ТиБ"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "название"
 
@@ -558,17 +562,17 @@ msgstr "название"
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "трек"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -590,14 +594,14 @@ msgstr "Невозможно сохранить {0}"
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "год"
 
@@ -622,7 +626,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr ""
 
@@ -641,20 +645,20 @@ msgstr ""
 msgid "Description"
 msgstr "Описание"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."
@@ -1181,8 +1185,8 @@ msgstr "— Поиск информации о файлах с помощью Mu
 #~ "\n"
 #~ "            !title=\"\";artist=\"bob\"\n"
 #~ "            Эта команда отфильтрует список таким образом, чтобы он "
-#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя \"bob"
-#~ "\"\n"
+#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя "
+#~ "\"bob\"\n"
 #~ "\n"
 #~ "            [Заметки]\n"
 #~ "            * Продвинутый поиск не чувствителен к регистру\n"

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -102,15 +102,15 @@ msgstr "Добавить"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "альбом"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "альбомартист"
 
@@ -135,8 +135,8 @@ msgstr "Применить изменения?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "artist"
 
@@ -152,15 +152,15 @@ msgstr "Задняя"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -178,15 +178,15 @@ msgstr "Отмена"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "комментарий"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "композитор"
 
@@ -240,8 +240,8 @@ msgstr "Давид Лапшин {0}"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "описание"
 
@@ -270,9 +270,13 @@ msgid "Error"
 msgstr ""
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "ОШИБКА"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid "Existing Lyrics"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -284,7 +288,7 @@ msgstr "Экспортировать заднюю обложку альбома"
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -298,7 +302,7 @@ msgstr "Успешный экспорт обложек альбомов в фа�
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -345,8 +349,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "жанр"
 
@@ -384,6 +388,10 @@ msgstr "Вставить заднюю обложку альбома"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -447,7 +455,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -481,8 +489,8 @@ msgstr "Имя свойства"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "издатель"
 
@@ -577,8 +585,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "название"
 
@@ -588,15 +596,15 @@ msgstr "Выбрано слишком много файлов"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "трек"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -604,9 +612,14 @@ msgstr "итогтрек"
 msgid "translator-credits"
 msgstr "Давид Лапшин <ddaudix@gmail.com>, 2023"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "Невозможно сохранить {0}."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "Невозможно сохранить {0}."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -627,10 +640,20 @@ msgstr "Невозможно сохранить {0}."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "год"
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,7 +51,6 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -65,7 +64,8 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -100,17 +100,17 @@ msgstr ""
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "альбомартист"
 
@@ -133,10 +133,10 @@ msgstr "Применить"
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "artist"
 
@@ -150,17 +150,17 @@ msgstr "Б"
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -176,17 +176,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "композитор"
 
@@ -219,8 +219,8 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "пользовательский"
 
@@ -238,10 +238,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "Давид Лапшин {0}"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "описание"
 
@@ -256,7 +256,7 @@ msgstr "Отменить"
 msgid "Discarding unapplied changes..."
 msgstr "Отмена изменений..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
@@ -265,11 +265,12 @@ msgstr "Метаданные для {0} файлов загружены успе
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -318,8 +319,8 @@ msgstr "Не удалось экспортировать обложки альб
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "имя файла"
 
@@ -342,10 +343,10 @@ msgstr "Передняя"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "жанр"
 
@@ -401,11 +402,11 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 msgid "lyrics"
 msgstr ""
 
@@ -438,7 +439,7 @@ msgstr ""
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -478,10 +479,10 @@ msgstr "Выберите формат строки."
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "издатель"
 
@@ -523,7 +524,7 @@ msgstr "Отправить"
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
@@ -562,6 +563,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger открыл некоторые файлы в режиме только для чтения."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "ТиБ"
@@ -570,10 +575,10 @@ msgstr "ТиБ"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "название"
 
@@ -581,17 +586,17 @@ msgstr "название"
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "трек"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -618,14 +623,14 @@ msgstr "Невозможно сохранить {0}"
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "год"
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-07-30 22:38+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -51,12 +51,6 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -65,7 +59,13 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -94,27 +94,27 @@ msgstr ""
 "отпечатком."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "альбомартист"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -133,10 +133,10 @@ msgstr "Применить"
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "artist"
 
@@ -150,17 +150,17 @@ msgstr "Б"
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -172,21 +172,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "композитор"
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -211,7 +211,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -219,8 +219,8 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "пользовательский"
 
@@ -238,10 +238,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr "Давид Лапшин {0}"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "описание"
 
@@ -256,7 +256,7 @@ msgstr "Отменить"
 msgid "Discarding unapplied changes..."
 msgstr "Отмена изменений..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
@@ -265,11 +265,11 @@ msgstr "Метаданные для {0} файлов загружены успе
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -283,23 +283,33 @@ msgstr "Экспортировать заднюю обложку альбома"
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Экспортировать"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
@@ -308,8 +318,8 @@ msgstr "Не удалось экспортировать обложки альб
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "имя файла"
 
@@ -332,10 +342,10 @@ msgstr "Передняя"
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "жанр"
 
@@ -354,6 +364,11 @@ msgstr "Репозиторий GitHub"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Справка"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -386,11 +401,11 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 msgid "lyrics"
 msgstr ""
 
@@ -410,7 +425,7 @@ msgstr "ID записи MusicBrainz"
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -419,16 +434,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -459,10 +478,10 @@ msgstr "Выберите формат строки."
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "издатель"
 
@@ -470,7 +489,7 @@ msgstr "издатель"
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 #, fuzzy
 msgid "Remove Lyric"
 msgstr "Удалить"
@@ -504,7 +523,7 @@ msgstr "Отправить"
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
@@ -547,14 +566,14 @@ msgstr "Tagger открыл некоторые файлы в режиме тол
 msgid "TiB"
 msgstr "ТиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "название"
 
@@ -562,17 +581,17 @@ msgstr "название"
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "трек"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -580,28 +599,33 @@ msgstr "итогтрек"
 msgid "translator-credits"
 msgstr "Давид Лапшин <ddaudix@gmail.com>, 2023"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "Невозможно сохранить {0}."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "год"
 
@@ -626,42 +650,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Описание"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -373,7 +373,7 @@ msgid "Insert Front Album Art"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -616,7 +616,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,10 +49,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -63,7 +59,11 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr ""
 
@@ -85,26 +85,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -123,10 +123,10 @@ msgstr ""
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr ""
 
@@ -140,17 +140,17 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr ""
 
@@ -166,17 +166,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr ""
 
@@ -222,10 +222,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgstr ""
 msgid "Discarding unapplied changes..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
@@ -249,11 +249,11 @@ msgstr ""
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr ""
 
@@ -316,10 +316,10 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr ""
 
@@ -369,8 +369,12 @@ msgstr[1] ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
+msgstr ""
+
+#: ../../../Models/MusicFile.cs:148
+msgid "lyrics"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:146
@@ -398,15 +402,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -436,10 +440,10 @@ msgstr ""
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr ""
 
@@ -478,7 +482,7 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
@@ -525,10 +529,10 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr ""
 
@@ -536,17 +540,17 @@ msgstr ""
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr ""
 
@@ -568,14 +572,14 @@ msgstr ""
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr ""
 
@@ -598,7 +602,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr ""
 
@@ -617,20 +621,20 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,12 +49,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -63,7 +57,13 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr ""
 
@@ -84,27 +84,27 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -123,10 +123,10 @@ msgstr ""
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr ""
 
@@ -140,17 +140,17 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr ""
 
@@ -162,21 +162,21 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr ""
 
@@ -190,22 +190,22 @@ msgstr ""
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr ""
 
@@ -222,10 +222,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgstr ""
 msgid "Discarding unapplied changes..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
@@ -249,11 +249,11 @@ msgstr ""
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr ""
 
@@ -267,23 +267,32 @@ msgstr ""
 msgid "Export Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+msgid "Export to LRC"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -292,8 +301,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr ""
 
@@ -316,10 +325,10 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr ""
 
@@ -337,6 +346,11 @@ msgstr ""
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
@@ -369,11 +383,11 @@ msgstr[1] ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 msgid "lyrics"
 msgstr ""
 
@@ -393,7 +407,7 @@ msgstr ""
 msgid "New Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -402,16 +416,20 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
@@ -440,10 +458,10 @@ msgstr ""
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr ""
 
@@ -451,7 +469,7 @@ msgstr ""
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr ""
 
@@ -482,7 +500,7 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
@@ -525,14 +543,14 @@ msgstr ""
 msgid "TiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr ""
 
@@ -540,17 +558,17 @@ msgstr ""
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr ""
 
@@ -558,28 +576,32 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+msgid "Unable to export to LRC."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr ""
 
@@ -602,42 +624,44 @@ msgstr ""
 msgid "Lyrics"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,6 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -63,7 +62,8 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr ""
 
@@ -90,17 +90,17 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr ""
 
@@ -123,10 +123,10 @@ msgstr ""
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr ""
 
@@ -140,17 +140,17 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr ""
 
@@ -166,17 +166,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr ""
 
@@ -222,10 +222,10 @@ msgstr ""
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgstr ""
 msgid "Discarding unapplied changes..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
@@ -249,11 +249,12 @@ msgstr ""
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr ""
 
@@ -301,8 +302,8 @@ msgstr ""
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr ""
 
@@ -325,10 +326,10 @@ msgstr ""
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr ""
 
@@ -383,11 +384,11 @@ msgstr[1] ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 msgid "lyrics"
 msgstr ""
 
@@ -420,7 +421,7 @@ msgstr ""
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr ""
 
@@ -458,10 +459,10 @@ msgstr ""
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr ""
 
@@ -500,7 +501,7 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
@@ -539,6 +540,10 @@ msgstr ""
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr ""
@@ -547,10 +552,10 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr ""
 
@@ -558,17 +563,17 @@ msgstr ""
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr ""
 
@@ -594,14 +599,14 @@ msgstr ""
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,15 +92,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr ""
 
@@ -125,8 +125,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr ""
 
@@ -142,15 +142,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr ""
 
@@ -168,15 +168,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr ""
 
@@ -224,8 +224,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr ""
 
@@ -254,8 +254,12 @@ msgid "Error"
 msgstr ""
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid "Existing Lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
@@ -268,7 +272,7 @@ msgstr ""
 msgid "Export Front Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 msgid "Export to LRC"
 msgstr ""
@@ -281,7 +285,7 @@ msgstr ""
 msgid "Exported front album art to file successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -328,8 +332,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr ""
 
@@ -366,6 +370,10 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:718
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -429,7 +437,7 @@ msgstr ""
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -461,8 +469,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr ""
 
@@ -554,8 +562,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr ""
 
@@ -565,15 +573,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr ""
 
@@ -581,8 +589,12 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 msgid "Unable to export to LRC."
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+msgid "Unable to import from LRC."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -603,10 +615,20 @@ msgstr ""
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:28-0400\n"
+"POT-Creation-Date: 2023-08-15 13:55-0400\n"
 "PO-Revision-Date: 2023-08-09 12:23+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -100,15 +100,15 @@ msgstr "Ekle"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1012
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "album"
 msgstr "album"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1061
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "albumartist"
 msgstr "albumartist"
 
@@ -133,8 +133,8 @@ msgstr "Değişiklikler Uygulansın Mı?"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1008
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "artist"
 msgstr "sanatçı"
 
@@ -150,15 +150,15 @@ msgstr "Arka"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1073
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:802
 msgid "bpm"
 msgstr "bpm"
 
@@ -176,15 +176,15 @@ msgstr "İptal"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1069
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "comment"
 msgstr "yorum"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1088
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "composer"
 msgstr "besteci"
 
@@ -232,8 +232,8 @@ msgstr "David Lapshin"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1092
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "description"
 msgstr "açıklama"
 
@@ -262,9 +262,14 @@ msgid "Error"
 msgstr "Hata"
 
 #: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
-#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:842
 msgid "ERROR"
 msgstr "HATA"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+#, fuzzy
+msgid "Existing Lyrics"
+msgstr "Şarkı Sözlerini Yönet"
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
@@ -276,7 +281,7 @@ msgstr "Albüm Arka Kapağını Dışa Aktar"
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
 #, fuzzy
 msgid "Export to LRC"
@@ -290,7 +295,7 @@ msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:275
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -337,8 +342,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1065
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "genre"
 msgstr "tür"
 
@@ -376,6 +381,10 @@ msgstr "Albüm Arka Kapağı Ekle"
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
+msgid "Keep Tagger's version"
+msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "KiB"
@@ -439,7 +448,7 @@ msgstr "Hiçbir üst veri indirilmedi"
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:253
 msgid "Nothing to export."
 msgstr ""
 
@@ -473,8 +482,8 @@ msgstr "Özellik Adı"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1096
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:814
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -568,8 +577,8 @@ msgstr "Zaman damgası (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1004
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "title"
 msgstr "başlık"
 
@@ -579,15 +588,15 @@ msgstr "Çok Fazla Dosya Seçildi"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1031
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:782
 msgid "track"
 msgstr "parça"
 
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1046
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:786
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -595,9 +604,14 @@ msgstr "toplam parça"
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
 #, fuzzy
 msgid "Unable to export to LRC."
+msgstr "{0} kaydedilemedi."
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:236
+#, fuzzy
+msgid "Unable to import from LRC."
 msgstr "{0} kaydedilemedi."
 
 #: ../../../Controllers/MainWindowController.cs:716
@@ -618,10 +632,20 @@ msgstr "{0} kaydedilemedi."
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
+msgid "Use LRC's version"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221
+msgid ""
+"What would you like Tagger to do with lyrics found from the LRC file that "
+"conflict with existing lyrics of the same timestamp?"
+msgstr ""
+
 #: ../../../Controllers/MainWindowController.cs:974
 #: ../../../Controllers/MainWindowController.cs:1016
-#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:778
 msgid "year"
 msgstr "yıl"
 

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:24-0400\n"
+"POT-Creation-Date: 2023-08-15 13:28-0400\n"
 "PO-Revision-Date: 2023-08-09 12:23+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,7 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
@@ -64,7 +63,8 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1380
 #: ../../../Controllers/MainWindowController.cs:1381
 #: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Controllers/MainWindowController.cs:1383
+#: ../../../Controllers/MainWindowController.cs:1387
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -98,17 +98,17 @@ msgstr ""
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1011
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:770
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1012
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:775
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1060
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:786
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1061
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "albumartist"
 msgstr "albumartist"
 
@@ -131,10 +131,10 @@ msgstr "Uygula"
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1007
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
-#: ../../../Models/MusicFile.cs:766
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1008
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:771
 msgid "artist"
 msgstr "sanatçı"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1072
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1073
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:803
 msgid "bpm"
 msgstr "bpm"
 
@@ -174,17 +174,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1068
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1069
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:799
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1087
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1088
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:807
 msgid "composer"
 msgstr "besteci"
 
@@ -212,8 +212,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1099
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1100
 msgid "custom"
 msgstr "özel"
 
@@ -230,10 +230,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1091
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1092
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:811
 msgid "description"
 msgstr "açıklama"
 
@@ -248,7 +248,7 @@ msgstr "Gözden Çıkar"
 msgid "Discarding unapplied changes..."
 msgstr "Uygulanmayan değişiklikler gözden çıkartılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
@@ -257,11 +257,12 @@ msgstr "{0} dosya için üst veri indirildi"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:929
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
+#: ../../../Models/MusicFile.cs:224 ../../../Models/MusicFile.cs:247
+#: ../../../Models/MusicFile.cs:344 ../../../Models/MusicFile.cs:843
 msgid "ERROR"
 msgstr "HATA"
 
@@ -310,8 +311,8 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:999
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1000
 msgid "filename"
 msgstr "dosya adı"
 
@@ -334,10 +335,10 @@ msgstr "Ön"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1064
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
-#: ../../../Models/MusicFile.cs:790
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1065
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:704
+#: ../../../Models/MusicFile.cs:795
 msgid "genre"
 msgstr "tür"
 
@@ -392,11 +393,11 @@ msgstr[1] "{0} müzik dosyası yüklendi."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1234
+#: ../../../Controllers/MainWindowController.cs:1235
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
 
-#: ../../../Models/MusicFile.cs:152
+#: ../../../Models/MusicFile.cs:153
 #, fuzzy
 msgid "lyrics"
 msgstr "Şarkı Sözleri"
@@ -430,7 +431,7 @@ msgstr "Nicholas Logozzo"
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:936
+#: ../../../Controllers/MainWindowController.cs:937
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
@@ -470,10 +471,10 @@ msgstr "Lütfen biçimlendirme dizgesi seçin."
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1095
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1096
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:815
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -514,7 +515,7 @@ msgstr "Gönder"
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
@@ -553,6 +554,10 @@ msgstr "Tagger"
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger kimi dosyaları salt okunur kipte açdı."
 
+#: ../../../Controllers/MainWindowController.cs:929
+msgid "This file does not have a valid fingerprint"
+msgstr ""
+
 #: ../../../Helpers/MediaHelpers.cs:33
 msgid "TiB"
 msgstr "TiB"
@@ -561,10 +566,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zaman damgası (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1003
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
-#: ../../../Models/MusicFile.cs:762
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "title"
 msgstr "başlık"
 
@@ -572,17 +577,17 @@ msgstr "başlık"
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1030
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:778
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1031
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:783
 msgid "track"
 msgstr "parça"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1045
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:782
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1046
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:787
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -609,14 +614,14 @@ msgstr "{0} kaydedilemedi"
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:949
+#: ../../../Controllers/MainWindowController.cs:950
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:973
-#: ../../../Controllers/MainWindowController.cs:1015
-#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:774
+#: ../../../Controllers/MainWindowController.cs:974
+#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Models/MusicFile.cs:153 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:779
 msgid "year"
 msgstr "yıl"
 

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-14 14:43-0400\n"
+"POT-Creation-Date: 2023-08-15 13:24-0400\n"
 "PO-Revision-Date: 2023-08-09 12:23+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -50,12 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1363
-#: ../../../Controllers/MainWindowController.cs:1364
-#: ../../../Controllers/MainWindowController.cs:1365
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Controllers/MainWindowController.cs:1368
 #: ../../../Controllers/MainWindowController.cs:1369
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
@@ -64,7 +58,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1374
 #: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Controllers/MainWindowController.cs:1378
+#: ../../../Controllers/MainWindowController.cs:1379
 #: ../../../Controllers/MainWindowController.cs:1380
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Controllers/MainWindowController.cs:1386
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -92,27 +92,27 @@ msgstr ""
 "iziyle ilişkili olarak gönderir."
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:114
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
-#: ../../../Models/MusicFile.cs:763
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1011
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:770
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:779
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1060
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:786
 msgid "albumartist"
 msgstr "albumartist"
 
-#: ../../../Controllers/MainWindowController.cs:922
+#: ../../../Controllers/MainWindowController.cs:928
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
@@ -131,10 +131,10 @@ msgstr "Uygula"
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
-#: ../../../Models/MusicFile.cs:759
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1007
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:663
+#: ../../../Models/MusicFile.cs:766
 msgid "artist"
 msgstr "sanatçı"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:791
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:798
 msgid "bpm"
 msgstr "bpm"
 
@@ -170,21 +170,21 @@ msgstr "bpm"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:829
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:884
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
-#: ../../../Models/MusicFile.cs:787
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:794
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:795
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1087
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:802
 msgid "composer"
 msgstr "besteci"
 
@@ -198,22 +198,22 @@ msgstr "GitHub Katkıcıları ❤️"
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:674
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:697
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1093
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1099
 msgid "custom"
 msgstr "özel"
 
@@ -230,10 +230,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
-#: ../../../Models/MusicFile.cs:799
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:806
 msgid "description"
 msgstr "açıklama"
 
@@ -248,7 +248,7 @@ msgstr "Gözden Çıkar"
 msgid "Discarding unapplied changes..."
 msgstr "Uygulanmayan değişiklikler gözden çıkartılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
@@ -257,11 +257,11 @@ msgstr "{0} dosya için üst veri indirildi"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:923
+#: ../../../Controllers/MainWindowController.cs:929
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
+#: ../../../Models/MusicFile.cs:223 ../../../Models/MusicFile.cs:246
 msgid "ERROR"
 msgstr "HATA"
 
@@ -275,23 +275,33 @@ msgstr "Albüm Arka Kapağını Dışa Aktar"
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:239
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:143
+#, fuzzy
+msgid "Export to LRC"
+msgstr "Dışa Aktar"
+
+#: ../../../Controllers/MainWindowController.cs:814
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:792
+#: ../../../Controllers/MainWindowController.cs:798
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:257
+msgid "Exported successfully to: {0}"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:450
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:813
+#: ../../../Controllers/MainWindowController.cs:819
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:797
+#: ../../../Controllers/MainWindowController.cs:803
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
@@ -300,8 +310,8 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:993
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:999
 msgid "filename"
 msgstr "dosya adı"
 
@@ -324,10 +334,10 @@ msgstr "Ön"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:783
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:790
 msgid "genre"
 msgstr "tür"
 
@@ -346,6 +356,11 @@ msgstr "GitHub Deposu"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Yardım"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:210
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:136
+msgid "Import from LRC"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
 msgid "Info"
@@ -377,11 +392,11 @@ msgstr[1] "{0} müzik dosyası yüklendi."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1234
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
 
-#: ../../../Models/MusicFile.cs:148
+#: ../../../Models/MusicFile.cs:152
 #, fuzzy
 msgid "lyrics"
 msgstr "Şarkı Sözleri"
@@ -402,7 +417,7 @@ msgstr "MusicBrainz Kayıt Kimliği"
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
@@ -411,17 +426,21 @@ msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:920
+#: ../../../Controllers/MainWindowController.cs:926
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:930
+#: ../../../Controllers/MainWindowController.cs:936
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:921
+#: ../../../Controllers/MainWindowController.cs:927
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
+
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:235
+msgid "Nothing to export."
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:822
 msgid "OK"
@@ -451,10 +470,10 @@ msgstr "Lütfen biçimlendirme dizgesi seçin."
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1089
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:803
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:810
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -462,7 +481,7 @@ msgstr "yayımcı"
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:148
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:136
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
@@ -495,7 +514,7 @@ msgstr "Gönder"
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
@@ -538,14 +557,14 @@ msgstr "Tagger kimi dosyaları salt okunur kipte açdı."
 msgid "TiB"
 msgstr "TiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zaman damgası (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
-#: ../../../Models/MusicFile.cs:755
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1003
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:659
+#: ../../../Models/MusicFile.cs:762
 msgid "title"
 msgstr "başlık"
 
@@ -553,17 +572,17 @@ msgstr "başlık"
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1024
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
-#: ../../../Models/MusicFile.cs:771
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1030
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:778
 msgid "track"
 msgstr "parça"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1039
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:775
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1045
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:782
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -571,28 +590,33 @@ msgstr "toplam parça"
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
-#: ../../../Controllers/MainWindowController.cs:710
+#: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:261
+#, fuzzy
+msgid "Unable to export to LRC."
+msgstr "{0} kaydedilemedi."
+
+#: ../../../Controllers/MainWindowController.cs:716
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:588
+#: ../../../Controllers/MainWindowController.cs:594
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:549
+#: ../../../Controllers/MainWindowController.cs:555
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:949
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:967
-#: ../../../Controllers/MainWindowController.cs:1009
-#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
-#: ../../../Models/MusicFile.cs:767
+#: ../../../Controllers/MainWindowController.cs:973
+#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Models/MusicFile.cs:152 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:774
 msgid "year"
 msgstr "yıl"
 
@@ -617,11 +641,11 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Şarkı Sözleri"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:31
 msgid "Configure"
 msgstr "Yapılandır"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:41
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:42
 msgid ""
 "Information about the provided lyrics. Applies to both unsynchronized and "
 "synchronized lyrics."
@@ -629,36 +653,36 @@ msgstr ""
 "Sağlanan şarkı sözleri hakkında bilgi. Hem eşitlenmemiş hem de eşitlenmiş "
 "şarkı sözleri için geçerlidir."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:44
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:45
 msgid "Language Code"
 msgstr "Dil Kodu"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:53
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:54
 #: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Description"
 msgstr "Açıklama"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:66
 msgid "Unsynchronized"
 msgstr "Eşitlenmemiş"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:77
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Eşitlenmemiş şarkı sözleri, zaman bilgisi olmadan tek dizge olarak saklanır."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:93
 msgid "Synchronized"
 msgstr "Eşitlenmiş"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
-msgid ""
-"Synchronized lyrics are stored as a dictionary of strings identified by "
-"their timestamp in milliseconds."
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:129
+msgid "Clear All Lyrics"
 msgstr ""
-"Eşitlenmiş şarkı sözleri, milisaniye cinsinden zaman damgalarıyla tanımlanan "
-"bir dizge sözlüğü olarak saklanır."
+
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
+msgid "Offset (in milliseconds)"
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:11
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:119
@@ -1031,6 +1055,13 @@ msgstr ""
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 msgid "— Lookup file information using MusicBrainz"
 msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
+
+#~ msgid ""
+#~ "Synchronized lyrics are stored as a dictionary of strings identified by "
+#~ "their timestamp in milliseconds."
+#~ msgstr ""
+#~ "Eşitlenmiş şarkı sözleri, milisaniye cinsinden zaman damgalarıyla "
+#~ "tanımlanan bir dizge sözlüğü olarak saklanır."
 
 #~ msgid "Duration"
 #~ msgstr "Süre"

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-15 13:55-0400\n"
+"POT-Creation-Date: 2023-08-15 22:00-0400\n"
 "PO-Revision-Date: 2023-08-09 12:23+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -383,7 +383,7 @@ msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:223
-msgid "Keep Tagger's version"
+msgid "Keep Tagger's lyrics"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:33
@@ -633,7 +633,7 @@ msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:226
-msgid "Use LRC's version"
+msgid "Use LRC's lyrics"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:221

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-08 23:17-0400\n"
+"POT-Creation-Date: 2023-08-14 14:43-0400\n"
 "PO-Revision-Date: 2023-08-09 12:23+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/tr/>\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,10 +50,6 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:455
 #: ../../../Controllers/MainWindowController.cs:460
 #: ../../../Controllers/MainWindowController.cs:469
-#: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Controllers/MainWindowController.cs:1360
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Controllers/MainWindowController.cs:1362
 #: ../../../Controllers/MainWindowController.cs:1363
 #: ../../../Controllers/MainWindowController.cs:1364
 #: ../../../Controllers/MainWindowController.cs:1365
@@ -64,7 +60,11 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1370
 #: ../../../Controllers/MainWindowController.cs:1371
 #: ../../../Controllers/MainWindowController.cs:1372
+#: ../../../Controllers/MainWindowController.cs:1373
+#: ../../../Controllers/MainWindowController.cs:1374
+#: ../../../Controllers/MainWindowController.cs:1375
 #: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Controllers/MainWindowController.cs:1380
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -93,26 +93,26 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:114
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:98
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:108
 #: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1001
-#: ../../../Models/MusicFile.cs:648 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1005
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:763
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1050
-#: ../../../Models/MusicFile.cs:676 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:779
 msgid "albumartist"
 msgstr "albumartist"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:922
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
@@ -131,10 +131,10 @@ msgstr "Uygula"
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:997
-#: ../../../Models/MusicFile.cs:644 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:748
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1001
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:656
+#: ../../../Models/MusicFile.cs:759
 msgid "artist"
 msgstr "sanatçı"
 
@@ -148,17 +148,17 @@ msgstr "B"
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:688 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1066
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:791
 msgid "bpm"
 msgstr "bpm"
 
@@ -174,17 +174,17 @@ msgstr "bpm"
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:684 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1062
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:787
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1077
-#: ../../../Models/MusicFile.cs:696 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1081
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:795
 msgid "composer"
 msgstr "besteci"
 
@@ -212,8 +212,8 @@ msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1093
 msgid "custom"
 msgstr "özel"
 
@@ -230,10 +230,10 @@ msgstr "DaPigGuy"
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1081
-#: ../../../Models/MusicFile.cs:700 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1085
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:712
+#: ../../../Models/MusicFile.cs:799
 msgid "description"
 msgstr "açıklama"
 
@@ -248,7 +248,7 @@ msgstr "Gözden Çıkar"
 msgid "Discarding unapplied changes..."
 msgstr "Uygulanmayan değişiklikler gözden çıkartılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
@@ -257,11 +257,11 @@ msgstr "{0} dosya için üst veri indirildi"
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:919
+#: ../../../Controllers/MainWindowController.cs:923
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:215 ../../../Models/MusicFile.cs:238
+#: ../../../Models/MusicFile.cs:218 ../../../Models/MusicFile.cs:241
 msgid "ERROR"
 msgstr "HATA"
 
@@ -300,8 +300,8 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:989
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:993
 msgid "filename"
 msgstr "dosya adı"
 
@@ -324,10 +324,10 @@ msgstr "Ön"
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1054
-#: ../../../Models/MusicFile.cs:680 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1058
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:783
 msgid "genre"
 msgstr "tür"
 
@@ -377,9 +377,14 @@ msgstr[1] "{0} müzik dosyası yüklendi."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:584
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:617
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:626
-#: ../../../Controllers/MainWindowController.cs:1224
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
+
+#: ../../../Models/MusicFile.cs:148
+#, fuzzy
+msgid "lyrics"
+msgstr "Şarkı Sözleri"
 
 #: ../../../Controllers/MainWindowController.cs:146
 msgid "Matrix Chat"
@@ -406,15 +411,15 @@ msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:916
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:926
+#: ../../../Controllers/MainWindowController.cs:930
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:921
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
@@ -446,10 +451,10 @@ msgstr "Lütfen biçimlendirme dizgesi seçin."
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:704 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1089
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:803
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -490,7 +495,7 @@ msgstr "Gönder"
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
@@ -537,10 +542,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zaman damgası (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:993
-#: ../../../Models/MusicFile.cs:640 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:744
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:755
 msgid "title"
 msgstr "başlık"
 
@@ -548,17 +553,17 @@ msgstr "başlık"
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1020
-#: ../../../Models/MusicFile.cs:660 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:771
 msgid "track"
 msgstr "parça"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1035
-#: ../../../Models/MusicFile.cs:668 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1039
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:775
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -580,14 +585,14 @@ msgstr "{0} kaydedilemedi"
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:939
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:963
-#: ../../../Controllers/MainWindowController.cs:1005
-#: ../../../Models/MusicFile.cs:652 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:967
+#: ../../../Controllers/MainWindowController.cs:1009
+#: ../../../Models/MusicFile.cs:148 ../../../Models/MusicFile.cs:664
+#: ../../../Models/MusicFile.cs:767
 msgid "year"
 msgstr "yıl"
 
@@ -612,7 +617,7 @@ msgstr ""
 msgid "Lyrics"
 msgstr "Şarkı Sözleri"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:36
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
 msgid "Configure"
 msgstr "Yapılandır"
 
@@ -633,21 +638,21 @@ msgstr "Dil Kodu"
 msgid "Description"
 msgstr "Açıklama"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:65
 msgid "Unsynchronized"
 msgstr "Eşitlenmemiş"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:69
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:74
 msgid ""
 "Unsynchronized lyrics are stored as a single string with no time information."
 msgstr ""
 "Eşitlenmemiş şarkı sözleri, zaman bilgisi olmadan tek dizge olarak saklanır."
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:84
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:90
 msgid "Synchronized"
 msgstr "Eşitlenmiş"
 
-#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:89
+#: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:99
 msgid ""
 "Synchronized lyrics are stored as a dictionary of strings identified by "
 "their timestamp in milliseconds."

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -40,7 +40,7 @@
       <description translatable="no">
         <p>- Added offset field to synchronized lyrics page</p>
         <p>- Added the ability to import and export LRC files in the synchronized lyrics page</p>
-        <p>- Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics</p>
+        <p>- Fixed an issue where synchronized lyrics stored in the LRC format were not displayed correctly</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -36,15 +36,9 @@
     <binary>org.nickvision.tagger</binary>
   </provides>
   <releases>
-    <release version="2023.8.2" date="2023-08-11">
+    <release version="2023.8.3-next" date="2023-08-11">
       <description translatable="no">
-        <p>- Added support for managing a file's lyrics</p>
-        <p>- Tagger will now provide suggestions while typing a genre</p>
-        <p>- Fixed an issue where downloading MusicBrainz metadata would fail even if metadata was available</p>
-        <p>- Fixed an issue where Web Services were disabled even though network connection was available</p>
-        <p>- Fixed an issue where back album art was not saved correctly</p>
-        <p>- An Info button will appear when MusicBrainz lookup fails and will provide more information about why the process failed</p>
-        <p>- Improved tag panel design</p>
+        <p>- Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -38,6 +38,7 @@
   <releases>
     <release version="2023.8.3-next" date="2023-08-11">
       <description translatable="no">
+        <p>- Added offset field to synchronized lyrics page</p>
         <p>- Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -39,6 +39,7 @@
     <release version="2023.8.3-next" date="2023-08-11">
       <description translatable="no">
         <p>- Added offset field to synchronized lyrics page</p>
+        <p>- Added the ability to import and export LRC files in the synchronized lyrics page</p>
         <p>- Lyrics stored in LRC format will now be displayed correctly as synchronized lyrics</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>


### PR DESCRIPTION
Closes #225 

- [x] Update atldotnet to V5.0.0 which fixes unable to read syncrhonized tags in LRC format
- [x] Make it so custom properties with valid property names can't be created (i.e can't create custom properties who's name are `lyrics`, `title`, `artist`, etc...)
- [x] Add offset field to synchronized lyrics
- [x] Sort new sync lyrics by timstamp 
- [x] No two of the same timestamp
- [x] Import and export sync lyrics to and from LRC
- [x] (Unrelated to Lyrics) Don't allow musicbrainz/acoustid webservice if fingerprint error

![image](https://github.com/NickvisionApps/Tagger/assets/17648453/5ea3a8ad-bfb8-4cb9-9314-6e2ed13847e6)