### PR TITLE
Music files list with headers

### DIFF
--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -208,7 +208,7 @@ Adw.ApplicationWindow _root {
                         selection-mode: multiple;
                         activate-on-single-click: false;
 
-                        styles ["card", "boxed-list"]
+                        styles ["background", "music-list"]
                       };
                     }
                   };

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -35,6 +35,8 @@ menu tagActionsMenu {
         item(_("Remove"), "win.removeBackAlbumArt")
         item(_("Export"), "win.exportBackAlbumArt")
       }
+
+      item(_("Switch Album Art"), "win.switchAlbumArt")
     }
 
     submenu {

--- a/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
+++ b/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.9.1" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.9.3" />
     <PackageReference Include="Nickvision.GirExt" Version="2023.7.1" />
   </ItemGroup>
 

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -34,7 +34,8 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
-            @"* Updated translations (Thanks everyone on Weblate!)";
+            @"* Tagger will display headers in the list of music files when sorting to provide a more organized view of files
+              * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))
         {

--- a/NickvisionTagger.GNOME/Resources/org.nickvision.tagger-dark.css
+++ b/NickvisionTagger.GNOME/Resources/org.nickvision.tagger-dark.css
@@ -1,0 +1,3 @@
+.music-list > row {
+  margin-bottom: 1px;
+}

--- a/NickvisionTagger.GNOME/Resources/org.nickvision.tagger.css
+++ b/NickvisionTagger.GNOME/Resources/org.nickvision.tagger.css
@@ -18,3 +18,28 @@
   border-color: @borders;
   border-radius: 8px;
 }
+
+.music-list > row:not(.start-row):not(.end-row):not(.single-row) {
+  border-radius: 0px;
+}
+
+.start-row {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+.end-row {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+}
+
+.single-row {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+}

--- a/NickvisionTagger.GNOME/Resources/org.nickvision.tagger.gresource.xml
+++ b/NickvisionTagger.GNOME/Resources/org.nickvision.tagger.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/org/nickvision/tagger">
     <file alias="style.css">org.nickvision.tagger.css</file>
+    <file alias="style-dark.css">org.nickvision.tagger-dark.css</file>
   </gresource>
   <gresource prefix="/org/nickvision/tagger/icons/scalable/status/">
     <file preprocess="xml-stripblanks">dark-mode-symbolic.svg</file>
@@ -16,7 +17,7 @@
     <file preprocess="xml-stripblanks">notepad-symbolic.svg</file>
     <file preprocess="xml-stripblanks">quotation-symbolic.svg</file>
     <file preprocess="xml-stripblanks">tag-outline-symbolic.svg</file>
-    <file preprocess="xml-stripblanks">user-trash-symbolic.svg</file>    
+    <file preprocess="xml-stripblanks">user-trash-symbolic.svg</file>
     <file preprocess="xml-stripblanks">web-browser-symbolic.svg</file>
     <file preprocess="xml-stripblanks">wrench-wide-symbolic.svg</file>
   </gresource>

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -1160,6 +1160,10 @@ public partial class MainWindow : Adw.ApplicationWindow
             }
             if (_listMusicFilesRows.Any())
             {
+                if (!_listMusicFilesRows[0].HasCssClass("start-row"))
+                {
+                    _listMusicFilesRows[0].AddCssClass("start-row");
+                }
                 if (_listMusicFilesRows[^1].HasCssClass("start-row"))
                 {
                     _listMusicFilesRows[^1].RemoveCssClass("start-row");

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -22,6 +23,14 @@ namespace NickvisionTagger.GNOME.Views;
 /// </summary>
 public partial class MainWindow : Adw.ApplicationWindow
 {
+    private delegate void GtkListBoxUpdateHeaderFunc(nint row, nint before, nint data);
+
+    [LibraryImport("libadwaita-1.so.0")]
+    private static partial void gtk_list_box_set_header_func(nint box, GtkListBoxUpdateHeaderFunc updateHeader, nint data, nint destroy);
+    [LibraryImport("libadwaita-1.so.0")]
+    private static partial void gtk_list_box_row_set_header(nint row, nint header);
+
+
     private readonly MainWindowController _controller;
     private readonly Adw.Application _application;
     private readonly Gtk.DropTarget _dropTarget;
@@ -33,7 +42,9 @@ public partial class MainWindow : Adw.ApplicationWindow
     private readonly Gio.SimpleAction _musicBrainzAction;
     private readonly Gio.SimpleAction _downloadLyricsAction;
     private readonly Gio.SimpleAction _acoustIdAction;
+    private readonly GtkListBoxUpdateHeaderFunc _updateHeaderFunc;
     private AlbumArtType _currentAlbumArtType;
+    private string _listHeader;
     private List<Adw.ActionRow> _listMusicFilesRows;
     private List<Adw.EntryRow> _customPropertyRows;
     private AutocompleteBox _autocompleteBox;
@@ -119,6 +130,24 @@ public partial class MainWindow : Adw.ApplicationWindow
                 _searchSeparator.SetVisible(musicFilesVadjustment.GetValue() > 0);
             }
         };
+        _updateHeaderFunc = (rowPtr, _, _) =>
+        {
+            if (!string.IsNullOrEmpty(_listHeader))
+            {
+                var label = Gtk.Label.New(_listHeader);
+                label.AddCssClass("dim-label");
+                label.AddCssClass("title-4");
+                label.SetMarginTop(6);
+                label.SetMarginStart(6);
+                label.SetMarginEnd(6);
+                label.SetMarginBottom(6);
+                label.SetHalign(Gtk.Align.Start);
+                label.SetEllipsize(Pango.EllipsizeMode.End);
+                gtk_list_box_row_set_header(rowPtr, label.Handle);
+                _listHeader = string.Empty;
+            }
+        };
+        gtk_list_box_set_header_func(_listMusicFiles.Handle, _updateHeaderFunc, IntPtr.Zero, IntPtr.Zero);
         _listMusicFiles.OnSelectedRowsChanged += ListMusicFiles_SelectionChanged;
         var switchAlbumArtLabel = (Gtk.Label)_switchAlbumArtButtonContent.GetLastChild();
         switchAlbumArtLabel.SetWrap(true);
@@ -1080,6 +1109,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         _listMusicFilesRows.Clear();
         if (!string.IsNullOrEmpty(_controller.MusicFolderPath))
         {
+            string? comparable = null;
             foreach (var musicFile in _controller.MusicFiles)
             {
                 var row = Adw.ActionRow.New();
@@ -1093,8 +1123,52 @@ public partial class MainWindow : Adw.ApplicationWindow
                     row.SetTitle(Regex.Replace(musicFile.Filename, "\\&", "&amp;"));
                     row.SetSubtitle("");
                 }
+                row.AddCssClass("card");
+                var compareTo = _controller.SortFilesBy switch
+                {
+                    SortBy.Album => musicFile.Album,
+                    SortBy.Artist => musicFile.Artist,
+                    SortBy.Genre => musicFile.Genre,
+                    SortBy.Path => Path.GetDirectoryName(musicFile.Path)!.Replace(_controller.MusicFolderPath, ""),
+                    SortBy.Year => musicFile.Year.ToString(),
+                    _ => null
+                };
+                if (compareTo == string.Empty)
+                {
+                    compareTo = _("Unknown");
+                }
+                if (comparable != compareTo)
+                {
+                    comparable = compareTo;
+                    _listHeader = compareTo!;
+                    if (_listMusicFilesRows.Any())
+                    {
+                        if (_listMusicFilesRows[^1].HasCssClass("start-row"))
+                        {
+                            _listMusicFilesRows[^1].RemoveCssClass("start-row");
+                            _listMusicFilesRows[^1].AddCssClass("single-row");
+                        }
+                        else
+                        {
+                            _listMusicFilesRows[^1].AddCssClass("end-row");
+                        }
+                    }
+                    row.AddCssClass("start-row");
+                }
                 _listMusicFiles.Append(row);
                 _listMusicFilesRows.Add(row);
+            }
+            if (_listMusicFilesRows.Any())
+            {
+                if (_listMusicFilesRows[^1].HasCssClass("start-row"))
+                {
+                    _listMusicFilesRows[^1].RemoveCssClass("start-row");
+                    _listMusicFilesRows[^1].AddCssClass("single-row");
+                }
+                else
+                {
+                    _listMusicFilesRows[^1].AddCssClass("end-row");
+                }
             }
             _headerBar.RemoveCssClass("flat");
             _title.SetSubtitle(_controller.MusicFolderPath);

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -1135,7 +1135,7 @@ public partial class MainWindow : Adw.ApplicationWindow
                 };
                 if (compareTo == string.Empty)
                 {
-                    compareTo = _("Unknown");
+                    compareTo = _controller.SortFilesBy != SortBy.Path ? _("Unknown") : "/";
                 }
                 if (comparable != compareTo)
                 {

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -141,7 +141,7 @@ public class MainWindowController : IDisposable
                 _folderToLaunch = dir;
             }
         }
