### PR TITLE
Shared - Use PropertyMap For Storing Original Copies

### DIFF
--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -501,7 +501,7 @@ public class MainWindowController : IDisposable
                     if(p.Value != pair.Value.GetCustomProperty(p.Key) && p.Value != _("<keep>"))
                     {
                         pair.Value.SetCustomProperty(p.Key, p.Value);
-                        updated = p.Value != _filesBeingEditedOriginals[pair.Key].CustomProperties[p.Key];
+                        updated = !_filesBeingEditedOriginals[pair.Key].CustomProperties.ContainsKey(p.Key) || p.Value != _filesBeingEditedOriginals[pair.Key].CustomProperties[p.Key];
                     }
                 }
             }

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -35,7 +35,7 @@ public class MainWindowController : IDisposable
     private bool _forceAllowClose;
     private readonly string[] _genreSuggestions;
     private readonly List<bool> _musicFileChangedFromUpdate;
-    private readonly Dictionary<int, MusicFile> _filesBeingEditedOriginals;
+    private readonly Dictionary<int, PropertyMap> _filesBeingEditedOriginals;
     
     /// <summary>
     /// The list of predefined format strings
@@ -181,7 +181,7 @@ public class MainWindowController : IDisposable
             "Indie", "Merengue", "Salsa", "Bachata", "Christmas", "EDM"
         };
         _musicFileChangedFromUpdate = new List<bool>();
-        _filesBeingEditedOriginals = new Dictionary<int, MusicFile>();
+        _filesBeingEditedOriginals = new Dictionary<int, PropertyMap>();
         FormatStrings = new string[] { _("%artist%- %title%"), _("%title%- %artist%"), _("%track%- %title%"), _("%title%") };
         MusicFileSaveStates = new List<bool>();
         SelectedMusicFiles = new Dictionary<int, MusicFile>();
@@ -388,7 +388,7 @@ public class MainWindowController : IDisposable
             }
             if (!_filesBeingEditedOriginals.ContainsKey(pair.Key))
             {
-                _filesBeingEditedOriginals.Add(pair.Key, new MusicFile(pair.Value.Path));
+                _filesBeingEditedOriginals.Add(pair.Key, pair.Value.PropertyMap);
             }
             var updated = false;
             if(map.Filename != pair.Value.Filename && map.Filename != _("<keep>"))
@@ -501,7 +501,7 @@ public class MainWindowController : IDisposable
                     if(p.Value != pair.Value.GetCustomProperty(p.Key) && p.Value != _("<keep>"))
                     {
                         pair.Value.SetCustomProperty(p.Key, p.Value);
-                        updated = p.Value != _filesBeingEditedOriginals[pair.Key].GetCustomProperty(p.Key);
+                        updated = p.Value != _filesBeingEditedOriginals[pair.Key].CustomProperties[p.Key];
                     }
                 }
             }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using static NickvisionTagger.Shared.Helpers.Gettext;
@@ -412,6 +413,39 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             var names = _track.AdditionalFields.Keys.ToList();
             names.Sort();
             return names;
+        }
+    }
+
+    /// <summary>
+    /// The PropertyMap of the MusicFile
+    /// </summary>
+    public PropertyMap PropertyMap
+    {
+        get
+        {
+            return new PropertyMap()
+            {
+                Filename = Filename,
+                Title = Title,
+                Artist = Artist,
+                Album = Album,
+                Year = Year == 0 ? "" : Year.ToString(),
+                Track = Track == 0 ? "" : Track.ToString(),
+                TrackTotal = TrackTotal == 0 ? "" : TrackTotal.ToString(),
+                AlbumArtist = AlbumArtist,
+                Genre = Genre,
+                Comment = Comment,
+                BeatsPerMinute = BeatsPerMinute == 0 ? "" : BeatsPerMinute.ToString(),
+                Composer = Composer,
+                Description = Description,
+                Publisher = Publisher,
+                FrontAlbumArt = Encoding.UTF8.GetString(FrontAlbumArt),
+                BackAlbumArt = Encoding.UTF8.GetString(BackAlbumArt),
+                CustomProperties = _track.AdditionalFields.ToDictionary(x => x.Key, x => x.Value),
+                Duration = Duration.ToDurationString(),
+                Fingerprint = _fingerprint,
+                FileSize = FileSize.ToFileSizeString()
+            };
         }
     }
     


### PR DESCRIPTION
This will store original copies of MusicFiles via a PropertyMap instead of a new MusicFile object. Much more efficent as we don't need to make a copy from the file on disk we can just create a PropertyMap for the original copy.