-        Aura.Init("org.nickvision.tagger", "Nickvision Tagger", _("Tagger"), _("Tag your music"));
+        Aura.Init("org.nickvision.tagger", "Nickvision Tagger");
         if (Directory.Exists($"{UserDirectories.Config}{Path.DirectorySeparatorChar}Nickvision{Path.DirectorySeparatorChar}{AppInfo.Name}"))
         {
             // Move config files from older versions and delete old directory
@@ -158,6 +158,8 @@ public class MainWindowController : IDisposable
         Aura.Active.SetConfig<Configuration>("config");
         Configuration.Current.Saved += ConfigurationSaved;
         AppInfo.Version = "2023.9.1-next";
+        AppInfo.ShortName = _("Tagger");
+        AppInfo.Description = _("Tag your music");
         AppInfo.SourceRepo = new Uri("https://github.com/NickvisionApps/Tagger");
         AppInfo.IssueTracker = new Uri("https://github.com/NickvisionApps/Tagger/issues/new");
         AppInfo.SupportUrl = new Uri("https://github.com/NickvisionApps/Tagger/discussions");

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -68,6 +68,10 @@ public class MainWindowController : IDisposable
     /// </summary>
     public Theme Theme => Configuration.Current.Theme;
     /// <summary>
+    /// What to sort files in a music folder by
+    /// </summary>
+    public SortBy SortFilesBy => Configuration.Current.SortFilesBy;
+    /// <summary>
     /// The path of the music folder
     /// </summary>
     public string MusicFolderPath => _musicFolder?.ParentPath ?? "";

--- a/NickvisionTagger.Shared/Models/Configuration.cs
+++ b/NickvisionTagger.Shared/Models/Configuration.cs
@@ -71,7 +71,7 @@ public class Configuration : ConfigurationBase
         Theme = Theme.System;
         RememberLastOpenedFolder = true;
         IncludeSubfolders = true;
-        SortFilesBy = SortBy.Artist;
+        SortFilesBy = SortBy.Path;
         LastOpenedFolder = "";
         PreserveModificationTimestamp = false;
         OverwriteTagWithMusicBrainz = true;

--- a/NickvisionTagger.Shared/Models/Configuration.cs
+++ b/NickvisionTagger.Shared/Models/Configuration.cs
@@ -71,7 +71,7 @@ public class Configuration : ConfigurationBase
         Theme = Theme.System;
         RememberLastOpenedFolder = true;
         IncludeSubfolders = true;
-        SortFilesBy = SortBy.Filename;
+        SortFilesBy = SortBy.Artist;
         LastOpenedFolder = "";
         PreserveModificationTimestamp = false;
         OverwriteTagWithMusicBrainz = true;

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -1070,16 +1070,26 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is less than b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
+        //Pad first number part of filename with 0 (i.e. "2- Test" becomes "02- Test")
         var aPath = a?.Path;
         var bPath = b?.Path;
-        if (aPath != null && a!.Track != 0)
+        if (aPath != null)
         {
-            aPath = aPath.Replace(a.Track.ToString(), a.Track.ToString("D2"));
+            var x = a!.Filename.Substring(0, a.Filename.IndexOf(' ')); //first part of filename
+            if (int.TryParse(x, out var n))
+            {
+                aPath = aPath.Replace(x, n.ToString("D2"));
+            }
         }
         if (bPath != null && b!.Track != 0)
         {
-            bPath = bPath.Replace(b.Track.ToString(), b.Track.ToString("D2"));
+            var x = b!.Filename.Substring(0, b.Filename.IndexOf(' ')); //first part of filename
+            if (int.TryParse(x, out var n))
+            {
+                bPath = bPath.Replace(x, n.ToString("D2"));
+            }
         }
+        //Compare
         return SortFilesBy switch
         {
             SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == -1,
@@ -1102,16 +1112,26 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is greater than b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
+        //Pad first number part of filename with 0 (i.e. "2- Test" becomes "02- Test")
         var aPath = a?.Path;
         var bPath = b?.Path;
-        if (aPath != null && a!.Track != 0)
+        if (aPath != null)
         {
-            aPath = aPath.Replace(a.Track.ToString(), a.Track.ToString("D2"));
+            var x = a!.Filename.Substring(0, a.Filename.IndexOf(' ')); //first part of filename
+            if (int.TryParse(x, out var n))
+            {
+                aPath = aPath.Replace(x, n.ToString("D2"));
+            }
         }
         if (bPath != null && b!.Track != 0)
         {
-            bPath = bPath.Replace(b.Track.ToString(), b.Track.ToString("D2"));
+            var x = b!.Filename.Substring(0, b.Filename.IndexOf(' ')); //first part of filename
+            if (int.TryParse(x, out var n))
+            {
+                bPath = bPath.Replace(x, n.ToString("D2"));
+            }
         }
+        //Compare
         return SortFilesBy switch
         {
             SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == 1,

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -77,7 +77,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         ATL.Settings.UseFileNameWhenNoTitle = false;
         ATL.Settings.FileBufferSize = 1024;
         ATL.Settings.ID3v2_writePictureDataLengthIndicator = false;
-        SortFilesBy = SortBy.Filename;
+        SortFilesBy = SortBy.Path;
     }
 
     /// <summary>
@@ -1072,8 +1072,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     {
         return SortFilesBy switch
         {
-            SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == -1,
-            SortBy.Path => a?.Path.CompareTo(b?.Path) == -1,
+            SortBy.Filename => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Filename.CompareTo(b?.Filename) == -1,
+            SortBy.Path => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Path.CompareTo(b?.Path) == -1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track < b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track < b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
@@ -1094,8 +1094,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     {
         return SortFilesBy switch
         {
-            SortBy.Filename => a?.Filename.CompareTo(b?.Filename) == 1,
-            SortBy.Path => a?.Path.CompareTo(b?.Path) == 1,
+            SortBy.Filename => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Filename.CompareTo(b?.Filename) == 1,
+            SortBy.Path => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Path.CompareTo(b?.Path) == 1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track > b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track > b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -1070,26 +1070,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is less than b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
-        //Pad first number part of filename with 0 (i.e. "2- Test" becomes "02- Test")
-        var aPath = a?.Path;
-        var bPath = b?.Path;
-        if (aPath != null)
-        {
-            var x = a!.Filename.Substring(0, a.Filename.IndexOf(' ')); //first part of filename
-            if (int.TryParse(x, out var n))
-            {
-                aPath = aPath.Replace(x, n.ToString("D2"));
-            }
-        }
-        if (bPath != null && b!.Track != 0)
-        {
-            var x = b!.Filename.Substring(0, b.Filename.IndexOf(' ')); //first part of filename
-            if (int.TryParse(x, out var n))
-            {
-                bPath = bPath.Replace(x, n.ToString("D2"));
-            }
-        }
-        //Compare
+        var aPath = PadNumberInPathIfFirst(a?.Path);
+        var bPath = PadNumberInPathIfFirst(b?.Path);
         return SortFilesBy switch
         {
             SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == -1,
@@ -1112,26 +1094,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is greater than b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
-        //Pad first number part of filename with 0 (i.e. "2- Test" becomes "02- Test")
-        var aPath = a?.Path;
-        var bPath = b?.Path;
-        if (aPath != null)
-        {
-            var x = a!.Filename.Substring(0, a.Filename.IndexOf(' ')); //first part of filename
-            if (int.TryParse(x, out var n))
-            {
-                aPath = aPath.Replace(x, n.ToString("D2"));
-            }
-        }
-        if (bPath != null && b!.Track != 0)
-        {
-            var x = b!.Filename.Substring(0, b.Filename.IndexOf(' ')); //first part of filename
-            if (int.TryParse(x, out var n))
-            {
-                bPath = bPath.Replace(x, n.ToString("D2"));
-            }
-        }
-        //Compare
+        var aPath = PadNumberInPathIfFirst(a?.Path ?? "");
+        var bPath = PadNumberInPathIfFirst(b?.Path ?? "");
         return SortFilesBy switch
         {
             SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == 1,
@@ -1144,5 +1108,25 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             SortBy.Genre => a?.Genre.CompareTo(b?.Genre) == 1 || a?.Genre == b?.Genre && a?.Album.CompareTo(b?.Album) == 1 || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track > b?.Track || a?.Genre == b?.Genre && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             _ => false
         };
+    }
+
+    /// <summary>
+    /// Pads a number in a file path if said number is at the beginning of the filename
+    /// (i.e. "2 - Test.mp3" becomes "02 - Test.mp3" whereas "How 2 make.mp3" remains unchanged)
+    /// </summary>
+    /// <param name="path">The file path</param>
+    /// <returns>The padded path</returns>
+    private static string PadNumberInPathIfFirst(string? path)
+    {
+        if (!string.IsNullOrEmpty(path))
+        {
+            var filename = System.IO.Path.GetFileName(path);
+            var x = filename.Substring(0, filename.IndexOf(' ')); //first part of filename
+            if (int.TryParse(x, out var n))
+            {
+                return path.Replace(x, n.ToString("D2"));
+            }
+        }
+        return path ?? "";
     }
 }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -1070,12 +1070,10 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is less than b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
-        var aPath = PadNumberInPathIfFirst(a?.Path);
-        var bPath = PadNumberInPathIfFirst(b?.Path);
         return SortFilesBy switch
         {
-            SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == -1,
-            SortBy.Path => aPath.CompareTo(bPath) == -1,
+            SortBy.Filename => CompareFilename(a?.Filename, b?.Filename) == -1,
+            SortBy.Path => ComparePath(a?.Path, b?.Path) == -1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track < b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track < b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
@@ -1094,12 +1092,10 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is greater than b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
-        var aPath = PadNumberInPathIfFirst(a?.Path ?? "");
-        var bPath = PadNumberInPathIfFirst(b?.Path ?? "");
         return SortFilesBy switch
         {
-            SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == 1,
-            SortBy.Path => aPath.CompareTo(bPath) == 1,
+            SortBy.Filename => CompareFilename(a?.Filename, b?.Filename) == 1,
+            SortBy.Path => ComparePath(a?.Path, b?.Path) == 1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track > b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track > b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
@@ -1111,22 +1107,32 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     }
 
     /// <summary>
-    /// Pads a number in a file path if said number is at the beginning of the filename
-    /// (i.e. "2 - Test.mp3" becomes "02 - Test.mp3" whereas "How 2 make.mp3" remains unchanged)
+    /// Compares two filenames
     /// </summary>
-    /// <param name="path">The file path</param>
-    /// <returns>The padded path</returns>
-    private static string PadNumberInPathIfFirst(string? path)
+    /// <param name="a">First filename</param>
+    /// <param name="b">Second filename</param>
+    /// <returns>-1 if a &lt; b, 1 if a &gt; b, else 0</returns>
+    private static int CompareFilename(string? a, string? b)
     {
-        if (!string.IsNullOrEmpty(path))
+        var padA = Regex.Replace(a ?? "", @"\d+", match => match.Value.PadLeft(4, '0'));
+        var padB = Regex.Replace(b ?? "", @"\d+", match => match.Value.PadLeft(4, '0'));
+        return padA.CompareTo(padB);
+    }
+
+    /// <summary>
+    /// Compares two paths
+    /// </summary>
+    /// <param name="a">First path</param>
+    /// <param name="b">Second path</param>
+    /// <returns>-1 if a &lt; b, 1 if a &gt; b, else 0</returns>
+    private static int ComparePath(string? a, string? b)
+    {
+        var parentA = System.IO.Path.GetDirectoryName(a) ?? "";
+        var parentB = System.IO.Path.GetDirectoryName(b) ?? "";
+        if (parentA != parentB)
         {
-            var filename = System.IO.Path.GetFileName(path);
-            var x = filename.Substring(0, filename.IndexOf(' ')); //first part of filename
-            if (int.TryParse(x, out var n))
-            {
-                return path.Replace(x, n.ToString("D2"));
-            }
+            return ComparePath(parentA, parentB);
         }
-        return path ?? "";
+        return CompareFilename(System.IO.Path.GetFileName(a), System.IO.Path.GetFileName(b));
     }
 }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -1070,10 +1070,20 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is less than b, else false</returns>
     public static bool operator <(MusicFile? a, MusicFile? b)
     {
+        var aPath = a?.Path;
+        var bPath = b?.Path;
+        if (aPath != null && a!.Track != 0)
+        {
+            aPath = aPath.Replace(a.Track.ToString(), a.Track.ToString("D2"));
+        }
+        if (bPath != null && b!.Track != 0)
+        {
+            bPath = bPath.Replace(b.Track.ToString(), b.Track.ToString("D2"));
+        }
         return SortFilesBy switch
         {
-            SortBy.Filename => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Filename.CompareTo(b?.Filename) == -1,
-            SortBy.Path => a?.Track.CompareTo(b?.Track) == -1 || a?.Track == b?.Track && a?.Path.CompareTo(b?.Path) == -1,
+            SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == -1,
+            SortBy.Path => aPath.CompareTo(bPath) == -1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == -1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == -1 || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track < b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == -1 || a?.Album == b?.Album && a?.Track < b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == -1,
@@ -1092,10 +1102,20 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <returns>True if a is greater than b, else false</returns>
     public static bool operator >(MusicFile? a, MusicFile? b)
     {
+        var aPath = a?.Path;
+        var bPath = b?.Path;
+        if (aPath != null && a!.Track != 0)
+        {
+            aPath = aPath.Replace(a.Track.ToString(), a.Track.ToString("D2"));
+        }
+        if (bPath != null && b!.Track != 0)
+        {
+            bPath = bPath.Replace(b.Track.ToString(), b.Track.ToString("D2"));
+        }
         return SortFilesBy switch
         {
-            SortBy.Filename => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Filename.CompareTo(b?.Filename) == 1,
-            SortBy.Path => a?.Track.CompareTo(b?.Track) == 1 || a?.Track == b?.Track && a?.Path.CompareTo(b?.Path) == 1,
+            SortBy.Filename => System.IO.Path.GetFileName(aPath).CompareTo(System.IO.Path.GetFileName(bPath)) == 1,
+            SortBy.Path => aPath.CompareTo(bPath) == 1,
             SortBy.Title => a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Artist => a?.Artist.CompareTo(b?.Artist) == 1 || a?.Artist == b?.Artist && a?.Album.CompareTo(b?.Album) == 1 || a?.Artist == b?.Artist &&a?.Album == b?.Album && a?.Track > b?.Track || a?.Artist == b?.Artist && a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,
             SortBy.Album => a?.Album.CompareTo(b?.Album) == 1 || a?.Album == b?.Album && a?.Track > b?.Track || a?.Album == b?.Album && a?.Track == b?.Track && a?.Title.CompareTo(b?.Title) == 1,

--- a/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
+++ b/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     <PackageReference Include="AcoustID.NET" Version="1.3.3" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.9.1" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.9.3" />
     <PackageReference Include="z440.atl.core" Version="5.6.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz" Version="5.0.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="5.0.0" />

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-06 22:11+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "Vybráno {0} z {1}"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<ponechat>"
 
@@ -78,7 +78,7 @@ msgstr "<ponechat>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -98,51 +98,51 @@ msgstr ""
 "s otiskem."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "umělecalba"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "umělec"
 
@@ -150,70 +150,70 @@ msgstr "umělec"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Vypočítávání..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "skladatel"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -221,7 +221,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -229,8 +229,8 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "vlastní"
 
@@ -239,64 +239,64 @@ msgstr "vlastní"
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "popis"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Zrušit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Zahazování značek..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Rušení nepoužitých změn..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Texty pro {0} souborů úspěšně staženy"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Stahování textů..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -304,12 +304,12 @@ msgstr "CHYBA"
 msgid "Existing Lyrics"
 msgstr "Existující texty"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exportovat zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
@@ -319,11 +319,11 @@ msgstr "Exportovat přední obal alba"
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
@@ -331,51 +331,51 @@ msgstr "Přední obal alba úspěšně exportován do souboru"
 msgid "Exported successfully to: {0}"
 msgstr "Úspěšně exportováno do: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "názevsouboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Otisk byl zkopírován do schránky."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Formátový řetězec"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Přední"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "žánr"
 
@@ -383,13 +383,13 @@ msgstr "žánr"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub repozitář"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -401,16 +401,16 @@ msgstr "Nápověda"
 msgid "Import from LRC"
 msgstr "Importovat z LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Informace"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Vložit zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
@@ -423,7 +423,7 @@ msgstr "Ponechat texty Označovače"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -431,12 +431,12 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Načítání hudebních souborů ze složky..."
 
@@ -445,11 +445,11 @@ msgstr "Načítání hudebních souborů ze složky..."
 msgid "lrc"
 msgstr "lrc"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "texty"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -457,11 +457,11 @@ msgstr "Matrix Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
@@ -469,24 +469,24 @@ msgstr "Nová vlastní vlastnost"
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Nebyly staženy žádné texty"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
@@ -494,11 +494,11 @@ msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 msgid "Nothing to export."
 msgstr "Nic k exportu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -507,29 +507,29 @@ msgstr ""
 "jeden soubor a zkuste to znovu."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Otevřít složku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Vyberte prosím formátový řetězec."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "vydavatel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
@@ -537,75 +537,75 @@ msgstr "Odebrat vlastní vlastnost"
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr "Některé hudební soubory mají stále čekající změny. Co chcete udělat?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Potvrdit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Přepnout na zadní obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Přepnout na přední obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Značka na název souboru"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označte svou hudbu"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Označovač"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Označovač otevřel některé soubory v režimu čtení."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Tento soubor nemá platný otisk"
 
@@ -617,32 +617,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Čas (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "název"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "stopa"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "celkemstop"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
@@ -654,23 +654,27 @@ msgstr "Nepodařilo se exportovat do souboru LRC."
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -684,10 +688,10 @@ msgstr ""
 "Co chcete, aby Označovač udělal s texty nalezenými v souboru LRC, které jsou "
 "v konfliktu s existujícími texty ve stejném čase?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "rok"
 
@@ -708,7 +712,7 @@ msgstr ""
 "Týká se to následujících souborů, které budou ignorovány Ozmačovačem:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Texty"
 
@@ -733,7 +737,7 @@ msgid "Language Code"
 msgstr "Kód jazyka"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Popis"
 
@@ -796,7 +800,7 @@ msgid "Sort Files By"
 msgstr "Řadit soubory podle"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Název souboru"
 
@@ -805,32 +809,32 @@ msgid "File Path"
 msgstr "Cesta k souboru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Název"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Umělec"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Rok"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Stopa"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Žánr"
 
@@ -843,7 +847,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Zachovat časové razítko změny"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Webové služby"
 
@@ -933,6 +937,7 @@ msgid "Remove Front Album Art"
 msgstr "Odebrat přední obal alba"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Přepnout obal alba"
 
@@ -942,7 +947,7 @@ msgstr "Odebrat zadní obal alba"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Spravovat texty"
 
@@ -952,12 +957,12 @@ msgid "Web Services"
 msgstr "Webové služby"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Stáhnout metadata z MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Stáhnout texty"
 
@@ -985,137 +990,137 @@ msgstr "Obal alba"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Vložit"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Odebrat"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Exportovat"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Otevřít složku s hudbou (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Otevřít"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Hlavní nabídka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Označte svou hudbu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Začněte otevřením složky s hudbou"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Zkuste jinou složku"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr ""
 "Hledat název souboru (zadejte ! pro aktivaci pokročilého vyhledávání)... "
 "https://hosted.weblate.org/js/ignore-check/19983055/?revert=1"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Vybrat všechny soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Vyberte nějaké soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Hlavní vlastnosti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Umělec alba"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Celkem stop"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Další vlastnosti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Komentář"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Skladatel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Vlastní vlastnosti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr "Vlastní vlastnosti lze upravit pouze u individuálních souborů."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Otisk"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Zkopírovat otisk do schránky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Přepnout panel značek"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Znovu načíst složku s hudbou (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Akce značky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Použít změny u značky (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-09 03:21+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} von {1} ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist%-%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -78,7 +78,7 @@ msgstr "<behalten>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -99,51 +99,51 @@ msgstr ""
 "Verbindung mit dem Fingerabdruck übermitteln."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "albumkünstler"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "künstler"
 
@@ -151,85 +151,85 @@ msgstr "künstler"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Hinten"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Berechne..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "Komponist"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "andere"
 
@@ -238,64 +238,64 @@ msgstr "andere"
 msgid "Custom"
 msgstr "Andere"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "Beschreibung"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Tags werden verworfen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Nicht angewendete Änderungen werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Songtexte für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Songtexte werden heruntergeladen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -303,12 +303,12 @@ msgstr "FEHLER"
 msgid "Existing Lyrics"
 msgstr "Existierende Songtexte"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Rückseite des Albumcovers exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Vorderseite des Albumcovers exportieren"
@@ -318,11 +318,11 @@ msgstr "Vorderseite des Albumcovers exportieren"
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Rückseite des Albumcovers erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
@@ -330,51 +330,51 @@ msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 msgid "Exported successfully to: {0}"
 msgstr "Erfolgreich exportiert nach: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim Exportieren des Rückseite des Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim Exportieren der Vorderseite des Albumcovers zur Datei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Formatvorlage"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Vorne"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "genre"
 
@@ -382,13 +382,13 @@ msgstr "genre"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -400,16 +400,16 @@ msgstr "Hilfe"
 msgid "Import from LRC"
 msgstr "Von LRC importieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Info"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Rückseite des Albumcovers einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Vorderseite des Albumcovers einfügen"
@@ -422,19 +422,19 @@ msgstr "Tagger's Songtexte behalten"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Lade Musikdateien von Ordner..."
 
@@ -443,11 +443,11 @@ msgstr "Lade Musikdateien von Ordner..."
 msgid "lrc"
 msgstr "lrc"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "Songtext"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -455,11 +455,11 @@ msgstr "Matrix-Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
@@ -467,24 +467,24 @@ msgstr "Neue Andere Eigenschaft"
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Es wurden keine Songtexte heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
@@ -492,11 +492,11 @@ msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 msgid "Nothing to export."
 msgstr "Nichts zu exportieren."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -505,29 +505,29 @@ msgstr ""
 "nur eine Datei aus und versuche es erneut."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Bitte Formatvorlage auswählen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
@@ -535,76 +535,76 @@ msgstr "Entferne Andere Eigenschaft"
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 "Einige Musikdateien haben ungespeicherte Änderungen. Was möchtest du tun?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Zur Rückseite wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Zur Vorderseite wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Tag zu Dateiname"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tagge deine Musik"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger hat manche Dateien im schreibgeschützen Modus geöffnet."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Die Datei hat keinen gültigen Fingerabdruck"
 
@@ -616,32 +616,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zeitstempel (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "songanzahl"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
@@ -653,23 +653,27 @@ msgstr "Export nach LRC fehlgeschlagen."
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -683,10 +687,10 @@ msgstr ""
 "Wie soll Tagger mit Songtexten aus der LRC-Datei umgehen, die mit "
 "existierenden Songtexten mit demselben Zeitstempel in Konflikt stehen?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "Jahr"
 
@@ -707,7 +711,7 @@ msgstr ""
 "Diese Dateien sind betroffen und werden von Tagger ignoriert:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Songtext"
 
@@ -732,7 +736,7 @@ msgid "Language Code"
 msgstr "Sprachcode"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -795,7 +799,7 @@ msgid "Sort Files By"
 msgstr "Dateien sortieren nach"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Dateiname"
 
@@ -804,32 +808,32 @@ msgid "File Path"
 msgstr "Dateipfad"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Titel"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Künstler"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Jahr"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Track"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Genre"
 
@@ -842,7 +846,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Änderungs-Zeitstempel erhalten"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Web-Dienste"
 
@@ -932,6 +936,7 @@ msgid "Remove Front Album Art"
 msgstr "Vorderseite des Albumcovers entfernen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Albumcover wechseln"
 
@@ -941,7 +946,7 @@ msgstr "Rückseite des Albumcovers entfernen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Songtexte Verwalten"
 
@@ -951,12 +956,12 @@ msgid "Web Services"
 msgstr "Web-Dienste"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Metadaten von MusicBrainz herunterladen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Songtexte herunterladen"
 
@@ -984,137 +989,137 @@ msgstr "Albumcover"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Einfügen"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Entfernen"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Exportieren"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Musikordner öffnen (Strg+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Öffnen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Tagge Deine Musik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Öffne einen Ordner mit Musik um loszulegen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Versuche einen anderen Ordner"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Suche nach Dateiname (schreibe ! um erweiterte Suche zu aktivieren)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Alle Dateien auswählen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Wähle Dateien aus"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Haupteigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Album-Interpret"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Song-Anzahl"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Zusätzliche Eigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Kommentar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Schläge pro Minute"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Komponist"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Verlag"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Andere Eigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Benutzerdefinierte Eigenschaften können nur für individuelle Dateien "
 "bearbeitet werden."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Dateieigenschaften"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Fingerabdruck in die Zwischenablage kopieren"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Tag-Bereich zeigen/verstecken"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Musikordner neu laden (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Tag-Aktionen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Änderungen auf Tag anwenden (Strg+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-09 03:21+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} de {1} seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<mantener>"
 
@@ -78,7 +78,7 @@ msgstr "<mantener>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -99,51 +99,51 @@ msgstr ""
 "la firma."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "álbum"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "artistadelálbum"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "artista"
 
@@ -151,85 +151,85 @@ msgstr "artista"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Calculando..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "compositor"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "personalizado"
 
@@ -238,64 +238,64 @@ msgstr "personalizado"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "descripción"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Descartar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Descartando las etiquetas..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Descartando cambios no aplicados..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Letras descargadas para {0} archivos correctamente"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Descargando las letras..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -303,12 +303,12 @@ msgstr "ERROR"
 msgid "Existing Lyrics"
 msgstr "Letras ya existentes"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exportar contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
@@ -318,11 +318,11 @@ msgstr "Exportar portada del álbum"
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
@@ -330,51 +330,51 @@ msgstr "Exportada correctamente la portada del álbum al archivo"
 msgid "Exported successfully to: {0}"
 msgstr "Exportado con éxito a: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "nombredearchivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Cadena de formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Frontal"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "género"
 
@@ -382,13 +382,13 @@ msgstr "género"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -400,16 +400,16 @@ msgstr "Ayuda"
 msgid "Import from LRC"
 msgstr "Importar desde LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Información"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Insertar la contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
@@ -422,19 +422,19 @@ msgstr "Mantener los textos de Tagger"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Cargando archivos de música desde la carpeta…"
 
@@ -443,11 +443,11 @@ msgstr "Cargando archivos de música desde la carpeta…"
 msgid "lrc"
 msgstr "lrc"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "letras"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
@@ -455,11 +455,11 @@ msgstr "Chat de Matrix"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
@@ -467,24 +467,24 @@ msgstr "Propiedad personalizada nueva"
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "No se ha descargado ninguna letra"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
@@ -494,11 +494,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr "Nada para exportar."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "Vale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -507,29 +507,29 @@ msgstr ""
 "archivo e inténtelo de nuevo."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Seleccione una cadena de formato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "editor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
@@ -537,20 +537,20 @@ msgstr "Eliminar propiedad personalizada"
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -558,56 +558,56 @@ msgstr ""
 "Algunos archivos de música aún tienen cambios pendientes de aplicar. ¿Qué le "
 "gustaría hacer?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Enviar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Cambiar a la contraportada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Cambiar a la portada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Etiqueta a nombre de archivo"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Etiqueta tu música"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha abierto algunos archivos en modo de solo lectura."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Este archivo no tiene una huella digital válida"
 
@@ -619,32 +619,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Marca de tiempo (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "pista"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "pistatotal"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
@@ -656,23 +656,27 @@ msgstr "No se puede exportar al LRC."
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -686,10 +690,10 @@ msgstr ""
 "¿Qué quiere que haga Tagger con las letras encontradas en el archivo LRC que "
 "entran en conflicto con letras existentes de la misma marca de tiempo?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "año"
 
@@ -711,7 +715,7 @@ msgstr ""
 "Tagger:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Letras"
 
@@ -736,7 +740,7 @@ msgid "Language Code"
 msgstr "Código de idioma"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Descripción"
 
@@ -799,7 +803,7 @@ msgid "Sort Files By"
 msgstr "Ordenar archivos por"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Nombre del archivo"
 
@@ -808,32 +812,32 @@ msgid "File Path"
 msgstr "Ruta del archivo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Título"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Artista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Álbum"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Año"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Pista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Género"
 
@@ -846,7 +850,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Conservar fecha de modificación"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Servicios web"
 
@@ -939,6 +943,7 @@ msgid "Remove Front Album Art"
 msgstr "Quitar la portada del álbum"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Cambiar portada del álbum"
 
@@ -948,7 +953,7 @@ msgstr "Quitar la contraportada del álbum"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Gestionar letras"
 
@@ -958,12 +963,12 @@ msgid "Web Services"
 msgstr "Servicios web"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Descargar metadatos de MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Descargar las letras"
 
@@ -991,137 +996,137 @@ msgstr "Portada"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Insertar"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Eliminar"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Exportar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Abrir carpeta de música (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Abrir"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Etiquetar Tu Música"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Abra una carpeta con música para empezar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Pruebe con otra carpeta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Buscar por nombre de archivo (escriba ! para búsqueda avanzada)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Seleccionar todos los archivos"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Seleccione algunos archivos"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Propiedades principales"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Artista del álbum"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Pista total"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Propiedades adicionales"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Comentario"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Compositor"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Editor"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Propiedades personalizadas"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Las propiedades personalizadas sólo pueden editarse para los archivos "
 "individuales."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Propiedades del archivo"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copiar firma al portapapeles"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Conmutar panel de etiquetas"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Recargar carpeta de música (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Acciones de etiqueta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-06 22:11+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
-"Language-Team: Finnish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/fi/>\n"
+"Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/fi/>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0}/{1} valittu"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -78,7 +78,7 @@ msgstr "<säilytä>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -91,51 +91,51 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "albumi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "esittäjä"
 
@@ -143,85 +143,85 @@ msgstr "esittäjä"
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Lasketaan..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Peru"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "säveltäjä"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Muunnettiin {0} tiedostonimi tunnisteeksi"
 msgstr[1] "Muunnettiin {0} tiedostonimeä tunnisteiksi"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Muunnettiin {0} tunniste tiedostonimeksi"
 msgstr[1] "Muunnettiin {0} tunnistetta tiedostonimiksi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr ""
 
@@ -230,64 +230,64 @@ msgstr ""
 msgid "Custom"
 msgstr "Mukautettu"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "kuvaus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Hylkää"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Hylätään tagit..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Hylätään toteuttamattomat muutokset..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} tiedostolle ladattiin sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Ladataan sanoituksia..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -295,12 +295,12 @@ msgstr "VIRHE"
 msgid "Existing Lyrics"
 msgstr "Olemassa olevat sanoitukset"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Vie albumin takakuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
@@ -311,11 +311,11 @@ msgstr "Vie albumin etukuvitus"
 msgid "Export to LRC"
 msgstr "Vie"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -323,51 +323,51 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Viety onnistuneesti: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Tiedostonimi tunnisteeksi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "tiedostonimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Sormenjälki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Etu"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -375,13 +375,13 @@ msgstr "tyylilaji"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -393,16 +393,16 @@ msgstr "Ohje"
 msgid "Import from LRC"
 msgstr "Tuo LRC:stä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr ""
@@ -415,19 +415,19 @@ msgstr ""
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
@@ -436,12 +436,12 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "lrc"
 msgstr "Sanoitukset"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
@@ -449,11 +449,11 @@ msgstr "Matrix-keskustelu"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
@@ -461,24 +461,24 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Sanoituksia ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Metatietoja ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -486,40 +486,40 @@ msgstr ""
 msgid "Nothing to export."
 msgstr "Ei mitään vietävää."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
@@ -527,75 +527,75 @@ msgstr "Poista mukautettu ominaisuus"
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Lähetetään tietoja AcoustId:hen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Vaihda takakanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Vaihda etukanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Lisää tagit musiikkiin"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Tällä tiedostolla ei ole kelvollista sormenjälkeä"
 
@@ -607,33 +607,33 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "nimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
@@ -646,22 +646,26 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
@@ -674,10 +678,10 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "vuosi"
 
@@ -696,7 +700,7 @@ msgid ""
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Sanoitukset"
 
@@ -721,7 +725,7 @@ msgid "Language Code"
 msgstr "Kielikoodi"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -784,7 +788,7 @@ msgid "Sort Files By"
 msgstr "Järjestä tiedostot"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Tiedostonimi"
 
@@ -793,32 +797,32 @@ msgid "File Path"
 msgstr "Tiedostopolku"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Nimi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Esittäjä"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Albumi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Vuosi"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Kappale"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Tyylilaji"
 
@@ -831,7 +835,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Säilytä muokkauksen aikaleima"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Verkkopalvelut"
 
@@ -916,6 +920,7 @@ msgid "Remove Front Album Art"
 msgstr "Poista albumin etukannen kuvitus"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Vaihda albumin kuvitus"
 
@@ -925,7 +930,7 @@ msgstr "Poista albumin takakannen kuvitus"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Hallitse sanoituksia"
 
@@ -935,12 +940,12 @@ msgid "Web Services"
 msgstr "Verkkopalvelut"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Lataa MusicBrainz-metatiedot"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Lataa sanoitukset"
 
@@ -968,135 +973,135 @@ msgstr "Albumin kuvitus"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Syötä"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Poista"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Vie"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Avaa musiikkikansio (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Avaa"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Päävalikko"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Lisää tagit musiikkiin"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Aloita avaamalla musiikkia sisältävä kansio"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Musiikkitiedostoja ei löytynyt"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Kokeile eri kansiota"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Etsi tiedostonimeä (kirjoita ! avataksesi edistyneen haun)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Valitse kaikki tiedostot"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Valitse joitain tiedostoja"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Keskeisimmät ominaisuudet"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Albumin esittäjä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Kappaleita yhteensä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Lisäominaisuudet"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Kommentti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Säveltäjä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Mukautettu ominaisuus"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Tiedoston ominaisuudet"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopioi sormenjälki leikepöydälle"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Lataa musiikkikansio uudelleen(F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-09 03:21+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} sur {1} sélectionné(s)"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artiste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%titre%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%titre%- %artiste%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%piste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -78,7 +78,7 @@ msgstr "<conserver>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -99,51 +99,51 @@ msgstr ""
 "associées à l’empreinte à la place."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "artiste de l’album"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "artiste"
 
@@ -151,85 +151,85 @@ msgstr "artiste"
 msgid "B"
 msgstr "o"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Dos"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Calcul…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "compositeur"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "personnalisé"
 
@@ -238,64 +238,64 @@ msgstr "personnalisé"
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "description"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Abandonner"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Abandon des balises…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Abandon des changements..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Paroles téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Téléchargement des paroles…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -303,12 +303,12 @@ msgstr "ERREUR"
 msgid "Existing Lyrics"
 msgstr "Paroles existantes"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Exporter le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
@@ -318,12 +318,12 @@ msgstr "Exporter la face de la pochette d’album"
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
@@ -332,52 +332,52 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Exporté avec succès vers : {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "nom de fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Empreinte copiée vers le presse-papiers."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Chaîne de format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Face"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "genre"
 
@@ -385,13 +385,13 @@ msgstr "genre"
 msgid "GiB"
 msgstr "Gio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -403,16 +403,16 @@ msgstr "Aide"
 msgid "Import from LRC"
 msgstr "Importer depuis LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Informations"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Insérer le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
@@ -425,19 +425,19 @@ msgstr "Conserver les paroles de Tagger"
 msgid "KiB"
 msgstr "kio"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Chargement des musiques depuis le dossier…"
 
@@ -446,11 +446,11 @@ msgstr "Chargement des musiques depuis le dossier…"
 msgid "lrc"
 msgstr "lrc"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "paroles"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
@@ -458,11 +458,11 @@ msgstr "Discussion Matrix"
 msgid "MiB"
 msgstr "Mio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
 
@@ -470,24 +470,24 @@ msgstr "Nouvelle propriété personnalisée"
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Aucune parole n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
@@ -496,11 +496,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr "Rien à exporter."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "OK"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -509,29 +509,29 @@ msgstr ""
 "fichier et essayez à nouveau."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Sélectionnez un format."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Supprimer la propriété personnalisée"
 
@@ -539,20 +539,20 @@ msgstr "Supprimer la propriété personnalisée"
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -560,56 +560,56 @@ msgstr ""
 "Des fichiers de musiques ont encore des modifications en attente d’être "
 "appliquées. Que souhaitez-vous faire ?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Envoyer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Dos de la couverture"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Face de la couverture"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Balise vers nom de fichier"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associez des balises à vos musiques"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger a ouvert des fichiers en mode lecture seule."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Ce fichier n’a pas d’empreinte valide"
 
@@ -621,32 +621,32 @@ msgstr "Tio"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Horodatage (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "piste"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "pistestotal"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
@@ -658,23 +658,27 @@ msgstr "Impossible d’exporter vers LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -688,10 +692,10 @@ msgstr ""
 "Que souhaitez-vous que Tagger fasse avec les paroles trouvées dans le "
 "fichier LRC, en conflit avec les paroles existantes pour le même horodatage ?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "année"
 
@@ -713,7 +717,7 @@ msgstr ""
 "Tagger :"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Paroles"
 
@@ -738,7 +742,7 @@ msgid "Language Code"
 msgstr "Code de langage"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Description"
 
@@ -801,7 +805,7 @@ msgid "Sort Files By"
 msgstr "Trier les fichiers par"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Nom du fichier"
 
@@ -810,32 +814,32 @@ msgid "File Path"
 msgstr "Chemin d’accès du fichier"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Titre"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Artiste"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Année"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Morceau"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Genre"
 
@@ -848,7 +852,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Conserver l’horodatage de modification"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Services Web"
 
@@ -941,6 +945,7 @@ msgid "Remove Front Album Art"
 msgstr "Retirer la face de la pochette d’album"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Échanger la couverture de l’album"
 
@@ -950,7 +955,7 @@ msgstr "Retirer le dos de la pochette d’album"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Gérer les paroles"
 
@@ -960,12 +965,12 @@ msgid "Web Services"
 msgstr "Services Web"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Télécharger les paroles"
 
@@ -993,138 +998,138 @@ msgstr "Couverture de l’album"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Insérer"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Supprimer"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Exporter"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Ouvrir un dossier de musiques (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Ouvrir"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Étiquetez vos musiques"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Ouvrez un dossier contenant des musiques pour commencer"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Essayez un autre dossier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr ""
 "Rechercher un nom de fichier (tapez ! pour activer la recherche avancée)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Sélectionner tous les fichiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Sélectionnez des fichiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Propriétés principales"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Artiste de l'album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Total des pistes"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Propriétés additionnelles"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Commentaire"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Battements par minute"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Compositeur"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Maison de disques"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Propriétés personnalisées"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Les propriétés personnalisées ne peuvent être éditées que pour des fichiers "
 "individuels."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Propriétés du fichier"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Empreinte"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copier l’empreinte vers le presse-papiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Basculer le volet des balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Recharger le dossier de musiques (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Actions relatives aux balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,49 +20,43 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%אמן% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%כותרת% - %אמן%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%רצועה% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -71,7 +65,13 @@ msgstr "%רצועה% - %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -79,7 +79,7 @@ msgstr "<לשמור>"
 msgid "0 MiB"
 msgstr "0 מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -98,51 +98,51 @@ msgstr ""
 "אם אין ברשותך, המתייג ישלח את נתוני התגיות שלך יחד עם טביעת האצבע במקום."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "אלבום"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "אמן האלבום"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "אמן"
 
@@ -150,70 +150,70 @@ msgstr "אמן"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "ביטול"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "מלחין"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub ‏❤️ {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -222,7 +222,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -231,8 +231,8 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -241,66 +241,66 @@ msgstr "מותאם אישית"
 msgid "Custom"
 msgstr "מותאם אישית"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "תיאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "השלכה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "השלכת שינויים שלא הוחלו…"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -308,12 +308,12 @@ msgstr "תקלה"
 msgid "Existing Lyrics"
 msgstr "מילות שיר קיימות"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
@@ -323,11 +323,11 @@ msgstr "ייצוא עטיפת אלבום קדמית"
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
@@ -335,51 +335,51 @@ msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 msgid "Exported successfully to: {0}"
 msgstr "הייצוא בוצע בהצלחה אל: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "קדמי"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "סוגה"
 
@@ -387,13 +387,13 @@ msgstr "סוגה"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -405,16 +405,16 @@ msgstr "עזרה"
 msgid "Import from LRC"
 msgstr "ייבוא מ־LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "מידע"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
@@ -427,7 +427,7 @@ msgstr "לשמור מילות שיר מהמתייג"
 msgid "KiB"
 msgstr "קי״ב"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -436,12 +436,12 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
@@ -450,11 +450,11 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "lrc"
 msgstr "מילות שיר"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -462,11 +462,11 @@ msgstr "צ׳אט במטריקס"
 msgid "MiB"
 msgstr "מבי״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
@@ -474,24 +474,24 @@ msgstr "מאפיין מותאם חדש"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -499,11 +499,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr "אין מה לייצא."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "אישור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -512,29 +512,29 @@ msgstr ""
 "שוב."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "יש לבחור תבנית למחרוזת."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
@@ -542,75 +542,75 @@ msgstr "הסרת מאפיין מותאם"
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של שינויים עליהם. מה ברצונך לעשות?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "החלפה לכיסוי קדמי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "תג לשם קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "המתייג"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "המתייג פתח כמה קבצים במצב קריאה בלבד."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "לקובץ זה אין טביעת אצבע תקפה"
 
@@ -622,32 +622,32 @@ msgstr "טבי״ב"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "חותמת זמן (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
@@ -661,23 +661,27 @@ msgstr "לא ניתן לייצא ל־LRC."
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -691,10 +695,10 @@ msgstr ""
 "מה ברצונך שהמתייג יעשה עם מילות שיר שנמצאו בקובץ LRC שמתנגשות עם מילות שיר "
 "קיימות עם אותה חותמת זמן?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "שנה"
 
@@ -715,7 +719,7 @@ msgstr ""
 "שמושפעים מכך:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "מילות שיר"
 
@@ -740,7 +744,7 @@ msgid "Language Code"
 msgstr "שפת קוד"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "תיאור"
 
@@ -803,7 +807,7 @@ msgid "Sort Files By"
 msgstr "מיון פריטים לפי"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "שם קובץ"
 
@@ -812,32 +816,32 @@ msgid "File Path"
 msgstr "נתיב הקובץ"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "כותרת"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "אמן"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "אלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "שנה"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "רצועה"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "סוגה"
 
@@ -850,7 +854,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "שמירת חותמת זמן השינוי"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "שרת אינטרנט"
 
@@ -940,6 +944,7 @@ msgid "Remove Front Album Art"
 msgstr "הסרת עטיפה קדמית לאלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "החלפת עטיפת אלבום"
 
@@ -949,7 +954,7 @@ msgstr "הסרת עטיפה אחורית לאלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "ניהול מילות שיר"
 
@@ -959,12 +964,12 @@ msgid "Web Services"
 msgstr "שרתי אינטרנט"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #, fuzzy
 msgid "Download Lyrics"
 msgstr "ניהול מילות שיר"
@@ -993,136 +998,136 @@ msgstr "עטיפת אלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "הוספה"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "הסרה"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "ייצוא"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "פתיחת תיקיית מוזיקה (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "פתיחה"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "תפריט ראשי"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "תיוג המוזיקה שלך"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "לא נמצאו קובצי מוזיקה"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "יש לנסות תיקייה אחרת"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "חיפוש שם קובץ (יש להזין ! לחיפוש מתקדם)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "חיפוש מידע מתקדם"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 #, fuzzy
 msgid "Select All Files"
 msgstr "יש לבחור קבצים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "יש לבחור קבצים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "מאפיינים ראשיים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "אמן האלבום"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "מספר רצועות כולל"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "מאפיינים נוספים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "הערה"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "פעימות לדקה"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "מלחין"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "מוציא לאור"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "מאפיינים מותאמים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "מאפייני קובץ"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "טביעת אצבע"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "העתקת טביעת אצבע ללוח הגזירים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "הצגה/הסתרת סרגל התיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "טעינת תיקיית המוזיקה מחדש (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "פעולות תיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,53 +16,47 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%izvođač%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%naslov%- %izvođač%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -71,7 +65,13 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -79,7 +79,7 @@ msgstr "<zadrži>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -99,51 +99,51 @@ msgstr ""
 "koje su povezane s digitalnim otiskom."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "izvođač albuma"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "izvođač"
 
@@ -151,73 +151,73 @@ msgstr "izvođač"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Odustani"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "skladatelj"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Doprinositelji na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -225,7 +225,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -233,8 +233,8 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -243,67 +243,67 @@ msgstr "prilagođeno"
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "opis"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Odbaci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Spremanje oznaka …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Odbacivanje neprimjenjenih promjena …"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -311,12 +311,12 @@ msgstr "GREŠKA"
 msgid "Existing Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Izvezi stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
@@ -327,11 +327,11 @@ msgstr "Izvezi prednju sliku albuma"
 msgid "Export to LRC"
 msgstr "Izvezi"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
@@ -339,51 +339,51 @@ msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "ime datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Digitalni otisak je kopiran u međuspremnik."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Prednja strana"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "žanr"
 
@@ -391,13 +391,13 @@ msgstr "žanr"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -409,16 +409,16 @@ msgstr "Pomoć"
 msgid "Import from LRC"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Umetni stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
@@ -431,7 +431,7 @@ msgstr ""
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -439,12 +439,12 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
@@ -453,11 +453,11 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "lrc"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -465,11 +465,11 @@ msgstr "Matrix Chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "ID oznaka MusicBrainz snimke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
@@ -477,24 +477,24 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -502,11 +502,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "U redu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -515,29 +515,29 @@ msgstr ""
 "i pokušaj ponovo."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Odaberi jedan format izraza."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
@@ -546,20 +546,20 @@ msgstr "Ukloni prilagođeno svojstvo"
 msgid "Remove Lyric"
 msgstr "Ukloni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -567,56 +567,56 @@ msgstr ""
 "Neke glazbene datoteke još uvijek sadrže promjene koje još nisu "
 "primijenjene. Želiš li primijeniti te promjene?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Pošalji"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Prikaži stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Prikaži prednju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Oznaka u ime datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označite svoju glazbu"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger je otvorio neke datoteke u modusu „samo čitanje”."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -628,32 +628,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "naslov"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "broj pjesama"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
@@ -667,23 +667,27 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -695,10 +699,10 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "godina"
 
@@ -719,7 +723,7 @@ msgstr ""
 "Sljedeće datoteke su pogođene i Tagger će ih zanemariti:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr ""
 
@@ -744,7 +748,7 @@ msgid "Language Code"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Opis"
 
@@ -807,7 +811,7 @@ msgid "Sort Files By"
 msgstr "Redoslijed datoteka"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Ime datoteke"
 
@@ -817,32 +821,32 @@ msgid "File Path"
 msgstr "Staza do datoteke"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Naslov"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Izvođač"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Godina"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Pjesma"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Žanr"
 
@@ -855,7 +859,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Sačuvaj vremensku oznaku modifikacije"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Web usluge"
 
@@ -947,6 +951,7 @@ msgid "Remove Front Album Art"
 msgstr "Ukloni prednju sliku albuma"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Zamijeni sliku albuma"
 
@@ -956,7 +961,7 @@ msgstr "Ukloni stražnju sliku albuma"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr ""
 
@@ -966,12 +971,12 @@ msgid "Web Services"
 msgstr "Web usluge"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr ""
 
@@ -999,136 +1004,136 @@ msgstr "Slika albuma"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Umetni"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Ukloni"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Izvezi"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Otvori mapu glazbe (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Otvori"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Glavni izbornik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Označi svoju glazbu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Započni otvaranjem mape s glazbom"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Pokušaj koristiti jednu drugu mapu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 #, fuzzy
 msgid "Select All Files"
 msgstr "Odaberi neke datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Odaberi neke datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Glavna svojstva"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Izvođač albuma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Broj pjesama"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Dodatna svojstva"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Komentar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "BPM"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Skladatelj"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Izdavač"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Prilagođena svojstva"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Svojstva datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Digitalni otisak"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopiraj digitalni otisak u međuspremnik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Uklj./Isklj. ploču oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Ponovo učitaj mapu glazbe (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Radnje oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-08-24 10:19+0000\n"
 "Last-Translator: Federico Marchetti <marchetti.federico@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} di {1} selezionato"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -78,7 +78,7 @@ msgstr "<tieni>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -99,51 +99,51 @@ msgstr ""
 "associati alla firma di questo brano."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "artistaalbum"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un Id non valido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Vuoi applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "artista"
 
@@ -151,85 +151,85 @@ msgstr "artista"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Elaborazione in corso..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "commento"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "compositore"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Hanno collaborato su GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file è stato convertito con successo"
 msgstr[1] "{0} nomi di file sono stati convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta è stata convertita in nome di file con successo"
 msgstr[1] "{0} etichette sono state convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -238,64 +238,64 @@ msgstr "personalizzato/a"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "descrizione"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Scarta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Cancellazione delle etichette in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Annullamento modifiche non applicate..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "I testi per {0} sono stati scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "I metadati per {0} sono stati scaricati con successo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Download dei testi in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Download dei metadati da MusicBrainz in corso..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -303,12 +303,12 @@ msgstr "ERRORE"
 msgid "Existing Lyrics"
 msgstr "Testo esistente"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Esporta copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
@@ -318,11 +318,11 @@ msgstr "Esporta copertina (fronte)"
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
@@ -330,51 +330,51 @@ msgstr "La copertina anteriore è stata esportata correttamente"
 msgid "Exported successfully to: {0}"
 msgstr "Esportazione completata con successo su: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo fallito su MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "È avvenuto un errore durante l'esportazione della copertina anteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Nome del file a etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "nomefile"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma è stata copiata negli appunti."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Stringa di formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Fronte"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "genere"
 
@@ -382,13 +382,13 @@ msgstr "genere"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -400,16 +400,16 @@ msgstr "Aiuto"
 msgid "Import from LRC"
 msgstr "Importa da LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Info"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Inserisci copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
@@ -422,19 +422,19 @@ msgstr "Mantieni il testo da Tagger"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Brano {0} caricato."
 msgstr[1] "Brani {0} caricati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Caricamento dei brani dalla cartella..."
 
@@ -443,11 +443,11 @@ msgstr "Caricamento dei brani dalla cartella..."
 msgid "lrc"
 msgstr "lrc"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "testo"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
@@ -455,11 +455,11 @@ msgstr "Chat Matrix"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
@@ -467,24 +467,24 @@ msgstr "Nuova proprietà personalizzata"
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovato alcun AcoustId per il file"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Nessun testo scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
@@ -493,11 +493,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr "Nulla da esportare."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "Ok"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -506,29 +506,29 @@ msgstr ""
 "solo brano ed invia nuovamente i dati."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Seleziona un formato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
@@ -536,76 +536,76 @@ msgstr "Rimuovi proprietà personalizzata"
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 "Sono presenti alcune modifiche in attesa di essere applicate. Cosa vuoi fare?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Invia"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Scambia a copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Scambia a copertina anteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Etichetta a nome di file"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associa un'etichetta ai tuoi brani"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger ha aperto dei file in sola lettura."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Questo file non ha una firma valida"
 
@@ -617,32 +617,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Istante temporale (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "traccia"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "traccetotali"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Federico Marchetti"
 
@@ -654,23 +654,27 @@ msgstr "Impossibile salvare su LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossibile importare da LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Impossibile caricare l'immagine"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossibile salvare {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossibile salvare {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossibile inviare dati ad AcoustId. Controlla la chiave dell'API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -684,10 +688,10 @@ msgstr ""
 "Cosa deve fare Tagger con il testo trovato nel file LRC che va in conflitto "
 "con il testo già esistente per lo stesso istante temporale?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "anno"
 
@@ -708,7 +712,7 @@ msgstr ""
 "ignorati da Tagger:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Testo"
 
@@ -733,7 +737,7 @@ msgid "Language Code"
 msgstr "Codice della lingua"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Descrizione"
 
@@ -796,7 +800,7 @@ msgid "Sort Files By"
 msgstr "Ordina file per"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Nome del file"
 
@@ -805,32 +809,32 @@ msgid "File Path"
 msgstr "Percorso del file"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Titolo"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Artista"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Anno"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Numero della traccia"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Genere"
 
@@ -843,7 +847,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Mantieni l'istante temporale di modifica"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Servizi Web"
 
@@ -934,6 +938,7 @@ msgid "Remove Front Album Art"
 msgstr "Rimuovi la copertina anteriore"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Cambia la copertina"
 
@@ -943,7 +948,7 @@ msgstr "Rimuovi la copertina posteriore"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Gestisci testo"
 
@@ -953,12 +958,12 @@ msgid "Web Services"
 msgstr "Servizi Web"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Scarica i metadati da MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Scarica testo"
 
@@ -986,135 +991,135 @@ msgstr "Copertina"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Inserisci"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Rimuovi"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Esporta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Apri la cartella contenente i brani (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Apri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Menù principale"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Etichetta la tua musica"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Apri una cartella contenente dei brani per iniziare"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Prova una cartella diversa"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Cerca un brano (inserisci ! per attivare la ricerca avanzata)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Seleziona tutti i file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Seleziona dei file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Proprietà principali"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Artista dell'album"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Numero delle tracce totali"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Proprietà in più"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Commento"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Battiti al minuto"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Compositore"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Etichetta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Proprietà personalizzate del file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Proprietà del file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copia l'impronta negli appunti"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Commuta i pannelli delle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Ricarica la cartella contenente i brani (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Azioni sulle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -18,49 +18,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title% - %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -69,7 +63,13 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<behouden>"
 
@@ -77,7 +77,7 @@ msgstr "<behouden>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -99,51 +99,51 @@ msgstr ""
 "controlesom versturen."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "albumartiest"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "artiest"
 
@@ -151,85 +151,85 @@ msgstr "artiest"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Achterkant"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "componist"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "aangepast"
 
@@ -238,66 +238,66 @@ msgstr "aangepast"
 msgid "Custom"
 msgstr "Aangepast"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "omschrijving"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Verwerpen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Bezig met opslaan van tags…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Bezig met verwerpen van wijzigingen…"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -306,13 +306,13 @@ msgstr "FOUT"
 msgid "Existing Lyrics"
 msgstr "Songtekst beheren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 #, fuzzy
 msgid "Export Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 #, fuzzy
 msgid "Export Front Album Art"
@@ -324,12 +324,12 @@ msgstr "Albumhoes toevoegen"
 msgid "Export to LRC"
 msgstr "Exporteren"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
@@ -338,52 +338,52 @@ msgstr "Er zijn %d tags omgezet in bestandsnamen"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #, fuzzy
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "bestandsnaam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Voorkant"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "genre"
 
@@ -391,13 +391,13 @@ msgstr "genre"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -409,17 +409,17 @@ msgstr "Hulp"
 msgid "Import from LRC"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Info"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 #, fuzzy
 msgid "Insert Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 #, fuzzy
 msgid "Insert Front Album Art"
@@ -433,19 +433,19 @@ msgstr ""
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 #, fuzzy
 msgid "Loading music files from folder..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -455,12 +455,12 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "lrc"
 msgstr "Songtekst"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix-chat"
 
@@ -468,11 +468,11 @@ msgstr "Matrix-chat"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr ""
 
@@ -480,24 +480,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -505,11 +505,11 @@ msgstr ""
 msgid "Nothing to export."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "Oké"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 #, fuzzy
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -519,29 +519,29 @@ msgstr ""
 "bestand en probeer het opnieuw."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Kies een opmaakmethode."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr ""
 
@@ -549,20 +549,20 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 #, fuzzy
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
@@ -571,59 +571,59 @@ msgstr ""
 "Enkele muziekbestanden zijn gewijzigd, maar nog niet opgeslagen. Wilt u dat "
 "nu doen of de wijzigingen verwerpen?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Inzenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 #, fuzzy
 msgid "Tag to File Name"
 msgstr "Tag naar bestandsnaam"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tag uw muziek"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -635,32 +635,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "nummer"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "aantalnummers"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
@@ -672,24 +672,28 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -701,10 +705,10 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "jaar"
 
@@ -727,7 +731,7 @@ msgstr ""
 "nu doen of de wijzigingen verwerpen?"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Songtekst"
 
@@ -752,7 +756,7 @@ msgid "Language Code"
 msgstr "Taalcode"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -815,7 +819,7 @@ msgid "Sort Files By"
 msgstr "Bestanden sorteren op"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Bestandsnaam"
 
@@ -824,32 +828,32 @@ msgid "File Path"
 msgstr "Bestands­pad"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Titel"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Artiest"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Album"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Jaar"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Volgnummer"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Genre"
 
@@ -863,7 +867,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Bewerktijdstip niet aanpassen"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Online-diensten"
 
@@ -952,6 +956,7 @@ msgid "Remove Front Album Art"
 msgstr "Albumhoes verwijderen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 #, fuzzy
 msgid "Switch Album Art"
 msgstr "Albumartiest"
@@ -963,7 +968,7 @@ msgstr "Albumhoes verwijderen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Songtekst beheren"
 
@@ -973,12 +978,12 @@ msgid "Web Services"
 msgstr "Web­diensten"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz-metagegevens ophalen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #, fuzzy
 msgid "Download Lyrics"
 msgstr "Songtekst beheren"
@@ -1007,141 +1012,141 @@ msgstr "Album­omslag"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Invoegen"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Verwijderen"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Exporteren"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Muziekmap openen (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Openen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Hoofdmenu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 #, fuzzy
 msgid "Open a folder with music to get started"
 msgstr ""
 "Open een map met muziekbestanden of sleep een map hierheen om aan de slag te "
 "gaan."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 #, fuzzy
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 #, fuzzy
 msgid "Select All Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 #, fuzzy
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Hoofd­eigenschappen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Albumartiest"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Aantal nummers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Extra eigenschappen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Opmerking"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Componist"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Aangepaste eigenschappen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Bestands­eigenschappen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Controlesom"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Muziekmap herladen (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Tagacties"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-08-17 05:59+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -16,53 +16,47 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%исполнитель%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%название%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%название%- %исполнитель%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -71,7 +65,13 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<keep>"
 
@@ -79,7 +79,7 @@ msgstr "<keep>"
 msgid "0 MiB"
 msgstr "0 МиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -100,51 +100,51 @@ msgstr ""
 "отпечатком."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "альбом"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "альбомартист"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "В MusicBrainz был передан неверный RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "artist"
 
@@ -152,70 +152,70 @@ msgstr "artist"
 msgid "B"
 msgstr "Б"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "Отмена"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "композитор"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "Участники на GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -223,7 +223,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -231,8 +231,8 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "пользовательский"
 
@@ -241,66 +241,66 @@ msgstr "пользовательский"
 msgid "Custom"
 msgstr "Пользовательский"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "Давид Лапшин"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "описание"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Отменить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Сохранение тегов..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Отмена изменений..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -308,12 +308,12 @@ msgstr "ОШИБКА"
 msgid "Existing Lyrics"
 msgstr "Существующие лирики"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Экспортировать заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
@@ -323,11 +323,11 @@ msgstr "Экспортировать переднюю обложку альбо�
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
@@ -335,51 +335,51 @@ msgstr "Успешно экспортированы в файл передние
 msgid "Exported successfully to: {0}"
 msgstr "Успешно экспортировано в: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "Неудачные поиски в MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "имя файла"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Отпечаток был скопирован в буфер обмена."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Формат строки"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Передняя"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "жанр"
 
@@ -387,13 +387,13 @@ msgstr "жанр"
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -405,16 +405,16 @@ msgstr "Справка"
 msgid "Import from LRC"
 msgstr "Импорт из LRC"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Информация"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Вставить заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
@@ -427,7 +427,7 @@ msgstr "Оставить лирики Tagger"
 msgid "KiB"
 msgstr "КиБ"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -435,12 +435,12 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Загрузка музыкальных файлов из папки..."
 
@@ -449,11 +449,11 @@ msgstr "Загрузка музыкальных файлов из папки..."
 msgid "lrc"
 msgstr "лирики"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "лирики"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -461,11 +461,11 @@ msgstr "Чат Matrix"
 msgid "MiB"
 msgstr "МиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
@@ -473,25 +473,25 @@ msgstr "Новое пользовательское свойство"
 msgid "New Synchronized Lyric"
 msgstr "Новая синхронизированная лирика"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Для отпечатка файла не найдено записи AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy
 msgid "No lyrics were downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Для записи AcoustId не был предоставлен MusicBrainz RecordingId"
 
@@ -499,11 +499,11 @@ msgstr "Для записи AcoustId не был предоставлен MusicB
 msgid "Nothing to export."
 msgstr "Нечего экспортировать."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "ОК"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -512,29 +512,29 @@ msgstr ""
 "выберите только один файл и повторите попытку."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Выберите формат строки."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "издатель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
@@ -542,20 +542,20 @@ msgstr "Удалить пользовательское свойство"
 msgid "Remove Lyric"
 msgstr "Удалить лирику"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -563,56 +563,56 @@ msgstr ""
 "Некоторые музыкальные файлы все еще содержат изменения, ожидающие "
 "применения. Что бы вы хотели сделать?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Отправить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Переключиться на переднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Тег в имя файла"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger открыл некоторые файлы в режиме только для чтения."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Этот файл не имеет действительного отпечатка"
 
@@ -624,32 +624,32 @@ msgstr "ТиБ"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Временная метка (чч:мм:сс)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "название"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "трек"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "итогтрек"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Давид Лапшин <ddaudix@gmail.com>, 2023"
 
@@ -661,23 +661,27 @@ msgstr "Невозможно экспортировать в LRC."
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -691,10 +695,10 @@ msgstr ""
 "Что вы хотите, чтобы Tagger делал с лириками, найденными в файле LRC, "
 "которые конфликтуют с существующими лириками с той же временной меткой?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "год"
 
@@ -715,7 +719,7 @@ msgstr ""
 "Следующие файлы затронуты и будут проигнорированы Tagger:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Лирика"
 
@@ -740,7 +744,7 @@ msgid "Language Code"
 msgstr "Языковой код"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Описание"
 
@@ -803,7 +807,7 @@ msgid "Sort Files By"
 msgstr "Сортировать файлы по"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Имя файла"
 
@@ -812,32 +816,32 @@ msgid "File Path"
 msgstr "Путь к файлу"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Название"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Исполнитель"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Альбом"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Год"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Номер трека"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Жанр"
 
@@ -850,7 +854,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Сохранение временной метки модификации"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Веб-сервисы"
 
@@ -942,6 +946,7 @@ msgid "Remove Front Album Art"
 msgstr "Удалить переднюю обложку альбома"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Переключить обложку альбома"
 
@@ -951,7 +956,7 @@ msgstr "Удалить заднюю обложку альбома"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Управление лириками"
 
@@ -961,12 +966,12 @@ msgid "Web Services"
 msgstr "Веб-сервисы"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "Скачать метаданные MusicBrainz"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #, fuzzy
 msgid "Download Lyrics"
 msgstr "Управление лириками"
@@ -995,136 +1000,136 @@ msgstr "Обложка альбома"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Вставить"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Удалить"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Экспортировать"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Открыть папку с музыкой (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Открыть"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Главное меню"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Откройте папку с музыкой, чтобы начать"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Попробуйте другую папку"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Поиск по имени файла (введите ! для расширенного поиска)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 #, fuzzy
 msgid "Select All Files"
 msgstr "Выберите несколько файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Выберите несколько файлов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Основные свойства"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Трек Всего"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Дополнительные свойства"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Комментарий"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Композитор"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Издатель"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Пользовательские свойства"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Свойства файла"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Скопировать отпечаток в буфер обмена"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Переключить панели тегов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Перезагрузить папку с музыкой (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Действия с тегами"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Применить изменения в тегах (Ctrl+S)"
 
@@ -1321,8 +1326,8 @@ msgstr "— Поиск информации о файлах с помощью Mu
 #~ "\n"
 #~ "            !title=\"\";artist=\"bob\"\n"
 #~ "            Эта команда отфильтрует список таким образом, чтобы он "
-#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя \"bob"
-#~ "\"\n"
+#~ "содержал только файлы с пустым тегом названия и с тегом исполнителя "
+#~ "\"bob\"\n"
 #~ "\n"
 #~ "            [Заметки]\n"
 #~ "            * Продвинутый поиск не чувствителен к регистру\n"

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,49 +18,43 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -69,7 +63,13 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgstr ""
 msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -90,51 +90,51 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr ""
 
@@ -142,85 +142,85 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr ""
 
@@ -229,64 +229,64 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr ""
 
@@ -294,12 +294,12 @@ msgstr ""
 msgid "Existing Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr ""
@@ -309,11 +309,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -321,51 +321,51 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr ""
 
@@ -373,13 +373,13 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -391,16 +391,16 @@ msgstr ""
 msgid "Import from LRC"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr ""
@@ -413,19 +413,19 @@ msgstr ""
 msgid "KiB"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr ""
 
@@ -434,11 +434,11 @@ msgstr ""
 msgid "lrc"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr ""
 
@@ -446,11 +446,11 @@ msgstr ""
 msgid "MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr ""
 
@@ -458,24 +458,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -483,40 +483,40 @@ msgstr ""
 msgid "Nothing to export."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr ""
 
@@ -524,75 +524,75 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -604,32 +604,32 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr ""
 
@@ -641,22 +641,26 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
@@ -669,10 +673,10 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr ""
 
@@ -691,7 +695,7 @@ msgid ""
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgid "Language Code"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr ""
 
@@ -779,7 +783,7 @@ msgid "Sort Files By"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr ""
 
@@ -788,32 +792,32 @@ msgid "File Path"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr ""
 
@@ -826,7 +830,7 @@ msgid "Preserve Modification Timestamp"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr ""
 
@@ -911,6 +915,7 @@ msgid "Remove Front Album Art"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr ""
 
@@ -920,7 +925,7 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr ""
 
@@ -930,12 +935,12 @@ msgid "Web Services"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr ""
 
@@ -963,135 +968,135 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-03 14:28-0400\n"
+"POT-Creation-Date: 2023-09-10 22:10-0400\n"
 "PO-Revision-Date: 2023-09-03 23:02+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/tr/>\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,49 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1117
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1195
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1226
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} / {1} seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:191
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:394
-#: ../../../Controllers/MainWindowController.cs:404
-#: ../../../Controllers/MainWindowController.cs:409
-#: ../../../Controllers/MainWindowController.cs:414
-#: ../../../Controllers/MainWindowController.cs:419
-#: ../../../Controllers/MainWindowController.cs:431
-#: ../../../Controllers/MainWindowController.cs:443
-#: ../../../Controllers/MainWindowController.cs:455
-#: ../../../Controllers/MainWindowController.cs:460
-#: ../../../Controllers/MainWindowController.cs:465
-#: ../../../Controllers/MainWindowController.cs:470
-#: ../../../Controllers/MainWindowController.cs:475
-#: ../../../Controllers/MainWindowController.cs:487
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:501
-#: ../../../Controllers/MainWindowController.cs:1424
-#: ../../../Controllers/MainWindowController.cs:1425
-#: ../../../Controllers/MainWindowController.cs:1426
-#: ../../../Controllers/MainWindowController.cs:1427
-#: ../../../Controllers/MainWindowController.cs:1428
-#: ../../../Controllers/MainWindowController.cs:1429
+#: ../../../Controllers/MainWindowController.cs:400
+#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:415
+#: ../../../Controllers/MainWindowController.cs:420
+#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:437
+#: ../../../Controllers/MainWindowController.cs:449
+#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:466
+#: ../../../Controllers/MainWindowController.cs:471
+#: ../../../Controllers/MainWindowController.cs:476
+#: ../../../Controllers/MainWindowController.cs:481
+#: ../../../Controllers/MainWindowController.cs:493
+#: ../../../Controllers/MainWindowController.cs:498
+#: ../../../Controllers/MainWindowController.cs:507
 #: ../../../Controllers/MainWindowController.cs:1430
 #: ../../../Controllers/MainWindowController.cs:1431
 #: ../../../Controllers/MainWindowController.cs:1432
@@ -70,7 +64,13 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1435
 #: ../../../Controllers/MainWindowController.cs:1436
 #: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Controllers/MainWindowController.cs:1438
+#: ../../../Controllers/MainWindowController.cs:1439
+#: ../../../Controllers/MainWindowController.cs:1440
 #: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Controllers/MainWindowController.cs:1443
+#: ../../../Controllers/MainWindowController.cs:1447
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -78,7 +78,7 @@ msgstr "<koru>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -98,51 +98,51 @@ msgstr ""
 "iziyle ilişkili olarak gönderir."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:496
+#: NickvisionTagger.GNOME/Blueprints/window.blp:498
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1066
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:606
-#: ../../../Models/MusicFile.cs:709
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:640
+#: ../../../Models/MusicFile.cs:743
 msgid "album"
 msgstr "album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1115
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:634
-#: ../../../Models/MusicFile.cs:725
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:668
+#: ../../../Models/MusicFile.cs:759
 msgid "albumartist"
 msgstr "albumartist"
 
-#: ../../../Controllers/MainWindowController.cs:960
+#: ../../../Controllers/MainWindowController.cs:966
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:621
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:840
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:902
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:572
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:650
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:869
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:982
+#: NickvisionTagger.GNOME/Blueprints/window.blp:600
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1062
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:602
-#: ../../../Models/MusicFile.cs:705
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1068
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:636
+#: ../../../Models/MusicFile.cs:739
 msgid "artist"
 msgstr "sanatçı"
 
@@ -150,85 +150,85 @@ msgstr "sanatçı"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:32
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1127
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:646
-#: ../../../Models/MusicFile.cs:737
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1133
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:771
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1436
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
 #: ../../../Controllers/MainWindowController.cs:1327
+#: ../../../Controllers/MainWindowController.cs:1333
 msgid "Calculating..."
 msgstr "Hesaplanıyor..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:538
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:616
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:897
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:977
 msgid "Cancel"
 msgstr "İptal"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1123
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:642
-#: ../../../Models/MusicFile.cs:733
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:676
+#: ../../../Models/MusicFile.cs:767
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1142
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:654
-#: ../../../Models/MusicFile.cs:741
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1148
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:775
 msgid "composer"
 msgstr "besteci"
 
-#: ../../../Controllers/MainWindowController.cs:162
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:41
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:43
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:698
+#: ../../../Controllers/MainWindowController.cs:704
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:722
+#: ../../../Controllers/MainWindowController.cs:728
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1154
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1160
 msgid "custom"
 msgstr "özel"
 
@@ -237,64 +237,64 @@ msgstr "özel"
 msgid "Custom"
 msgstr "Özel"
 
-#: ../../../Controllers/MainWindowController.cs:165
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1146
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:658
-#: ../../../Models/MusicFile.cs:745
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1152
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:779
 msgid "description"
 msgstr "açıklama"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:541
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:619
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:838
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:900
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:951
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:570
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:648
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:980
 msgid "Discard"
 msgstr "Gözden Çıkar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:964
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:880
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:993
 msgid "Discarding tags..."
 msgstr "Etiketler siliniyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:693
 msgid "Discarding unapplied changes..."
 msgstr "Uygulanmayan değişiklikler gözden çıkartılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} dosya için şarkı sözleri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:865
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:894
 msgid "Downloading lyrics..."
 msgstr "Şarkı sözleri indiriliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:825
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:962
+#: ../../../Controllers/MainWindowController.cs:968
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:396 ../../../Models/MusicFile.cs:778
-#: ../../../Models/MusicFile.cs:936
+#: ../../../Models/MusicFile.cs:397 ../../../Models/MusicFile.cs:812
+#: ../../../Models/MusicFile.cs:970
 msgid "ERROR"
 msgstr "HATA"
 
@@ -302,12 +302,12 @@ msgstr "HATA"
 msgid "Existing Lyrics"
 msgstr "Var Olan Şarkı Sözleri"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:91
 msgid "Export Back Album Art"
 msgstr "Albüm Arka Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:797
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:71
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
@@ -317,11 +317,11 @@ msgstr "Albüm Ön Kapağını Dışa Aktar"
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:843
+#: ../../../Controllers/MainWindowController.cs:849
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:827
+#: ../../../Controllers/MainWindowController.cs:833
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
@@ -329,51 +329,51 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 msgid "Exported successfully to: {0}"
 msgstr "Dışa aktarıldı: {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:465
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:494
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:848
+#: ../../../Controllers/MainWindowController.cs:854
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: NickvisionTagger.GNOME/Blueprints/window.blp:43
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: NickvisionTagger.GNOME/Blueprints/window.blp:45
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1054
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1060
 msgid "filename"
 msgstr "dosya adı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1453
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1531
 msgid "Fingerprint was copied to clipboard."
 msgstr "Parmak izi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Format String"
 msgstr "Biçimlendirme Dizgesi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:126
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:722
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
 #: NickvisionTagger.GNOME/Blueprints/window.blp:24
 msgid "Front"
 msgstr "Ön"
 
-#: ../../../Controllers/MainWindowController.cs:164
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1119
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:638
-#: ../../../Models/MusicFile.cs:729
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1125
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:672
+#: ../../../Models/MusicFile.cs:763
 msgid "genre"
 msgstr "tür"
 
@@ -381,13 +381,13 @@ msgstr "tür"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1057
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1086
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:447
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:457
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:476
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:481
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:486
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -399,16 +399,16 @@ msgstr "Yardım"
 msgid "Import from LRC"
 msgstr "LRC'den İçe Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:462
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:491
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:81
 msgid "Insert Back Album Art"
 msgstr "Albüm Arka Kapağı Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:733
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:61
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
@@ -421,19 +421,19 @@ msgstr "Tagger Şarkı Sözlerini Tut"
 msgid "KiB"
 msgstr "KiB"
 
-#: ../../../Controllers/MainWindowController.cs:363
+#: ../../../Controllers/MainWindowController.cs:369
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:427
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:599
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:632
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:641
-#: ../../../Controllers/MainWindowController.cs:1289
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:456
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:628
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:670
+#: ../../../Controllers/MainWindowController.cs:1295
 msgid "Loading music files from folder..."
 msgstr "Müzik dosyaları klasörden yükleniyor..."
 
@@ -442,11 +442,11 @@ msgstr "Müzik dosyaları klasörden yükleniyor..."
 msgid "lrc"
 msgstr "Şsz"
 
-#: ../../../Models/MusicFile.cs:75
+#: ../../../Models/MusicFile.cs:76
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:160
+#: ../../../Controllers/MainWindowController.cs:166
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
@@ -454,11 +454,11 @@ msgstr "Matrix Sohbet"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz Kayıt Kimliği"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
@@ -466,24 +466,24 @@ msgstr "Yeni Özel Özellik"
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:161
-#: ../../../Controllers/MainWindowController.cs:163
+#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../Controllers/MainWindowController.cs:958
+#: ../../../Controllers/MainWindowController.cs:964
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:992
+#: ../../../Controllers/MainWindowController.cs:998
 msgid "No lyrics were downloaded"
 msgstr "Hiçbir şarkı sözü indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:969
+#: ../../../Controllers/MainWindowController.cs:975
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:959
+#: ../../../Controllers/MainWindowController.cs:965
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
@@ -491,11 +491,11 @@ msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 msgid "Nothing to export."
 msgstr "Dışa aktarılacak bir şey yok."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:910
 msgid "OK"
 msgstr "Tamam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -504,29 +504,29 @@ msgstr ""
 "dosya seçip tekrar deneyin."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:45
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:624
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:17
-#: NickvisionTagger.GNOME/Blueprints/window.blp:102
+#: NickvisionTagger.GNOME/Blueprints/window.blp:104
 msgid "Open Folder"
 msgstr "Klasör Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:711
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
 msgid "Please select a format string."
 msgstr "Lütfen biçimlendirme dizgesi seçin."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:806
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:835
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1150
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:662
-#: ../../../Models/MusicFile.cs:749
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1156
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:696
+#: ../../../Models/MusicFile.cs:783
 msgid "publisher"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1329
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
@@ -534,20 +534,20 @@ msgstr "Özel Özelliği Kaldır"
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:549
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:627
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:653
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:959
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:578
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:682
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:988
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:536
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:614
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:833
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:895
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:946
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:565
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:643
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:924
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:975
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -555,56 +555,56 @@ msgstr ""
 "Bazı müzik dosyalarında uygulanmayı bekleyen değişiklikler var. Ne yapmak "
 "istersin?"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 msgid "Submit"
 msgstr "Gönder"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:917
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:927
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:956
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
-#: NickvisionTagger.GNOME/Blueprints/window.blp:302
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
+#: NickvisionTagger.GNOME/Blueprints/window.blp:304
 msgid "Switch to Back Cover"
 msgstr "Arka Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:721
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:750
 msgid "Switch to Front Cover"
 msgstr "Ön Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:701
-#: NickvisionTagger.GNOME/Blueprints/window.blp:44
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:730
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
 msgid "Tag to File Name"
 msgstr "Etiketten Dosya Adına"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:162
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Müziklerinizi etiketleyin"
 
-#: ../../../Controllers/MainWindowController.cs:140
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../Controllers/MainWindowController.cs:371
+#: ../../../Controllers/MainWindowController.cs:377
 msgid "Tagger has opened some files in read-only mode."
 msgstr "Tagger kimi dosyaları salt okunur kipte açdı."
 
-#: ../../../Controllers/MainWindowController.cs:961
+#: ../../../Controllers/MainWindowController.cs:967
 msgid "This file does not have a valid fingerprint"
 msgstr "Bu dosyanın geçerli bir parmak izi yok"
 
@@ -616,32 +616,32 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss)"
 msgstr "Zaman damgası (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1058
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:598
-#: ../../../Models/MusicFile.cs:701
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:632
+#: ../../../Models/MusicFile.cs:735
 msgid "title"
 msgstr "başlık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:879
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:908
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1085
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:618
-#: ../../../Models/MusicFile.cs:717
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1091
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:652
+#: ../../../Models/MusicFile.cs:751
 msgid "track"
 msgstr "parça"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1100
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:626
-#: ../../../Models/MusicFile.cs:721
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:660
+#: ../../../Models/MusicFile.cs:755
 msgid "tracktotal"
 msgstr "toplam parça"
 
-#: ../../../Controllers/MainWindowController.cs:167
+#: ../../../Controllers/MainWindowController.cs:173
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
@@ -653,23 +653,27 @@ msgstr "LRC'ye dışa aktarılamıyor."
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:741
+#: ../../../Controllers/MainWindowController.cs:747
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:619
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:572
+#: ../../../Controllers/MainWindowController.cs:578
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:1004
+#: ../../../Controllers/MainWindowController.cs:1010
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1138
+msgid "Unknown"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
 msgid "Use LRC's lyrics"
@@ -683,10 +687,10 @@ msgstr ""
 "Tagger'ın, LRC dosyasında bulunan ve aynı zaman damgasına sahip mevcut şarkı "
 "sözleriyle çelişen şarkı sözleriyle ne yapmasını istersiniz?"
 
-#: ../../../Controllers/MainWindowController.cs:1028
-#: ../../../Controllers/MainWindowController.cs:1070
-#: ../../../Models/MusicFile.cs:75 ../../../Models/MusicFile.cs:610
-#: ../../../Models/MusicFile.cs:713
+#: ../../../Controllers/MainWindowController.cs:1034
+#: ../../../Controllers/MainWindowController.cs:1076
+#: ../../../Models/MusicFile.cs:76 ../../../Models/MusicFile.cs:644
+#: ../../../Models/MusicFile.cs:747
 msgid "year"
 msgstr "yıl"
 
@@ -707,7 +711,7 @@ msgstr ""
 "dosyalar bundan etkileniyor ve Tagger tarafından yok sayılacaklar:"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:395
+#: NickvisionTagger.GNOME/Blueprints/window.blp:397
 msgid "Lyrics"
 msgstr "Şarkı Sözleri"
 
@@ -732,7 +736,7 @@ msgid "Language Code"
 msgstr "Dil Kodu"
 
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:477
+#: NickvisionTagger.GNOME/Blueprints/window.blp:479
 msgid "Description"
 msgstr "Açıklama"
 
@@ -795,7 +799,7 @@ msgid "Sort Files By"
 msgstr "Dosyaları Sırala"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:375
+#: NickvisionTagger.GNOME/Blueprints/window.blp:377
 msgid "File Name"
 msgstr "Dosya Adı"
 
@@ -804,32 +808,32 @@ msgid "File Path"
 msgstr "Dosya Yolu"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:404
+#: NickvisionTagger.GNOME/Blueprints/window.blp:406
 msgid "Title"
 msgstr "Başlık"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:408
+#: NickvisionTagger.GNOME/Blueprints/window.blp:410
 msgid "Artist"
 msgstr "Sanatçı"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:412
+#: NickvisionTagger.GNOME/Blueprints/window.blp:414
 msgid "Album"
 msgstr "Albüm"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:424
+#: NickvisionTagger.GNOME/Blueprints/window.blp:426
 msgid "Year"
 msgstr "Yıl"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:437
+#: NickvisionTagger.GNOME/Blueprints/window.blp:439
 msgid "Track"
 msgstr "Parça"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:420
+#: NickvisionTagger.GNOME/Blueprints/window.blp:422
 msgid "Genre"
 msgstr "Tür"
 
@@ -842,7 +846,7 @@ msgid "Preserve Modification Timestamp"
 msgstr "Değişiklik Zaman Damgasını Koru"
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:48
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Web Services"
 msgstr "Web Servisleri"
 
@@ -935,6 +939,7 @@ msgid "Remove Front Album Art"
 msgstr "Albüm Ön Kapağını Kaldır"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:76
+#: NickvisionTagger.GNOME/Blueprints/window.blp:39
 msgid "Switch Album Art"
 msgstr "Albüm Kapağını Değiştir"
 
@@ -944,7 +949,7 @@ msgstr "Albüm Arka Kapağını Kaldır"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:96
 #: NickvisionTagger.GNOME/Blueprints/window.blp:18
-#: NickvisionTagger.GNOME/Blueprints/window.blp:391
+#: NickvisionTagger.GNOME/Blueprints/window.blp:393
 msgid "Manage Lyrics"
 msgstr "Şarkı Sözlerini Yönet"
 
@@ -954,12 +959,12 @@ msgid "Web Services"
 msgstr "Web Servisleri"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:105
-#: NickvisionTagger.GNOME/Blueprints/window.blp:50
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz Üst Verilerini İndir"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
 msgid "Download Lyrics"
 msgstr "Şarkı Sözlerini İndir"
 
@@ -987,135 +992,135 @@ msgstr "Albüm Kapağı"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:26
 #: NickvisionTagger.GNOME/Blueprints/window.blp:34
-#: NickvisionTagger.GNOME/Blueprints/window.blp:275
+#: NickvisionTagger.GNOME/Blueprints/window.blp:277
 msgid "Insert"
 msgstr "Ekle"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:27
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:284
+#: NickvisionTagger.GNOME/Blueprints/window.blp:286
 msgid "Remove"
 msgstr "Kaldır"
 
 #: NickvisionTagger.GNOME/Blueprints/window.blp:28
 #: NickvisionTagger.GNOME/Blueprints/window.blp:36
-#: NickvisionTagger.GNOME/Blueprints/window.blp:293
+#: NickvisionTagger.GNOME/Blueprints/window.blp:295
 msgid "Export"
 msgstr "Dışa Aktar"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Open Music Folder (Ctrl+O)"
 msgstr "Müzik Klasörü Aç (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:74
+#: NickvisionTagger.GNOME/Blueprints/window.blp:76
 msgid "Open"
 msgstr "Aç"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:83
+#: NickvisionTagger.GNOME/Blueprints/window.blp:85
 msgid "Main Menu"
 msgstr "Ana Menü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Tag Your Music"
 msgstr "Müziklerinizi Etiketleyin"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:100
+#: NickvisionTagger.GNOME/Blueprints/window.blp:102
 msgid "Open a folder with music to get started"
 msgstr "Başlamak için müzik içeren bir klasör açın"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:156
+#: NickvisionTagger.GNOME/Blueprints/window.blp:158
 msgid "No Music Files Found"
 msgstr "Hiçbir Müzik Dosyası Bulunamadı"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:157
+#: NickvisionTagger.GNOME/Blueprints/window.blp:159
 msgid "Try a different folder"
 msgstr "Başka bir klasör dene"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:176
+#: NickvisionTagger.GNOME/Blueprints/window.blp:178
 msgid "Search for filename (type ! for advanced search)..."
 msgstr "Dosya adı ara (gelişmiş arama için ! yazın)..."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:181
+#: NickvisionTagger.GNOME/Blueprints/window.blp:183
 msgid "Advanced Search Info"
 msgstr "Gelişmiş Arama Bilgisi"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:187
+#: NickvisionTagger.GNOME/Blueprints/window.blp:189
 msgid "Select All Files"
 msgstr "Tüm Dosyaları Seç"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:233
+#: NickvisionTagger.GNOME/Blueprints/window.blp:235
 msgid "No Selected Music Files"
 msgstr "Seçili Müzik Dosyası Yok"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:234
+#: NickvisionTagger.GNOME/Blueprints/window.blp:236
 msgid "Select some files"
 msgstr "Bazı dosyaları seçin"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:384
+#: NickvisionTagger.GNOME/Blueprints/window.blp:386
 msgid "Main Properties"
 msgstr "Ana Özellikler"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:416
+#: NickvisionTagger.GNOME/Blueprints/window.blp:418
 msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:455
+#: NickvisionTagger.GNOME/Blueprints/window.blp:457
 msgid "Track Total"
 msgstr "Toplam Parça"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:462
+#: NickvisionTagger.GNOME/Blueprints/window.blp:464
 msgid "Additional Properties"
 msgstr "Ek Özellikler"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:465
+#: NickvisionTagger.GNOME/Blueprints/window.blp:467
 msgid "Comment"
 msgstr "Yorum"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:469
+#: NickvisionTagger.GNOME/Blueprints/window.blp:471
 msgid "Beats Per Minute"
 msgstr "Dakika Başına Vuruş"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:473
+#: NickvisionTagger.GNOME/Blueprints/window.blp:475
 msgid "Composer"
 msgstr "Besteci"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:483
 msgid "Publisher"
 msgstr "Yayımcı"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:488
+#: NickvisionTagger.GNOME/Blueprints/window.blp:490
 msgid "Custom Properties"
 msgstr "Özel Özellikler"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:505
+#: NickvisionTagger.GNOME/Blueprints/window.blp:507
 msgid "Custom properties can only be edited for individual files."
 msgstr "Özel özellikler yalnızca bağımsız dosyalar için düzenlenebilir."
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:514
+#: NickvisionTagger.GNOME/Blueprints/window.blp:516
 msgid "File Properties"
 msgstr "Dosya Özellikleri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:519
 msgid "Fingerprint"
 msgstr "Parmak izi"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:536
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Parmak İzini Panoya Kopyala"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:564
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Toggle Tags Pane"
 msgstr "Etiket Bölmesini Aç/Kapat"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:570
+#: NickvisionTagger.GNOME/Blueprints/window.blp:572
 msgid "Reload Music Folder (F5)"
 msgstr "Müzik Klasörünü Yeniden Yükle (F5)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:593
+#: NickvisionTagger.GNOME/Blueprints/window.blp:595
 msgid "Tag Actions"
 msgstr "Etiket Eylemleri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: NickvisionTagger.GNOME/Blueprints/window.blp:601
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Etiket Değişikliklerini Uygula (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -38,6 +38,7 @@
   <releases>
     <release version="2023.9.1-next" date="2023-09-06">
       <description translatable="no">
+        <p>- Tagger will display headers in the list of music files when sorting to provide a more organized view of files</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>


### PR DESCRIPTION
Closes #312 
Closes #315 

![image](https://github.com/NickvisionApps/Tagger/assets/117388856/b0a20a45-ec63-4c65-a55b-eadfe05d58b5)

TODO:
- [x] Change default sorting to Path and fix the order
- [x] Update po(t)

Notes:
* I realized the buttons that appear on album art hovering are probably inaccessible on touch screens, and switch art action was the only one missing in the menu.
* `Gtk.ListBox.SetHeaderFunc` is available in gir.core but causes crash (I will later create bug report with small reproducer)