### PR TITLE
Features and a Fix :)

### DIFF
--- a/NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp
@@ -1,0 +1,56 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.Window _root {
+  default-width: 360;
+  modal: true;
+  resizable: false;
+
+  content: Gtk.Box {
+    orientation: vertical;
+
+    Adw.HeaderBar {
+      title-widget: Gtk.Label {};
+      styles ["flat"]
+    }
+
+    Gtk.WindowHandle {
+      Gtk.Box {
+        orientation: vertical;
+        spacing: 24;
+        margin-bottom: 24;
+
+        Gtk.Label _titleLabel {
+          styles ["title-2"]
+        }
+
+        Adw.PreferencesGroup {
+          margin-start: 24;
+          margin-end: 24;
+
+          Adw.ActionRow _mimeTypeRow {
+            title: _("Mime Type");
+            subtitle-selectable: true;
+          }
+
+          Adw.ActionRow _widthRow {
+            title: _("Width");
+            subtitle-selectable: true;
+          }
+
+          Adw.ActionRow _heightRow {
+            title: _("Height");
+            subtitle-selectable: true;
+          }
+        }
+      }
+    }
+  };
+  
+  Gtk.ShortcutController {
+    Gtk.Shortcut {
+      trigger: "Escape";
+      action: "action(window.close)";
+    }
+  }
+}

--- a/NickvisionTagger.GNOME/Blueprints/music_file_row.blp
+++ b/NickvisionTagger.GNOME/Blueprints/music_file_row.blp
@@ -4,6 +4,7 @@ using Adw 1;
 Adw.ActionRow _root {
   title-lines: 1;
   subtitle-lines: 1;
+  use-markup: false;
   
   [prefix]
   Gtk.Image _artImage {

--- a/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp
@@ -90,6 +90,22 @@ Adw.PreferencesWindow _root {
           valign: center;
         }
       }
+
+      Adw.ActionRow {
+        title: _("Limit File Name Characters");
+        subtitle: _("Restricts characters in file names to only those supported by Windows.");
+        activatable-widget: _limitCharactersSwitch;
+
+        [prefix]
+        Gtk.Image {
+          icon-name: "insert-text-symbolic";
+        }
+
+        [suffix]
+        Gtk.Switch _limitCharactersSwitch {
+          valign: center;
+        }
+      }
     }
 
     Adw.PreferencesGroup {

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -43,6 +43,7 @@ menu tagActionsMenu {
         item(_("Insert"), "win.insertFrontAlbumArt")
         item(_("Remove"), "win.removeFrontAlbumArt")
         item(_("Export"), "win.exportFrontAlbumArt")
+        item(_("Info"), "win.infoFrontAlbumArt")
       }
 
       submenu {
@@ -51,6 +52,7 @@ menu tagActionsMenu {
         item(_("Insert"), "win.insertBackAlbumArt")
         item(_("Remove"), "win.removeBackAlbumArt")
         item(_("Export"), "win.exportBackAlbumArt")
+        item(_("Info"), "win.infoBackAlbumArt")
       }
 
       item(_("Switch Album Art"), "win.switchAlbumArt")
@@ -313,7 +315,9 @@ Adw.ApplicationWindow _root {
                                 halign: center;
                                 valign: center;
 
-                                Gtk.Button _insertAlbumArtButton {
+                                Gtk.Button {
+                                  action-name: "win.insertAlbumArt";
+
                                   Adw.ButtonContent {
                                     icon-name: "list-add-symbolic";
                                     label: _("Insert");
@@ -322,7 +326,9 @@ Adw.ApplicationWindow _root {
                                   styles [ "opaque" ]
                                 }
 
-                                Gtk.Button _removeAlbumArtButton {
+                                Gtk.Button {
+                                  action-name: "win.removeAlbumArt";
+
                                   Adw.ButtonContent {
                                     icon-name: "list-remove-symbolic";
                                     label: _("Remove");
@@ -331,7 +337,9 @@ Adw.ApplicationWindow _root {
                                   styles [ "opaque" ]
                                 }
 
-                                Gtk.Button _exportAlbumArtButton {
+                                Gtk.Button {
+                                  action-name: "win.exportAlbumArt";
+
                                   Adw.ButtonContent {
                                     icon-name: "document-save-symbolic";
                                     label: _("Export");
@@ -340,7 +348,20 @@ Adw.ApplicationWindow _root {
                                   styles [ "opaque" ]
                                 }
 
+                                Gtk.Button {
+                                  action-name: "win.infoAlbumArt";
+
+                                  Adw.ButtonContent {
+                                    icon-name: "help-about-symbolic";
+                                    label: _("Info");
+                                  }
+
+                                  styles [ "opaque" ]
+                                }
+
                                 Gtk.Button _switchAlbumArtButton {
+                                  action-name: "win.switchAlbumArt";
+                                  
                                   Adw.ButtonContent _switchAlbumArtButtonContent {
                                     icon-name: "view-paged-symbolic";
                                     label: _("Switch to Back Cover");

--- a/NickvisionTagger.GNOME/Blueprints/window.blp
+++ b/NickvisionTagger.GNOME/Blueprints/window.blp
@@ -500,6 +500,38 @@ Adw.ApplicationWindow _root {
                                 }
                               }
                             }
+
+                            Gtk.Box {
+                              orientation: horizontal;
+                              margin-top: 6;
+                              
+                              Adw.PreferencesGroup {
+                                halign: start;
+                                hexpand: true;
+                                
+                                Adw.EntryRow _discNumberRow {
+                                  title: _("Disc Number");
+                                }
+                              }
+                              
+                              Gtk.Label {
+                                margin-start: 12;
+                                margin-end: 12;
+                                halign: center;
+                                label: "/";
+                                
+                                styles ["title-4"]
+                              }
+                              
+                              Adw.PreferencesGroup {
+                                halign: end;
+                                hexpand: true;
+                                
+                                Adw.EntryRow _discTotalRow {
+                                  title: _("Disc Total");
+                                }
+                              }
+                            }
                             
                             Adw.PreferencesGroup {
                               margin-top: 12;

--- a/NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs
+++ b/NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs
@@ -1,0 +1,47 @@
+﻿using NickvisionTagger.GNOME.Helpers;
+using NickvisionTagger.Shared.Models;
+using static Nickvision.Aura.Localization.Gettext;
+
+namespace NickvisionTagger.GNOME.Controls;
+
+/// <summary>
+/// A dialog for showing album art info
+/// </summary>
+public class AlbumArtInfoDialog : Adw.Window
+{
+    [Gtk.Connect] private readonly Gtk.Label _titleLabel;
+    [Gtk.Connect] private readonly Adw.ActionRow _mimeTypeRow;
+    [Gtk.Connect] private readonly Adw.ActionRow _widthRow;
+    [Gtk.Connect] private readonly Adw.ActionRow _heightRow;
+
+    /// <summary>
+    /// Constructs a AlbumArtInfoDialog
+    /// </summary>
+    /// <param name="builder">Gtk.Builder</param>
+    /// <param name="art">AlbumArt</param>
+    /// <param name="parent">Gtk.Window</param>
+    /// <param name="iconName">The name of the icon</param>
+    public AlbumArtInfoDialog(Gtk.Builder builder, AlbumArt art, Gtk.Window parent, string iconName) : base(builder.GetPointer("_root"), false)
+    {
+        //Build UI
+        builder.Connect(this);
+        //Dialog Settings
+        SetTransientFor(parent);
+        SetIconName(iconName);
+        //Load
+        _titleLabel.SetLabel(art.Type == AlbumArtType.Front ? _("Front") : _("Back"));
+        _mimeTypeRow.SetSubtitle(art.MimeType);
+        _widthRow.SetSubtitle(_("{0} pixels", art.Width));
+        _heightRow.SetSubtitle(_("{0} pixels", art.Width));
+    }
+
+    /// <summary>
+    /// Constructs a AlbumArtInfoDialog
+    /// </summary>
+    /// <param name="art">AlbumArt</param>
+    /// <param name="parent">Gtk.Window</param>
+    /// <param name="iconName">The name of the icon</param>
+    public AlbumArtInfoDialog(AlbumArt art, Gtk.Window parent, string iconName) : this(Builder.FromFile("album_art_info_dialog.ui"), art, parent, iconName)
+    {
+    }
+}

--- a/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
+++ b/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
@@ -49,7 +49,7 @@ public class MusicFileRow : Adw.ActionRow
         if (!_art.IsEmpty)
         {
             _artImage.AddCssClass("list-icon");
-            using var bytes = GLib.Bytes.From(_art.Image.AsSpan());
+            using var bytes = GLib.Bytes.From(_art.Icon.AsSpan());
             using var texture = Gdk.Texture.NewFromBytes(bytes);
             _artImage.SetFromPaintable(texture);
         }

--- a/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
+++ b/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
@@ -1,7 +1,6 @@
 using NickvisionTagger.GNOME.Helpers;
 using NickvisionTagger.Shared.Models;
 using System;
-using System.Text.RegularExpressions;
 
 namespace NickvisionTagger.GNOME.Controls;
 

--- a/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
+++ b/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
@@ -74,12 +74,12 @@ public class MusicFileRow : Adw.ActionRow
     {
         if (!string.IsNullOrEmpty(musicFile.Title))
         {
-            SetTitle($"{(musicFile.Track != 0 ? $"{musicFile.Track:D2} - " : "")}{Regex.Replace(musicFile.Title, "\\&", "&amp;")}");
-            SetSubtitle(Regex.Replace(musicFile.Filename, "\\&", "&amp;"));
+            SetTitle($"{(musicFile.Track != 0 ? $"{musicFile.Track:D2} - " : "")}{musicFile.Title}");
+            SetSubtitle(musicFile.Filename);
         }
         else
         {
-            SetTitle(Regex.Replace(musicFile.Filename, "\\&", "&amp;"));
+            SetTitle(musicFile.Filename);
             SetSubtitle("");
         }
         SetArtFromAlbumArt(musicFile.FrontAlbumArt);

--- a/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
+++ b/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
@@ -11,7 +11,7 @@ namespace NickvisionTagger.GNOME.Controls;
 /// </summary>
 public class MusicFileRow : Adw.ActionRow
 {
-    private byte[] _art;
+    private AlbumArt _art;
 
     [Gtk.Connect] private readonly Gtk.Image _artImage;
     [Gtk.Connect] private readonly Gtk.Image _unsavedImage;
@@ -23,7 +23,7 @@ public class MusicFileRow : Adw.ActionRow
     /// <param name="musicFile">MusicFile</param>
     private MusicFileRow(Gtk.Builder builder, MusicFile musicFile) : base(builder.GetPointer("_root"), false)
     {
-        _art = Array.Empty<byte>();
+        _art = new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
         builder.Connect(this);
         Update(musicFile);
     }
@@ -37,20 +37,20 @@ public class MusicFileRow : Adw.ActionRow
     }
 
     /// <summary>
-    /// Sets art icon from bytes array
+    /// Sets art icon from AlbmArt object
     /// </summary>
-    /// <param name="art">Art as byte array</param>
-    public void SetArtFromBytes(byte[] art)
+    /// <param name="art">AlbumArt</param>
+    public void SetArtFromAlbumArt(AlbumArt art)
     {
-        if (_art.SequenceEqual(art))
+        if (_art == art)
         {
             return;
         }
         _art = art;
-        if (_art.Length > 0)
+        if (!_art.IsEmpty)
         {
             _artImage.AddCssClass("list-icon");
-            using var bytes = GLib.Bytes.From(_art.AsSpan());
+            using var bytes = GLib.Bytes.From(_art.Image.AsSpan());
             using var texture = Gdk.Texture.NewFromBytes(bytes);
             _artImage.SetFromPaintable(texture);
         }
@@ -83,6 +83,6 @@ public class MusicFileRow : Adw.ActionRow
             SetTitle(Regex.Replace(musicFile.Filename, "\\&", "&amp;"));
             SetSubtitle("");
         }
-        SetArtFromBytes(musicFile.FrontAlbumArt);
+        SetArtFromAlbumArt(musicFile.FrontAlbumArt);
     }
 }

--- a/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
+++ b/NickvisionTagger.GNOME/Controls/MusicFileRow.cs
@@ -1,7 +1,6 @@
 using NickvisionTagger.GNOME.Helpers;
 using NickvisionTagger.Shared.Models;
 using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace NickvisionTagger.GNOME.Controls;

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -34,7 +34,8 @@ public partial class Program
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
             @"* Added the option to use relative paths when creating a playlist. This means that Tagger also now supports opening playlists with relative paths
-              * Added the PublishingDate field to additional properties
+              * Added the Disc Number, Disc Total, and Publishing Date fields to additional properties
+              * Added information dialog for album art
               * Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary
               * Tagger will now display front album art within a music file row itself if available
               * Fixed an issue where downloaded lyrics would sometimes contain html encoded characters

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -36,6 +36,7 @@ public partial class Program
             @"* Added the option to use relative paths when creating a playlist. This means that Tagger also now supports opening playlists with relative paths
               * Added the Disc Number, Disc Total, and Publishing Date fields to additional properties
               * Added information dialog for album art
+              * Added an option in Preferences to limit file name characters to those only supported by Windows
               * Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary
               * Tagger will now display front album art within a music file row itself if available
               * Fixed an issue where downloaded lyrics would sometimes contain html encoded characters

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -38,6 +38,7 @@ public partial class Program
               * Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary
               * Tagger will now display front album art within a music file row itself if available
               * Fixed an issue where downloaded lyrics would sometimes contain html encoded characters
+              * Fixed an issue where file names containing the ""<"" character caused the music file row to not display
               * Improved create playlist dialog ux
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -62,7 +62,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     private readonly Gio.SimpleAction _insertAlbumArtAction;
     private readonly Gio.SimpleAction _removeAlbumArtAction;
     private readonly Gio.SimpleAction _exportAlbumArtAction;
-    private readonly Gio.SimpleAction _InfoAlbumArtAction;
+    private readonly Gio.SimpleAction _infoAlbumArtAction;
     private readonly Gio.SimpleAction _lyricsAction;
     private readonly Gio.SimpleAction _musicBrainzAction;
     private readonly Gio.SimpleAction _downloadLyricsAction;
@@ -453,9 +453,9 @@ public partial class MainWindow : Adw.ApplicationWindow
         _exportAlbumArtAction.OnActivate += async (sender, e) => await ExportAlbumArtAsync(_currentAlbumArtType);
         AddAction(_exportAlbumArtAction);
         //Info Album Art Action
-        _InfoAlbumArtAction = Gio.SimpleAction.New("infoAlbumArt", null);
-        _InfoAlbumArtAction.OnActivate += (sender, e) => AlbumArtInfo(_currentAlbumArtType);
-        AddAction(_InfoAlbumArtAction);
+        _infoAlbumArtAction = Gio.SimpleAction.New("infoAlbumArt", null);
+        _infoAlbumArtAction.OnActivate += (sender, e) => AlbumArtInfo(_currentAlbumArtType);
+        AddAction(_infoAlbumArtAction);
         //Insert Front Album Art Action
         var actInsertFrontAlbumArt = Gio.SimpleAction.New("insertFrontAlbumArt", null);
         actInsertFrontAlbumArt.OnActivate += async (sender, e) => await InsertAlbumArtAsync(AlbumArtType.Front);
@@ -1592,6 +1592,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         }
         _insertAlbumArtAction.SetEnabled(true);
         _removeAlbumArtAction.SetEnabled(_artViewStack.GetVisibleChildName() != "NoImage");
+        _infoAlbumArtAction.SetEnabled(albumArt == "hasArt");
         _exportAlbumArtAction.SetEnabled(albumArt == "hasArt");
         //Update Custom Properties
         foreach (var row in _customPropertyRows)

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -1415,11 +1415,13 @@ public partial class MainWindow : Adw.ApplicationWindow
         foreach (var row in _listMusicFilesRows)
         {
             _listMusicFiles.Remove(row);
+            GLib.Internal.MainContext.Iteration(GLib.Internal.MainContext.Default(), false);
         }
         _listMusicFilesRows.Clear();
         if (!string.IsNullOrEmpty(_controller.MusicLibraryName))
         {
             string? comparable = null;
+            _loadingLabel.SetLabel(_("Making everything pretty..."));
             foreach (var musicFile in _controller.MusicFiles)
             {
                 var row = new MusicFileRow(musicFile);
@@ -1442,8 +1444,10 @@ public partial class MainWindow : Adw.ApplicationWindow
                     }
                     row.AddCssClass("start-row");
                 }
+                GLib.Internal.MainContext.Iteration(GLib.Internal.MainContext.Default(), false);
                 _listMusicFiles.Append(row);
                 _listMusicFilesRows.Add(row);
+                GLib.Internal.MainContext.Iteration(GLib.Internal.MainContext.Default(), false);
             }
             if (_listMusicFilesRows.Any())
             {

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -62,6 +62,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     private readonly Gio.SimpleAction _insertAlbumArtAction;
     private readonly Gio.SimpleAction _removeAlbumArtAction;
     private readonly Gio.SimpleAction _exportAlbumArtAction;
+    private readonly Gio.SimpleAction _InfoAlbumArtAction;
     private readonly Gio.SimpleAction _lyricsAction;
     private readonly Gio.SimpleAction _musicBrainzAction;
     private readonly Gio.SimpleAction _downloadLyricsAction;
@@ -99,9 +100,6 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Adw.ViewStack _selectedViewStack;
     [Gtk.Connect] private readonly Gtk.Label _artTypeLabel;
     [Gtk.Connect] private readonly Adw.ViewStack _artViewStack;
-    [Gtk.Connect] private readonly Gtk.Button _insertAlbumArtButton;
-    [Gtk.Connect] private readonly Gtk.Button _removeAlbumArtButton;
-    [Gtk.Connect] private readonly Gtk.Button _exportAlbumArtButton;
     [Gtk.Connect] private readonly Gtk.Button _switchAlbumArtButton;
     [Gtk.Connect] private readonly Adw.ButtonContent _switchAlbumArtButtonContent;
     [Gtk.Connect] private readonly Gtk.Picture _albumArtImage;
@@ -437,22 +435,22 @@ public partial class MainWindow : Adw.ApplicationWindow
         actSwitchAlbumArt.OnActivate += SwitchAlbumArt;
         AddAction(actSwitchAlbumArt);
         application.SetAccelsForAction("win.switchAlbumArt", new string[] { "<Ctrl><Shift>S" });
-        _switchAlbumArtButton.SetDetailedActionName("win.switchAlbumArt");
         //Insert Album Art Action
         _insertAlbumArtAction = Gio.SimpleAction.New("insertAlbumArt", null);
         _insertAlbumArtAction.OnActivate += async (sender, e) => await InsertAlbumArtAsync(_currentAlbumArtType);
         AddAction(_insertAlbumArtAction);
-        _insertAlbumArtButton.SetDetailedActionName("win.insertAlbumArt");
         //Remove Album Art Action
         _removeAlbumArtAction = Gio.SimpleAction.New("removeAlbumArt", null);
         _removeAlbumArtAction.OnActivate += async (sender, e) => await RemoveAlbumArtAsync(_currentAlbumArtType);
         AddAction(_removeAlbumArtAction);
-        _removeAlbumArtButton.SetDetailedActionName("win.removeAlbumArt");
         //Export Album Art Action
         _exportAlbumArtAction = Gio.SimpleAction.New("exportAlbumArt", null);
         _exportAlbumArtAction.OnActivate += async (sender, e) => await ExportAlbumArtAsync(_currentAlbumArtType);
         AddAction(_exportAlbumArtAction);
-        _exportAlbumArtButton.SetDetailedActionName("win.exportAlbumArt");
+        //Info Album Art Action
+        _InfoAlbumArtAction = Gio.SimpleAction.New("infoAlbumArt", null);
+        _InfoAlbumArtAction.OnActivate += (sender, e) => AlbumArtInfo(_currentAlbumArtType);
+        AddAction(_InfoAlbumArtAction);
         //Insert Front Album Art Action
         var actInsertFrontAlbumArt = Gio.SimpleAction.New("insertFrontAlbumArt", null);
         actInsertFrontAlbumArt.OnActivate += async (sender, e) => await InsertAlbumArtAsync(AlbumArtType.Front);
@@ -468,6 +466,10 @@ public partial class MainWindow : Adw.ApplicationWindow
         actExportFrontAlbumArt.OnActivate += async (sender, e) => await ExportAlbumArtAsync(AlbumArtType.Front);
         AddAction(actExportFrontAlbumArt);
         application.SetAccelsForAction("win.exportFrontAlbumArt", new string[] { "<Ctrl>E" });
+        //Info Front Album Art Action
+        var actInfoFrontAlbumArt = Gio.SimpleAction.New("infoFrontAlbumArt", null);
+        actInfoFrontAlbumArt.OnActivate += (sender, e) => AlbumArtInfo(AlbumArtType.Front);
+        AddAction(actInfoFrontAlbumArt);
         //Insert Back Album Art Action
         var actInsertBackAlbumArt = Gio.SimpleAction.New("insertBackAlbumArt", null);
         actInsertBackAlbumArt.OnActivate += async (sender, e) => await InsertAlbumArtAsync(AlbumArtType.Back);
@@ -483,6 +485,10 @@ public partial class MainWindow : Adw.ApplicationWindow
         actExportBackAlbumArt.OnActivate += async (sender, e) => await ExportAlbumArtAsync(AlbumArtType.Back);
         AddAction(actExportBackAlbumArt);
         application.SetAccelsForAction("win.exportBackAlbumArt", new string[] { "<Ctrl><Shift>E" });
+        //Info Back Album Art Action
+        var actInfoBackAlbumArt = Gio.SimpleAction.New("infoBackAlbumArt", null);
+        actInfoBackAlbumArt.OnActivate += (sender, e) => AlbumArtInfo(AlbumArtType.Back);
+        AddAction(actInfoBackAlbumArt);
         //Lyrics Action
         _lyricsAction = Gio.SimpleAction.New("lyrics", null);
         _lyricsAction.OnActivate += Lyrics;
@@ -1103,6 +1109,16 @@ public partial class MainWindow : Adw.ApplicationWindow
             _controller.ExportSelectedAlbumArt(file.GetPath(), type);
         }
         catch { }
+    }
+
+    /// <summary>
+    /// Occurs wen the album art info action is triggered
+    /// </summary>
+    /// <param name="type">AlbumArtType</param>
+    private void AlbumArtInfo(AlbumArtType type)
+    {
+        var dialog = new AlbumArtInfoDialog(_controller.GetFirstAlbumArt(type), this, _controller.AppInfo.ID);
+        dialog.Present();
     }
 
     /// <summary>

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -120,6 +120,8 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Adw.EntryRow _bpmRow;
     [Gtk.Connect] private readonly Adw.EntryRow _composerRow;
     [Gtk.Connect] private readonly Adw.EntryRow _descriptionRow;
+    [Gtk.Connect] private readonly Adw.EntryRow _discNumberRow;
+    [Gtk.Connect] private readonly Adw.EntryRow _discTotalRow;
     [Gtk.Connect] private readonly Adw.EntryRow _publisherRow;
     [Gtk.Connect] private readonly Gtk.MenuButton _publishingDateButton;
     [Gtk.Connect] private readonly Gtk.Calendar _publishingDateCalendar;
@@ -288,6 +290,20 @@ public partial class MainWindow : Adw.ApplicationWindow
             }
         };
         _descriptionRow.OnNotify += (sender, e) =>
+        {
+            if (e.Pspec.GetName() == "text")
+            {
+                TagPropertyChanged();
+            }
+        };
+        _discNumberRow.OnNotify += (sender, e) =>
+        {
+            if (e.Pspec.GetName() == "text")
+            {
+                TagPropertyChanged();
+            }
+        };
+        _discTotalRow.OnNotify += (sender, e) =>
         {
             if (e.Pspec.GetName() == "text")
             {
@@ -1502,6 +1518,8 @@ public partial class MainWindow : Adw.ApplicationWindow
         _bpmRow.SetText(_controller.SelectedPropertyMap.BeatsPerMinute);
         _composerRow.SetText(_controller.SelectedPropertyMap.Composer);
         _descriptionRow.SetText(_controller.SelectedPropertyMap.Description);
+        _discNumberRow.SetText(_controller.SelectedPropertyMap.DiscNumber);
+        _discTotalRow.SetText(_controller.SelectedPropertyMap.DiscTotal);
         _publisherRow.SetText(_controller.SelectedPropertyMap.Publisher);
         if (string.IsNullOrEmpty(_controller.SelectedPropertyMap.PublishingDate))
         {
@@ -1706,6 +1724,8 @@ public partial class MainWindow : Adw.ApplicationWindow
                 BeatsPerMinute = _bpmRow.GetText(),
                 Composer = _composerRow.GetText(),
                 Description = _descriptionRow.GetText(),
+                DiscNumber = _discNumberRow.GetText(),
+                DiscTotal = _discTotalRow.GetText(),
                 Publisher = _publisherRow.GetText(),
                 PublishingDate = _publishingDateButton.GetLabel() == _("Pick a date") ? "" : _publishingDateButton.GetLabel()
             };

--- a/NickvisionTagger.GNOME/Views/MainWindow.cs
+++ b/NickvisionTagger.GNOME/Views/MainWindow.cs
@@ -1094,7 +1094,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         saveFileDialog.SetTitle(type == AlbumArtType.Front ? _("Export Front Album Art") : _("Export Back Album Art"));
         var filters = Gio.ListStore.New(Gtk.FileFilter.GetGType());
         var filter = Gtk.FileFilter.New();
-        filter.AddMimeType(_controller.GetFirstAlbumArtMimeType(type));
+        filter.AddMimeType(_controller.GetFirstAlbumArt(type).MimeType);
         filters.Append(filter);
         saveFileDialog.SetFilters(filters);
         try
@@ -1544,13 +1544,13 @@ public partial class MainWindow : Adw.ApplicationWindow
         {
             _artViewStack.SetVisibleChildName("Image");
             var art = _currentAlbumArtType == AlbumArtType.Front ? _controller.SelectedMusicFiles.First().Value.FrontAlbumArt : _controller.SelectedMusicFiles.First().Value.BackAlbumArt;
-            if (art.Length == 0)
+            if (art.IsEmpty)
             {
                 _albumArtImage.SetPaintable(null);
             }
             else
             {
-                using var bytes = GLib.Bytes.From(art.AsSpan());
+                using var bytes = GLib.Bytes.From(art.Image.AsSpan());
                 using var texture = Gdk.Texture.NewFromBytes(bytes);
                 _albumArtImage.SetPaintable(texture);
             }

--- a/NickvisionTagger.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionTagger.GNOME/Views/PreferencesDialog.cs
@@ -20,6 +20,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
     [Gtk.Connect] private readonly Gtk.Switch _includeSubfoldersSwitch;
     [Gtk.Connect] private readonly Adw.ComboRow _sortFilesRow;
     [Gtk.Connect] private readonly Gtk.Switch _preserveModificationTimestampSwitch;
+    [Gtk.Connect] private readonly Gtk.Switch _limitCharactersSwitch;
     [Gtk.Connect] private readonly Gtk.Switch _overwriteTagWithMusicBrainzSwitch;
     [Gtk.Connect] private readonly Gtk.Switch _overwriteAlbumArtWithMusicBrainzSwitch;
     [Gtk.Connect] private readonly Gtk.Switch _overwriteLyricsWithWebSwitch;
@@ -50,6 +51,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _includeSubfoldersSwitch.SetActive(_controller.IncludeSubfolders);
         _sortFilesRow.SetSelected((uint)_controller.SortFilesBy);
         _preserveModificationTimestampSwitch.SetActive(_controller.PreserveModificationTimestamp);
+        _limitCharactersSwitch.SetActive(_controller.LimitFilenameCharacters);
         _overwriteTagWithMusicBrainzSwitch.SetActive(_controller.OverwriteTagWithMusicBrainz);
         _overwriteAlbumArtWithMusicBrainzSwitch.SetActive(_controller.OverwriteAlbumArtWithMusicBrainz);
         _overwriteLyricsWithWebSwitch.SetActive(_controller.OverwriteLyricsWithWebService);
@@ -77,6 +79,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _controller.IncludeSubfolders = _includeSubfoldersSwitch.GetActive();
         _controller.SortFilesBy = (SortBy)_sortFilesRow.GetSelected();
         _controller.PreserveModificationTimestamp = _preserveModificationTimestampSwitch.GetActive();
+        _controller.LimitFilenameCharacters = _limitCharactersSwitch.GetActive();
         _controller.OverwriteTagWithMusicBrainz = _overwriteTagWithMusicBrainzSwitch.GetActive();
         _controller.OverwriteAlbumArtWithMusicBrainz = _overwriteAlbumArtWithMusicBrainzSwitch.GetActive();
         _controller.OverwriteLyricsWithWebService = _overwriteLyricsWithWebSwitch.GetActive();

--- a/NickvisionTagger.GNOME/nuget-sources.json
+++ b/NickvisionTagger.GNOME/nuget-sources.json
@@ -337,6 +337,13 @@
   },
   {
     "type": "file",
+    "url": "https://api.nuget.org/v3-flatcontainer/sixlabors.imagesharp/3.0.2/sixlabors.imagesharp.3.0.2.nupkg",
+    "sha512": "bc24490da6f0bbba03c1724681698418045534ce5f14bf4a1088de53c65a9b81adf3842ae9430a1e33f0dc68fda83cfacc3ddf9a849b9ac2195293d3239876e6",
+    "dest": "nuget-sources",
+    "dest-filename": "sixlabors.imagesharp.3.0.2.nupkg"
+  },
+  {
+    "type": "file",
     "url": "https://api.nuget.org/v3-flatcontainer/sqlitepclraw.bundle_e_sqlcipher/2.1.6/sqlitepclraw.bundle_e_sqlcipher.2.1.6.nupkg",
     "sha512": "e048023e511f00823c680a441696e003feeb76a1f673bb28124b999ce437051a1ae472673b89b22d89cbd5dc687fb51472b8bc643e97d2edd86fd33cd36cda19",
     "dest": "nuget-sources",

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -239,16 +239,6 @@ public class MainWindowController : IDisposable
     }
 
     /// <summary>
-    /// Whether or not to show the Extras Pane
-    /// </summary>
-    public bool ExtrasPane
-    {
-        get => Configuration.Current.ExtrasPane;
-
-        set => Configuration.Current.ExtrasPane = value;
-    }
-
-    /// <summary>
     /// What to sort files in a music library by
     /// </summary>
     public SortBy SortFilesBy
@@ -256,6 +246,26 @@ public class MainWindowController : IDisposable
         get => Configuration.Current.SortFilesBy;
 
         set => Configuration.Current.SortFilesBy = value;
+    }
+
+    /// <summary>
+    /// Whether or not filename characters should be limited to those only supported by Windows
+    /// </summary>
+    public bool LimitFilenameCharacters
+    {
+        get => Configuration.Current.LimitFilenameCharacters;
+
+        set => Configuration.Current.LimitFilenameCharacters = value;
+    }
+
+    /// <summary>
+    /// Whether or not to show the Extras Pane
+    /// </summary>
+    public bool ExtrasPane
+    {
+        get => Configuration.Current.ExtrasPane;
+
+        set => Configuration.Current.ExtrasPane = value;
     }
 
     /// <summary>

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -176,12 +176,12 @@ public class MainWindowController : IDisposable
         _filesBeingEditedOriginals = new Dictionary<int, PropertyMap>();
         _hadUserFilenameChange = false;
         _validSearchProperties = new string[]
-        { 
-            "filename", _("filename"), "title", _("title"), "artist", _("artist"), "album", _("album"), 
-            "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), 
-            "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), 
-            "composer", _("composer"), "description", _("description"), "discnumber", _("discnumber"), 
-            "disctotal", _("disctotal"), "publisher", _("publisher"), "publishingdate", _("publishingdate"), 
+        {
+            "filename", _("filename"), "title", _("title"), "artist", _("artist"), "album", _("album"),
+            "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"),
+            "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"),
+            "composer", _("composer"), "description", _("description"), "discnumber", _("discnumber"),
+            "disctotal", _("disctotal"), "publisher", _("publisher"), "publishingdate", _("publishingdate"),
             "custom", _("custom")
         };
         _genreSuggestions = new string[]
@@ -1008,7 +1008,7 @@ public class MainWindowController : IDisposable
         AlbumArt? pic = null;
         try
         {
-            pic = new (await File.ReadAllBytesAsync(path), type);
+            pic = new AlbumArt(await File.ReadAllBytesAsync(path), type);
         }
         catch
         {

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -366,6 +366,7 @@ public class MainWindowController : IDisposable
         {
             await CheckForUpdatesAsync();
         }
+        MusicFile.LimitFilenameCharacters = Configuration.Current.LimitFilenameCharacters;
         NetworkMonitor = await NetworkMonitor.NewAsync();
         if (_libraryToLaunch != null)
         {
@@ -1634,6 +1635,7 @@ public class MainWindowController : IDisposable
     /// <param name="e">EventArgs</param>
     private async void ConfigurationSaved(object? sender, EventArgs e)
     {
+        MusicFile.LimitFilenameCharacters = Configuration.Current.LimitFilenameCharacters;
         if (_musicLibrary != null)
         {
             var includeSubfoldersChanged = _musicLibrary.IncludeSubfolders != Configuration.Current.IncludeSubfolders;

--- a/NickvisionTagger.Shared/Controllers/PreferencesViewController.cs
+++ b/NickvisionTagger.Shared/Controllers/PreferencesViewController.cs
@@ -86,6 +86,16 @@ public class PreferencesViewController
     }
 
     /// <summary>
+    /// Whether or not filename characters should be limited to those only supported by Windows
+    /// </summary>
+    public bool LimitFilenameCharacters
+    {
+        get => Configuration.Current.LimitFilenameCharacters;
+
+        set => Configuration.Current.LimitFilenameCharacters = value;
+    }
+
+    /// <summary>
     /// Whether or not to overwrite a tag's existing data with data from MusicBrainz
     /// </summary>
     public bool OverwriteTagWithMusicBrainz

--- a/NickvisionTagger.Shared/Docs/html/C/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/C/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Preserve Modification Timestamp</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Note">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Overwrite Tag With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">Overwrite Album Art With MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/C/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/C/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/C/search.html
+++ b/NickvisionTagger.Shared/Docs/html/C/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/cs/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/cs/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Zachovat časové razítko změny</dt>
 <dd class="terms"><p class="p">Zda aktualizovat časové razítko úpravy souboru při uložení značky.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Upozornění">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Přepsat značku s MusicBrainz</dt>
 <dd class="terms"><p class="p">Zda přepsat existující metadata značek daty nalezenými na MusicBrainz. Při zakázání budou vyplněny pouze prázdné vlastnosti značek.</p></dd>
 <dt class="terms">Přepsat obal alba s MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/cs/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/cs/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/cs/search.html
+++ b/NickvisionTagger.Shared/Docs/html/cs/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/de/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/de/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Änderungs-Zeitstempel erhalten</dt>
 <dd class="terms"><p class="p">Legt fest, ob das Änderungsdatem der Datei aktualisiert werden soll wenn ein Tag gespeichert wird.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Anmerkung">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Tag mit MusicBrainz überschreiben</dt>
 <dd class="terms"><p class="p">Legt fest of existierende Metadaten mit Daten von MusicBrainz überschrieben werden sollen. Wenn die Option deaktiviert ist werden nur leere Tag-Felder gefüllt.</p></dd>
 <dt class="terms">Albumcover mit MusicBrainz überschreiben</dt>

--- a/NickvisionTagger.Shared/Docs/html/de/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/de/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/de/search.html
+++ b/NickvisionTagger.Shared/Docs/html/de/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/es/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/es/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Conservar fecha de modificación</dt>
 <dd class="terms"><p class="p">Si actualizar o no la marca de tiempo de escritura (modificado) de un archivo cuando se guarda su etiqueta.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Nota">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Sobreescribir etiqueta con MusicBrainz</dt>
 <dd class="terms"><p class="p">Si sobreescribir o no los metadatos de las etiquetas existentes con los datos encontrados en MusicBrainz. Si se desactiva, sólo se rellenarán las propiedades de etiqueta en blanco.</p></dd>
 <dt class="terms">Sobreescribir la portada del álbum con MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/es/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/es/configuration.html
@@ -33,9 +33,9 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">Nombre de archivo</span></p></li>
 <li class="list"><p class="p"><span class="code">Ruta del archivo</span></p></li>
 <li class="list"><p class="p"><span class="code">Título</span></p></li>
-<li class="list"><p class="p"><span class="code">Artist</span></p></li>
+<li class="list"><p class="p"><span class="code">Artista</span></p></li>
 <li class="list"><p class="p"><span class="code">Álbum</span></p></li>
-<li class="list"><p class="p"><span class="code">Year</span></p></li>
+<li class="list"><p class="p"><span class="code">Año</span></p></li>
 <li class="list"><p class="p"><span class="code">Pista</span></p></li>
 <li class="list"><p class="p"><span class="code">Género</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/es/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/es/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">pulsacionesporminuto (ppm)</span></p></li>
 <li class="list"><p class="p"><span class="code">compositor</span></p></li>
 <li class="list"><p class="p"><span class="code">descripción</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editor</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/es/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/es/format-strings.html
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">discnumber</span></p></li>
 <li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editor</span></p></li>
-<li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
+<li class="list"><p class="p"><span class="code">fecha de publicación</span></p></li>
 </ul></div></div></div>
 <div class="note" title="Nota">
 <svg height="24" width="24" version="1.1">

--- a/NickvisionTagger.Shared/Docs/html/es/search.html
+++ b/NickvisionTagger.Shared/Docs/html/es/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">pulsacionesporminuto (ppm)</span></p></li>
 <li class="list"><p class="p"><span class="code">compositor</span></p></li>
 <li class="list"><p class="p"><span class="code">descripción</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editor</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">personalizado</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/es/search.html
+++ b/NickvisionTagger.Shared/Docs/html/es/search.html
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">discnumber</span></p></li>
 <li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editor</span></p></li>
-<li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
+<li class="list"><p class="p"><span class="code">fecha de publicación</span></p></li>
 <li class="list"><p class="p"><span class="code">personalizado</span></p></li>
 </ul></div></div></div>
 <p class="p">Las propiedades distinguen entre mayúsculas y minúsculas.</p>

--- a/NickvisionTagger.Shared/Docs/html/fi/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/fi/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Säilytä muokkauksen aikaleima</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Huomautus">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Overwrite Tag With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">Overwrite Album Art With MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/fi/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/fi/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/fi/search.html
+++ b/NickvisionTagger.Shared/Docs/html/fi/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/fr/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Conserver l’horodatage de modification</dt>
 <dd class="terms"><p class="p">Indique s’il faut ou non mettre à jour l’horodatage de la dernière écriture (modification) d’un fichier lorsqu’une balise est enregistrée.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Note">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Écraser la balise avec MusicBrainz</dt>
 <dd class="terms"><p class="p">Indique s’il faut ou non écraser les métadonnées des balises existantes avec les données récupérées depuis MusicBrainz. Si cette option est désactivée, seules les propriétés des balises laissées vides seront remplies.</p></dd>
 <dt class="terms">Écraser la couverture d’album avec MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/fr/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">battementsparminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">compositeur</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">maisondedisques</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/fr/search.html
+++ b/NickvisionTagger.Shared/Docs/html/fr/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">battementsparminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">compositeur</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">maisondedisques</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">personnalisé</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/he/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/he/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">שמירת חותמת זמן השינוי</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="הערה">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">דריסת תג עם MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">דריסת עטיפת אלבום עם MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/he/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/he/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/he/search.html
+++ b/NickvisionTagger.Shared/Docs/html/he/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/hr/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/hr/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Sačuvaj vremensku oznaku modifikacije</dt>
 <dd class="terms"><p class="p">Da li aktualizirati vremensku oznaku pisanja (promjene) datoteke kada je njezina oznaka spremljena.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Bilješka">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Prepiši oznaku s MusicBrainz</dt>
 <dd class="terms"><p class="p">Da li prepisati postojeće metapodatke oznake podacima pronađenim na MusicBrainz. Ako je aktivirano, ispunit će se samo prazna svojstva oznake.</p></dd>
 <dt class="terms">Prepiši sliku albuma s MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/hr/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/hr/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">broje otkucaja u minuti (bmp)</span></p></li>
 <li class="list"><p class="p"><span class="code">skladatelj</span></p></li>
 <li class="list"><p class="p"><span class="code">opis</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">izdavač</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/hr/search.html
+++ b/NickvisionTagger.Shared/Docs/html/hr/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">broje otkucaja u minuti (bmp)</span></p></li>
 <li class="list"><p class="p"><span class="code">skladatelj</span></p></li>
 <li class="list"><p class="p"><span class="code">opis</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">izdavač</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">prilagođeno</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/it/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/it/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Mantieni l'istante temporale di modifica</dt>
 <dd class="terms"><p class="p">Se aggiornare o meno l'istante temporale di scrittura quando un tag è stato modificato.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Annotazione">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Sovrascrivi i tag con With MusicBrainz</dt>
 <dd class="terms"><p class="p">Se sovrascrivere i tag esistenti con i dati provenienti da MusicBrainz. Se disabilitato, verranno riempiti solo i campi lasciati vuoti.</p></dd>
 <dt class="terms">Sovrascrivi la copertina con MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/it/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/it/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">battiti al minuto</span></p></li>
 <li class="list"><p class="p"><span class="code">compositore</span></p></li>
 <li class="list"><p class="p"><span class="code">descrizione</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editore</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/it/search.html
+++ b/NickvisionTagger.Shared/Docs/html/it/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">battiti al minuto</span></p></li>
 <li class="list"><p class="p"><span class="code">compositore</span></p></li>
 <li class="list"><p class="p"><span class="code">descrizione</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">editore</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">personalizzato</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/nl/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/nl/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Preserve Modification Timestamp</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Opmerking">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Overwrite Tag With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">Overwrite Album Art With MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/nl/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/nl/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/nl/search.html
+++ b/NickvisionTagger.Shared/Docs/html/nl/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/pl/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/pl/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Preserve Modification Timestamp</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Uwaga">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Overwrite Tag With MusicBrainz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">Overwrite Album Art With MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/pl/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/pl/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/pl/search.html
+++ b/NickvisionTagger.Shared/Docs/html/pl/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/ru/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Сохранение временной метки модификации</dt>
 <dd class="terms"><p class="p">Следует ли не обновлять временную метку записи (модификации) файла при сохранении его метки.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Примечание">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">Перезапись тегов с помощью MusicBrainz</dt>
 <dd class="terms"><p class="p">Следует ли перезаписывать существующие метаданные тегов данными, полученными из MusicBrainz. Если отключено, то будут заполняться только пустые свойства тегов.</p></dd>
 <dt class="terms">Переписать обложку альбома с помощью MusicBrainz</dt>

--- a/NickvisionTagger.Shared/Docs/html/ru/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/configuration.html
@@ -33,9 +33,9 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">Имя файла</span></p></li>
 <li class="list"><p class="p"><span class="code">Путь к файлу</span></p></li>
 <li class="list"><p class="p"><span class="code">Название</span></p></li>
-<li class="list"><p class="p"><span class="code">Artist</span></p></li>
+<li class="list"><p class="p"><span class="code">Исполнитель</span></p></li>
 <li class="list"><p class="p"><span class="code">Альбом</span></p></li>
-<li class="list"><p class="p"><span class="code">Year</span></p></li>
+<li class="list"><p class="p"><span class="code">Год</span></p></li>
 <li class="list"><p class="p"><span class="code">Дорожка</span></p></li>
 <li class="list"><p class="p"><span class="code">Жанр</span></p></li>
 </ul></div></div></div>
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Следует ли перезаписывать имеющиеся в теге текстовые данные данными из Интернета.</p></dd>
 <dt class="terms">Ключ API пользователя AcoustId</dt>
 <dd class="terms">
-<p class="p">An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
+<p class="p">Пользовательский ключ API AcoustId для определения музыкальных файлов и нахождения информации о музыке.</p>
 <div class="note" title="Примечание">
 <svg height="24" width="24" version="1.1">
  <g>
@@ -78,11 +78,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/corrupted.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/corrupted.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<title>Corrupted Files</title>
+<title>Повреждённые файлы</title>
 <link rel="stylesheet" type="text/css" href="../C/C.css">
 <script type="text/javascript" src="../C/highlight.pack.js"></script><script>
 document.addEventListener('DOMContentLoaded', function() {
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
 </head>
 <body lang="ru" dir="ltr"><main><div class="page">
 <header><div class="inner pagewide"><div class="trails" role="navigation"><div class="trail">
-<a class="trail" href="index.html" title="Помощь Tagger">Помощь Tagger</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Corrupted Files</span></h1></div>
+<a class="trail" href="index.html" title="Помощь Tagger">Помощь Tagger</a> » </div></div></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title">Повреждённые файлы</span></h1></div>
 <div class="region">
 <div class="contents pagewide"><p class="p">This page explains music files with corrupted data.</p></div>
 <section id=""><div class="inner">
@@ -76,11 +76,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/format-strings.html
@@ -32,8 +32,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="title title-note"><h3><span class="title">Пример</span></h3></div>
 <div class="region"><div class="contents">
 <p class="p">Format String: <span class="code">%artist%- %title%</span></p>
-<p class="p">Filename: <span class="code">Artist1 - Song1.mp3</span></p>
-<p class="p">When running <span class="code">File Name to Tag</span> conversion, this format string and this file name will create a tag with an artist of <span class="code">Artist1</span> and a title of <span class="code">Song1</span>.</p>
+<p class="p">Имя файла: <span class="code">Исполнитель1 - Композиция1.mp3</span></p>
+<p class="p">При использовании преобразования <span class="code">Имён файлов в теги</span> эта строка и это имя файла создадут тег исполнителя <span class="code">Исполнитель1</span> и название <span class="code">Композиция1</span>.</p>
 </div></div>
 </div>
 </div>
@@ -42,22 +42,22 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Поддерживаемые свойства</span></h2></div>
 <div class="region"><div class="contents pagewide">
 <div class="list"><div class="inner"><div class="region"><ul class="list">
-<li class="list"><p class="p"><span class="code">title</span></p></li>
-<li class="list"><p class="p"><span class="code">artist</span></p></li>
-<li class="list"><p class="p"><span class="code">альбом</span></p></li>
-<li class="list"><p class="p"><span class="code">год</span></p></li>
-<li class="list"><p class="p"><span class="code">track</span></p></li>
-<li class="list"><p class="p"><span class="code">tracktotal</span></p></li>
-<li class="list"><p class="p"><span class="code">albumartist</span></p></li>
-<li class="list"><p class="p"><span class="code">жанр</span></p></li>
-<li class="list"><p class="p"><span class="code">comment</span></p></li>
-<li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
-<li class="list"><p class="p"><span class="code">composer</span></p></li>
-<li class="list"><p class="p"><span class="code">описание</span></p></li>
+<li class="list"><p class="p"><span class="code">title</span> (название)</p></li>
+<li class="list"><p class="p"><span class="code">artist</span> (исполнитель)</p></li>
+<li class="list"><p class="p"><span class="code">album</span> (альбом)</p></li>
+<li class="list"><p class="p"><span class="code">year</span> (год)</p></li>
+<li class="list"><p class="p"><span class="code">track</span> (дорожка)</p></li>
+<li class="list"><p class="p"><span class="code">tracktotal</span> (количество дорожек)</p></li>
+<li class="list"><p class="p"><span class="code">albumartist</span> (исполнитель альбома)</p></li>
+<li class="list"><p class="p"><span class="code">genre</span> (жанр)</p></li>
+<li class="list"><p class="p"><span class="code">comment</span> (комментарий)</p></li>
+<li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span> (ударов в минуту)</p></li>
+<li class="list"><p class="p"><span class="code">composer</span> (композитор)</p></li>
+<li class="list"><p class="p"><span class="code">description</span> (описание)</p></li>
 <li class="list"><p class="p"><span class="code">discnumber</span></p></li>
 <li class="list"><p class="p"><span class="code">disctotal</span></p></li>
-<li class="list"><p class="p"><span class="code">издатель</span></p></li>
-<li class="list"><p class="p"><span class="code">датапубликации</span></p></li>
+<li class="list"><p class="p"><span class="code">publisher</span> (издатель)</p></li>
+<li class="list"><p class="p"><span class="code">publishingdate</span> (дата публикации)</p></li>
 </ul></div></div></div>
 <div class="note" title="Примечание">
 <svg height="24" width="24" version="1.1">
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="title title-note"><h3><span class="title">Пример</span></h3></div>
 <div class="region"><div class="contents">
 <p class="p">Format String: <span class="code">%%- %track%. %%</span></p>
-<p class="p">Filename: <span class="code">Artist1- 05. Song1.mp3</span></p>
+<p class="p">Имя файла: <span class="code">Исполнитель1- 05. Композиция1.mp3</span></p>
 <p class="p">This format string and this file name will create a tag with a track of <span class="code">05</span> and ignore the rest of the file name.</p>
 </div></div>
 </div>
@@ -107,11 +107,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">описание</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">издатель</span></p></li>
 <li class="list"><p class="p"><span class="code">датапубликации</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/index.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/index.html
@@ -14,18 +14,18 @@ document.addEventListener('DOMContentLoaded', function() {
 }, false);</script><script type="text/javascript" src="../C/yelp.js"></script>
 </head>
 <body lang="ru" dir="ltr"><main><div class="page">
-<header><div class="inner pagewide"></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title"><span class="media"><span class="media media-image"><img src="../C/figures/tagger.png" class="media media-inline" alt=""></span></span> Tagger Help</span></h1></div>
+<header><div class="inner pagewide"></div></header><article><div class="hgroup pagewide"><h1 class="title"><span class="title"><span class="media"><span class="media media-image"><img src="../C/figures/tagger.png" class="media media-inline" alt=""></span></span> Помощь с Tagger</span></h1></div>
 <div class="region">
 <div class="contents pagewide">
 <p class="p">This documentation will help you understand how to configure <span class="app">Tagger</span> to get the most of the application.</p>
 <p class="p">To get support, use <span class="link"><a href="https://github.com/NickvisionApps/Tagger/issues" title="https://github.com/NickvisionApps/Tagger/issues">issues</a></span> or <span class="link"><a href="https://github.com/NickvisionApps/Tagger/discussions" title="https://github.com/NickvisionApps/Tagger/discussions">discussions</a></span> on Github, or <span class="link"><a href="https://bit.ly/3GrfEid" title="https://bit.ly/3GrfEid">join our Matrix channel</a></span>.</p>
 <p class="p"></p>
 <div class="links topiclinks"><div class="inner"><div class="region"><div class="links-divs">
-<div class="linkdiv "><a class="linkdiv" href="corrupted.html" title="Corrupted Files"><span class="title">Corrupted Files 🪲</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="format-strings.html" title="Format Strings"><span class="title">Format Strings ✍️</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="web-services.html" title="Веб-сервисы"><span class="title">Web Services 🌐</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="configuration.html" title="Конфигурация"><span class="title">Конфигурация 🔧</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="unsupported.html" title="Неподдерживаемые файлы"><span class="title">Неподдерживаемые файлы 🚫</span></a></div>
+<div class="linkdiv "><a class="linkdiv" href="corrupted.html" title="Повреждённые файлы"><span class="title">Повреждённые файлы 🪲</span></a></div>
 <div class="linkdiv "><a class="linkdiv" href="search.html" title="Расширенный поиск"><span class="title">Расширенный поиск 🔍</span></a></div>
 </div></div></div></div>
 </div>
@@ -93,11 +93,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Фёдор Соболев</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Фёдор Соболев</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/search.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/search.html
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="contents pagewide">
 <p class="p">This page explains how to use Advanced Search in <span class="app">Tagger</span>.</p>
 <p class="p">Advanced Search is a powerful feature provided by <span class="app">Tagger</span> that allows users to search files' tag contents for certain values, using a powerful tag-based syntax:</p>
-<p class="p"><span class="code">!prop1="value1";prop2="value2"</span></p>
+<p class="p"><span class="code">!prop1="значение1";prop2="значение2"</span></p>
 <p class="p">Where <span class="code">prop1</span>, <span class="code">prop2</span> are valid tag properties and <span class="code">value1</span>, <span class="code">value2</span> are the values to search wrapped in quotes. Each property is separated by a semicolon. Notice how the last property does not end with a semicolon.</p>
 </div>
 <section id=""><div class="inner">
@@ -28,22 +28,22 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="region"><div class="contents pagewide">
 <div class="list"><div class="inner"><div class="region"><ul class="list">
 <li class="list"><p class="p"><span class="code">filename</span></p></li>
-<li class="list"><p class="p"><span class="code">title</span></p></li>
-<li class="list"><p class="p"><span class="code">artist</span></p></li>
-<li class="list"><p class="p"><span class="code">альбом</span></p></li>
-<li class="list"><p class="p"><span class="code">год</span></p></li>
-<li class="list"><p class="p"><span class="code">track</span></p></li>
-<li class="list"><p class="p"><span class="code">tracktotal</span></p></li>
-<li class="list"><p class="p"><span class="code">albumartist</span></p></li>
-<li class="list"><p class="p"><span class="code">жанр</span></p></li>
-<li class="list"><p class="p"><span class="code">comment</span></p></li>
-<li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
-<li class="list"><p class="p"><span class="code">composer</span></p></li>
-<li class="list"><p class="p"><span class="code">описание</span></p></li>
+<li class="list"><p class="p"><span class="code">title</span> (название)</p></li>
+<li class="list"><p class="p"><span class="code">artist</span> (исполнитель)</p></li>
+<li class="list"><p class="p"><span class="code">album</span> (альбом)</p></li>
+<li class="list"><p class="p"><span class="code">year</span> (год)</p></li>
+<li class="list"><p class="p"><span class="code">track</span> (дорожка)</p></li>
+<li class="list"><p class="p"><span class="code">tracktotal</span> (количество дорожек)</p></li>
+<li class="list"><p class="p"><span class="code">albumartist</span> (исполнитель альбома)</p></li>
+<li class="list"><p class="p"><span class="code">genre</span> (жанр)</p></li>
+<li class="list"><p class="p"><span class="code">comment</span> (комментарий)</p></li>
+<li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span> (ударов в минуту)</p></li>
+<li class="list"><p class="p"><span class="code">composer</span> (композитор)</p></li>
+<li class="list"><p class="p"><span class="code">description</span> (описание)</p></li>
 <li class="list"><p class="p"><span class="code">discnumber</span></p></li>
 <li class="list"><p class="p"><span class="code">disctotal</span></p></li>
-<li class="list"><p class="p"><span class="code">издатель</span></p></li>
-<li class="list"><p class="p"><span class="code">датапубликации</span></p></li>
+<li class="list"><p class="p"><span class="code">publisher</span> (издатель)</p></li>
+<li class="list"><p class="p"><span class="code">publishingdate</span> (дата публикации)</p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>
 </ul></div></div></div>
 <p class="p">Properties are case-insensitive.</p>
@@ -79,11 +79,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/search.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">описание</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">издатель</span></p></li>
 <li class="list"><p class="p"><span class="code">датапубликации</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/html/ru/unsupported.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/unsupported.html
@@ -40,11 +40,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/web-services.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/web-services.html
@@ -86,11 +86,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="copyrights">
 <div class="copyright">© 2023 Nicholas Logozzo</div>
 <div class="copyright">© 2023 Nicholas Logozzo</div>
+<div class="copyright">© 2023 Давид Лапшин</div>
+<div class="copyright">© 2023 0куе</div>
 </div>
 <div class="credits">
 <div class="credits-authors">
 <div class="title"><span class="title">Написано</span></div>
 <ul class="credits"><li>Nicholas Logozzo</li></ul>
+</div>
+<div class="credits-translators">
+<div class="title"><span class="title">Переведено</span></div>
+<ul class="credits">
+<li>Давид Лапшин</li>
+<li>0куе</li>
+</ul>
 </div>
 <div class="credits-publishers">
 <div class="title"><span class="title">Опубликовано</span></div>

--- a/NickvisionTagger.Shared/Docs/html/tr/configuration.html
+++ b/NickvisionTagger.Shared/Docs/html/tr/configuration.html
@@ -42,6 +42,18 @@ document.addEventListener('DOMContentLoaded', function() {
 </dd>
 <dt class="terms">Değişiklik Zaman Damgasını Koru</dt>
 <dd class="terms"><p class="p">Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p></dd>
+<dt class="terms">Limit File Name Characters</dt>
+<dd class="terms">
+<p class="p">Whether or not filename characters should be limited to those only supported by Windows.</p>
+<div class="note" title="Not">
+<svg height="24" width="24" version="1.1">
+ <g>
+  <path class="yelp-svg-fill" d="m4 3h16c0.554 0 1 0.446 1 1v11h-6v6h-11c-0.554 0-1-0.446-1-1v-16c0-0.554 0.446-1 1-1z"></path>
+  <path class="yelp-svg-fill" d="m17 16h4l-5 5v-4c0-0.554 0.446-1 1-1z"></path>
+ </g>
+</svg><div class="inner"><div class="region"><div class="contents"><p class="p">This option is only available on non-Windows systems.</p></div></div></div>
+</div>
+</dd>
 <dt class="terms">MusicBrainz ile Etiketin Üzerine Yaz</dt>
 <dd class="terms"><p class="p">Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p></dd>
 <dt class="terms">MusicBrainz ile Albüm Kapağının Üzerine Yaz</dt>

--- a/NickvisionTagger.Shared/Docs/html/tr/format-strings.html
+++ b/NickvisionTagger.Shared/Docs/html/tr/format-strings.html
@@ -54,6 +54,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 </ul></div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/tr/search.html
+++ b/NickvisionTagger.Shared/Docs/html/tr/search.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <li class="list"><p class="p"><span class="code">beatsperminute (bpm)</span></p></li>
 <li class="list"><p class="p"><span class="code">composer</span></p></li>
 <li class="list"><p class="p"><span class="code">description</span></p></li>
+<li class="list"><p class="p"><span class="code">discnumber</span></p></li>
+<li class="list"><p class="p"><span class="code">disctotal</span></p></li>
 <li class="list"><p class="p"><span class="code">publisher</span></p></li>
 <li class="list"><p class="p"><span class="code">publishingdate</span></p></li>
 <li class="list"><p class="p"><span class="code">custom</span></p></li>

--- a/NickvisionTagger.Shared/Docs/po/cs.po
+++ b/NickvisionTagger.Shared/Docs/po/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-18 21:31+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -151,11 +151,28 @@ msgstr "Zda aktualizovat časové razítko úpravy souboru při uložení značk
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Přepsat značku s MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -164,36 +181,36 @@ msgstr ""
 "zakázání budou vyplněny pouze prázdné vlastnosti značek."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Přepsat obal alba s MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr "Zda přepsat existující obal alba obalem nalezeným na MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Přepsat texty s webovou službou"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr "Zda přepsat existující texty značky daty textů z webu."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "Klíč API uživatele AcoustId"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -202,7 +219,7 @@ msgstr ""
 "souborům a při vyhledávání informací o skladbách."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr "Klíč lze získat <link href=\"https://acoustid.org/api-key\">zde</link>"

--- a/NickvisionTagger.Shared/Docs/po/cs.po
+++ b/NickvisionTagger.Shared/Docs/po/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-10-18 21:31+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -317,7 +317,7 @@ msgstr ""
 "(%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Příklad"
 
@@ -409,21 +409,33 @@ msgstr "<code>description</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>composer</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>tracktotal</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>publisher</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr "<code>publishingdate</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr "Při používání převodů lze použít také vlastní názvy vlastností."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -432,12 +444,12 @@ msgstr ""
 "jako řetězec <code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Ignorování v názvech souborů k převodu na značky"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
@@ -446,17 +458,17 @@ msgstr ""
 "prázdné <code>%%</code> pro ignorování části názvu souboru při jeho čtení."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Formátový řetězec: <code>%%- %track%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Název souboru: <code>Umělec1- 05. Song1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -807,22 +819,22 @@ msgid "<code>filename</code>"
 msgstr "<code>filename</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>custom</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "U vlastností se rozlišují malá a velká písmena."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Kontrola syntaxe"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -834,17 +846,17 @@ msgstr ""
 "nebude."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Příklady"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artist=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -853,12 +865,12 @@ msgstr ""
 "kterých je prázdná značka interpreta."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";year=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -869,12 +881,12 @@ msgstr ""
 "stopa budou platné, pokud je řetězec hodnoty číslo)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!title=\"\";artist=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -883,12 +895,12 @@ msgstr ""
 "kterých je prázdná značka názvu a jejichž umělec je <code>bob</code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!custom=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/de.po
+++ b/NickvisionTagger.Shared/Docs/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-19 20:02+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -158,11 +158,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Tag mit MusicBrainz überschreiben"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -172,12 +189,12 @@ msgstr ""
 "gefüllt."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Albumcover mit MusicBrainz überschreiben"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -186,12 +203,12 @@ msgstr ""
 "überschrieben werden soll."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Songtexte mit Web-Service überschreiben"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 #, fuzzy
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
@@ -201,12 +218,12 @@ msgstr ""
 "überschrieben werden soll."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "AcoustId Nutzer-API-Key"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -215,7 +232,7 @@ msgstr ""
 "bei der Suche nach Songinformationen verwendet wird."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/de.po
+++ b/NickvisionTagger.Shared/Docs/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-09-19 20:02+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -335,7 +335,7 @@ msgstr ""
 "gehüllt sind."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Beispiel"
 
@@ -427,22 +427,34 @@ msgstr "<code>description</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>composer</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>tracktotal</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>publisher</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 #, fuzzy
 msgid "<code>publishingdate</code>"
 msgstr "<code>publisher</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr "Auch benutzerdefinierte Eigenschaftsnamen können genutzt werden."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -451,31 +463,31 @@ msgstr ""
 "<code>ENCODER</code> als <code>%encoder%</code> verwendet werden."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 #, fuzzy
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Formatvorlage: <code>%artist%- %title%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 #, fuzzy
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Dateiname: <code>Interpret1 - Song1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 #, fuzzy
 msgid ""
 "This format string and this file name will create a tag with a track of "
@@ -827,22 +839,22 @@ msgid "<code>filename</code>"
 msgstr "<code>filename</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>custom</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "Die Groß-/Kleinschreibung wird nicht beachtet."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Syntaxprüfung"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -853,29 +865,29 @@ msgstr ""
 "das Suchfeld rot angezeigt und die Suche wird nicht angewendet."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Beispiele"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artist=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr "Diese Suche filtert die Liste nach Musik, deren Interpret leer ist."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";year=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -886,12 +898,12 @@ msgstr ""
 "wenn eine Zahl angegeben wird)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!title=\"\";artist=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -900,12 +912,12 @@ msgstr ""
 "Interpret <code>bob</code> ist."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!custom=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/es.po
+++ b/NickvisionTagger.Shared/Docs/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-10-01 09:00+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -334,7 +334,7 @@ msgstr ""
 "porcentaje (%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Ejemplo"
 
@@ -426,24 +426,36 @@ msgstr "<code>descripción</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>isrc</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>pistatotal</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>editor</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 #, fuzzy
 msgid "<code>publishingdate</code>"
 msgstr "<code>editor</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 "Cuando se usan las conversiones, también se pueden usar los nombres de las "
 "propiedades personalizadas."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -452,12 +464,12 @@ msgstr ""
 "se puede usar como <code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Ignorar en la conversión el nombre del archivo a etiqueta"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
@@ -467,17 +479,17 @@ msgstr ""
 "archivo al leerlo."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Cadena de formato: <code>%%- %track%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Nombre del archivo: <code>Artist1- 05. Song1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -828,22 +840,22 @@ msgid "<code>filename</code>"
 msgstr "<code>nombredearchivo</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>personalizado</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "Las propiedades distinguen entre mayúsculas y minúsculas."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Comprobación sintáctica"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -854,17 +866,17 @@ msgstr ""
 "el cuadro de texto se volverá rojo y no filtrará la lista."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Ejemplos"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artista=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -873,12 +885,12 @@ msgstr ""
 "archivos de música cuyo artista esté vacío."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!género=\"\";año=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -889,12 +901,12 @@ msgstr ""
 "propiedades año y pista se validarán si la cadena de valores es un número)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!título=\"\";artista=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -904,12 +916,12 @@ msgstr ""
 "code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!personalizado=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."
@@ -1178,6 +1190,3 @@ msgstr ""
 
 #~ msgid "<code>bpm</code>"
 #~ msgstr "<code>ppm</code>"
-
-#~ msgid "<code>isrc</code>"
-#~ msgstr "<code>isrc</code>"

--- a/NickvisionTagger.Shared/Docs/po/es.po
+++ b/NickvisionTagger.Shared/Docs/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -156,11 +156,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Sobreescribir etiqueta con MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -170,12 +187,12 @@ msgstr ""
 "propiedades de etiqueta en blanco."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Sobreescribir la portada del álbum con MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -184,12 +201,12 @@ msgstr ""
 "encontradas en MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Sobrescribir las letras con el servicio web"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
@@ -198,12 +215,12 @@ msgstr ""
 "etiqueta con los datos de la web."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "Clave API de usuario de AcoustId"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -212,7 +229,7 @@ msgstr ""
 "de música y buscar información sobre canciones."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/es.po
+++ b/NickvisionTagger.Shared/Docs/po/es.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/docs/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/docs/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -331,7 +331,7 @@ msgstr ""
 "porcentaje (%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Ejemplo"
 
@@ -423,23 +423,35 @@ msgstr "<code>descripción</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>isrc</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>pistatotal</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>editor</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr "<code>fecha de publicación</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 "Cuando se usan las conversiones, también se pueden usar los nombres de las "
 "propiedades personalizadas."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -448,12 +460,12 @@ msgstr ""
 "se puede usar como <code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Ignorar en la conversión el nombre del archivo a etiqueta"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
@@ -463,17 +475,17 @@ msgstr ""
 "archivo al leerlo."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Cadena de formato: <code>%%- %track%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Nombre del archivo: <code>Artist1- 05. Song1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -824,22 +836,22 @@ msgid "<code>filename</code>"
 msgstr "<code>nombredearchivo</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>personalizado</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "Las propiedades distinguen entre mayúsculas y minúsculas."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Comprobación sintáctica"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -850,17 +862,17 @@ msgstr ""
 "el cuadro de texto se volverá rojo y no filtrará la lista."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Ejemplos"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artista=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -869,12 +881,12 @@ msgstr ""
 "archivos de música cuyo artista esté vacío."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!género=\"\";año=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -885,12 +897,12 @@ msgstr ""
 "propiedades año y pista se validarán si la cadena de valores es un número)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!título=\"\";artista=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -900,12 +912,12 @@ msgstr ""
 "code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!personalizado=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."
@@ -1174,6 +1186,3 @@ msgstr ""
 
 #~ msgid "<code>bpm</code>"
 #~ msgstr "<code>ppm</code>"
-
-#~ msgid "<code>isrc</code>"
-#~ msgstr "<code>isrc</code>"

--- a/NickvisionTagger.Shared/Docs/po/fi.po
+++ b/NickvisionTagger.Shared/Docs/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-06 22:11+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -146,54 +146,71 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
-msgid "Overwrite Tag With MusicBrainz"
+msgid "Limit File Name Characters"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
+msgid "Overwrite Tag With MusicBrainz"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "AcoustId:n käyttäjän API-avain"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/fi.po
+++ b/NickvisionTagger.Shared/Docs/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-09-06 22:11+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -291,7 +291,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -380,50 +380,60 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48 yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -756,22 +766,22 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -779,29 +789,29 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -809,24 +819,24 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/fr.po
+++ b/NickvisionTagger.Shared/Docs/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-14 22:10+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -159,11 +159,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Écraser la balise avec MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -173,12 +190,12 @@ msgstr ""
 "seules les propriétés des balises laissées vides seront remplies."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Écraser la couverture d’album avec MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -187,12 +204,12 @@ msgstr ""
 "celle récupérée depuis MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Remplacer les paroles avec le service web"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
@@ -201,12 +218,12 @@ msgstr ""
 "données avec des données récupérées depuis le web."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "Clé utilisateur d’API AcoustId"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -215,7 +232,7 @@ msgstr ""
 "fichiers musicaux et regarder les informations du morceau."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/fr.po
+++ b/NickvisionTagger.Shared/Docs/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-09-14 22:10+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -334,7 +334,7 @@ msgstr ""
 "pourcentages (%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Exemple"
 
@@ -426,24 +426,36 @@ msgstr "<code>description</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>compositeur</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>pistestotal</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>maisondedisques</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 #, fuzzy
 msgid "<code>publishingdate</code>"
 msgstr "<code>maisondedisques</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 "Lors de l’utilisation de la fonctionnalité conversions, des noms de "
 "propriété personnalisés peuvent aussi être utilisés."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -452,12 +464,12 @@ msgstr ""
 "code> peut être utilisée par <code>%encodeur%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Ignorer des éléments dans la conversion 'Nom de fichier vers balise'"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
@@ -467,17 +479,17 @@ msgstr ""
 "nom du fichier lors de sa lecture."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Chaîne de format : <code>%%- %piste%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Nom de fichier : <code>Artiste1- 05 Titre1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -830,22 +842,22 @@ msgid "<code>filename</code>"
 msgstr "<code>filename</code> (nom du fichier)"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>personnalisé</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "Les propriétés sont insensibles à la casse."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Vérification syntaxique"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -857,17 +869,17 @@ msgstr ""
 "liste."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Exemples"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artiste=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -876,12 +888,12 @@ msgstr ""
 "fichiers musicaux dont l’artiste n’est pas renseigné."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";année=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -893,12 +905,12 @@ msgstr ""
 "chiffres pour être valides)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!titre=\"\";artiste=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -908,12 +920,12 @@ msgstr ""
 "<code>bob</code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!personnalisée=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/he.po
+++ b/NickvisionTagger.Shared/Docs/po/he.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -147,54 +147,71 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "דריסת תג עם MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "דריסת עטיפת אלבום עם MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "מפתח משתמש API ל־AcoustId"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/he.po
+++ b/NickvisionTagger.Shared/Docs/po/he.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-08-03 18:11+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -292,7 +292,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -382,50 +382,60 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48 yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -758,22 +768,22 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -781,29 +791,29 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -811,24 +821,24 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/hr.po
+++ b/NickvisionTagger.Shared/Docs/po/hr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -329,7 +329,7 @@ msgstr ""
 "(%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Primjer"
 
@@ -421,23 +421,35 @@ msgstr "<code>opis</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>isrc</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>broj pjesama</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>izdavač</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 #, fuzzy
 msgid "<code>publishingdate</code>"
 msgstr "<code>izdavač</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 "Kada se koriste pretvaranja mogu se koristiti i imena prilagođenih svojstava."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -446,31 +458,31 @@ msgstr ""
 "koristiti kao <code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 #, fuzzy
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Format izraza: <code>%izvođač%- %naslov%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 #, fuzzy
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Ime datoteke: <code>Izvođač1 - Pjesma1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 #, fuzzy
 msgid ""
 "This format string and this file name will create a tag with a track of "
@@ -822,22 +834,22 @@ msgid "<code>filename</code>"
 msgstr "<code>ime datoteke</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>prilagođeno</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr "Svojstva ne razlikuju velika i mala slova."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Provjera sintakse"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -849,17 +861,17 @@ msgstr ""
 "popis."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Primjeri"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!izvođač=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -868,12 +880,12 @@ msgstr ""
 "o izvođaču."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!žanr=\"\";godina=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -884,12 +896,12 @@ msgstr ""
 "li se radi o broju)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!naslov=\"\";izvođač=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -898,12 +910,12 @@ msgstr ""
 "o naslovu ali s izvođačem <code>bob</code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!prilagođeno=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."
@@ -1138,6 +1150,3 @@ msgstr ""
 #~ msgstr ""
 #~ "<link href=\"https://github.com/Zeugma440/atldotnet/issues/208\">Podrška "
 #~ "za praćenja opus ispravaka</link>"
-
-#~ msgid "<code>isrc</code>"
-#~ msgstr "<code>isrc</code>"

--- a/NickvisionTagger.Shared/Docs/po/hr.po
+++ b/NickvisionTagger.Shared/Docs/po/hr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -158,11 +158,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Prepiši oznaku s MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -171,12 +188,12 @@ msgstr ""
 "MusicBrainz. Ako je aktivirano, ispunit će se samo prazna svojstva oznake."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Prepiši sliku albuma s MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -184,12 +201,12 @@ msgstr ""
 "Da li prepisati postojeće slike albuma sa slikama pronađenim ne MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 #, fuzzy
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
@@ -198,12 +215,12 @@ msgstr ""
 "Da li prepisati postojeće slike albuma sa slikama pronađenim ne MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "API ključ AcoustId korisnika"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -212,7 +229,7 @@ msgstr ""
 "datoteka i traženja informacija o pjesmi."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/it.po
+++ b/NickvisionTagger.Shared/Docs/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -330,7 +330,7 @@ msgstr ""
 "percento (%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Esempio"
 
@@ -422,24 +422,36 @@ msgstr "<code>descrizione</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>compositore</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>Traccia totale</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>editore</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 #, fuzzy
 msgid "<code>publishingdate</code>"
 msgstr "<code>editore</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 "Durante le conversioni è possibile usare nomi personalizzati per le "
 "proprietà."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -448,12 +460,12 @@ msgstr ""
 "code> può essere usata come <code>%codifica%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Da ignorare nella conversione da nome file ad etichetta"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
@@ -463,17 +475,17 @@ msgstr ""
 "nome del file durante la lettura."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Stringa di formato: <code>%%- %track%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Nome del file: <code>Artista1 -05. Brano1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -822,23 +834,23 @@ msgid "<code>filename</code>"
 msgstr "<code>nome del file</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr "<code>personalizzato</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 "Per le proprietà non viene fatta distinzione tra maiuscole e minuscole."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Controllo della sintassi"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -850,17 +862,17 @@ msgstr ""
 "casella di riepilogo."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Esempi"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artist=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
@@ -869,12 +881,12 @@ msgstr ""
 "contenga i file musicali il cui artista è vuoto."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";year=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -886,12 +898,12 @@ msgstr ""
 "un numero)."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!title=\"\";artist=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
@@ -901,12 +913,12 @@ msgstr ""
 "code>."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!custom=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/it.po
+++ b/NickvisionTagger.Shared/Docs/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -157,11 +157,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Sovrascrivi i tag con With MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -170,12 +187,12 @@ msgstr ""
 "disabilitato, verranno riempiti solo i campi lasciati vuoti."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Sovrascrivi la copertina con MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -184,12 +201,12 @@ msgstr ""
 "MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Sovrascrivi testo con il servizio in rete"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
@@ -198,12 +215,12 @@ msgstr ""
 "recuperati in rete."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "Chiave delle API di AcoustId dell'utente"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -212,7 +229,7 @@ msgstr ""
 "relative ai brani."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/nl.po
+++ b/NickvisionTagger.Shared/Docs/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -145,54 +145,71 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
-msgid "Overwrite Tag With MusicBrainz"
+msgid "Limit File Name Characters"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
+msgid "Overwrite Tag With MusicBrainz"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/nl.po
+++ b/NickvisionTagger.Shared/Docs/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -290,7 +290,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -379,50 +379,60 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48 yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -755,22 +765,22 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -778,29 +788,29 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -808,24 +818,24 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/pl.po
+++ b/NickvisionTagger.Shared/Docs/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -291,7 +291,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -380,50 +380,60 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48 yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -756,22 +766,22 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -779,29 +789,29 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -809,24 +819,24 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/po/pl.po
+++ b/NickvisionTagger.Shared/Docs/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -146,54 +146,71 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
-msgid "Overwrite Tag With MusicBrainz"
+msgid "Limit File Name Characters"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
+msgid "Overwrite Tag With MusicBrainz"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/ru.po
+++ b/NickvisionTagger.Shared/Docs/po/ru.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: 0que <0que@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/docs/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/docs/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -322,8 +322,8 @@ msgid ""
 "code> and <code>Tag to File Name</code> conversions."
 msgstr ""
 "На этой странице описывается использование строк форматирования для "
-"преобразований <code>имён файлов в теги</code> и <code>тегов в имена "
-"файлов</code>."
+"преобразований <code>имён файлов в теги</code> и <code>тегов в имена файлов</"
+"code>."
 
 #. (itstool) path: section/title
 #: yelp/C/format-strings.page:23
@@ -337,7 +337,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr "В строках форматирования свойства выделяются знаками процента (%)."
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Пример"
 
@@ -430,16 +430,28 @@ msgstr "<code>description</code> (описание)"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>composer</code> (композитор)"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>tracktotal</code> (количество дорожек)"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>publisher</code> (издатель)"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr "<code>publishingdate</code> (дата публикации)"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 #, fuzzy
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
@@ -447,7 +459,7 @@ msgstr ""
 "свойств."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -456,13 +468,13 @@ msgstr ""
 "<code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 #, fuzzy
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr "Игнорирование в преобразовании имён файлов в теги"
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 #, fuzzy
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
@@ -473,18 +485,18 @@ msgstr ""
 "прочтении."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 #, fuzzy
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr "Строка формата: <code>%%- %трек%. %%</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Имя файла: <code>Исполнитель1- 05. Композиция1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 #, fuzzy
 msgid ""
 "This format string and this file name will create a tag with a track of "
@@ -843,24 +855,24 @@ msgid "<code>filename</code>"
 msgstr "<code>filename</code> (имя файла)"
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 #, fuzzy
 msgid "<code>custom</code>"
 msgstr "<code>custom</code> (собственное)"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 #, fuzzy
 msgid "Properties are case-insensitive."
 msgstr "Свойства чувствительны к регистру."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Проверка синтаксиса"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 #, fuzzy
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
@@ -872,18 +884,18 @@ msgstr ""
 "применён не будет."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Примеры"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 #, fuzzy
 msgid "<code>!artist=\"\"</code>"
 msgstr "<code>!artist=\"\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -893,13 +905,13 @@ msgstr ""
 "исполнителем."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 #, fuzzy
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";year=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -911,13 +923,13 @@ msgstr ""
 "содержат число)"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 #, fuzzy
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!title=\"\";artist=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -927,13 +939,13 @@ msgstr ""
 "незаданным названием."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 #, fuzzy
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!custom=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files that "

--- a/NickvisionTagger.Shared/Docs/po/ru.po
+++ b/NickvisionTagger.Shared/Docs/po/ru.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-10-18 15:22+0000\n"
 "Last-Translator: 0que <0que@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/docs/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/docs/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -325,7 +325,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr "Пример"
 
@@ -423,16 +423,28 @@ msgstr "<code>описание</code>"
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
+#, fuzzy
+msgid "<code>discnumber</code>"
+msgstr "<code>композитор</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#, fuzzy
+msgid "<code>disctotal</code>"
+msgstr "<code>количество дорожек</code>"
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
 msgid "<code>publisher</code>"
 msgstr "<code>издатель</code>"
 
 #. (itstool) path: item/p
-#: yelp/C/format-strings.page:48 yelp/C/search.page:44
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr "<code>датапубликации</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 #, fuzzy
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
@@ -440,7 +452,7 @@ msgstr ""
 "свойств."
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
@@ -449,30 +461,30 @@ msgstr ""
 "<code>%encoder%</code>."
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 #, fuzzy
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr "Имя файла: <code>Исполнитель1- 05. Мелодия1.mp3</code>"
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -821,23 +833,23 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 #, fuzzy
 msgid "Properties are case-insensitive."
 msgstr "Свойства чувствительны к регистру."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr "Проверка синтаксиса"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 #, fuzzy
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
@@ -849,17 +861,17 @@ msgstr ""
 "применён не будет."
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr "Примеры"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -869,13 +881,13 @@ msgstr ""
 "исполнителем."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 #, fuzzy
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr "<code>!genre=\"\";year=\"2022\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -887,13 +899,13 @@ msgstr ""
 "содержат число)"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 #, fuzzy
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr "<code>!title=\"\";artist=\"bob\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files whose "
@@ -903,13 +915,13 @@ msgstr ""
 "незаданным названием."
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 #, fuzzy
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr "<code>!custom=\"mbrd\"</code>"
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 #, fuzzy
 msgid ""
 "This search string will filter the listbox to contain music files that "

--- a/NickvisionTagger.Shared/Docs/po/ru.po
+++ b/NickvisionTagger.Shared/Docs/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: 0que <0que@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -156,11 +156,28 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Перезапись тегов с помощью MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
@@ -170,12 +187,12 @@ msgstr ""
 "тегов."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Переписать обложку альбома с помощью MusicBrainz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
@@ -184,12 +201,12 @@ msgstr ""
 "из MusicBrainz."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr "Перезапись текстов с помощью веб-сервиса"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
@@ -198,12 +215,12 @@ msgstr ""
 "Интернета."
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "Ключ API пользователя AcoustId"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
@@ -212,7 +229,7 @@ msgstr ""
 "нахождения информации о музыке."
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/tagger.pot
+++ b/NickvisionTagger.Shared/Docs/po/tagger.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/NickvisionTagger.Shared/Docs/po/tagger.pot
+++ b/NickvisionTagger.Shared/Docs/po/tagger.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -139,46 +139,61 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
-msgid "Overwrite Tag With MusicBrainz"
+msgid "Limit File Name Characters"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:55
+msgid "Whether or not filename characters should be limited to those only supported by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
+msgid "Overwrite Tag With MusicBrainz"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:62
 msgid "Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid "Whether or not to overwrite overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid "Whether or not to overwrite a tag's existing lyric data with data from the web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid "An AcoustId User API key to use when fingerprinting music files and looking up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Docs/po/tagger.pot
+++ b/NickvisionTagger.Shared/Docs/po/tagger.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -263,7 +263,7 @@ msgstr ""
 
 #. (itstool) path: note/title
 #: yelp/C/format-strings.page:26
-#: yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -362,47 +362,59 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47
 #: yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48
 #: yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49
+#: yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50
+#: yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid "For example, a custom property who's name is <code>ENCODER</code> can be used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid "When running <code>File Name to Tag</code> conversion, an empty <code>%%</code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid "This format string and this file name will create a tag with a track of <code>05</code> and ignore the rest of the file name."
 msgstr ""
 
@@ -720,67 +732,67 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid "If the syntax of your string is valid, the textbox will turn green and will filter the listbox with your search. If the syntax of your string is invalid, the textbox will turn red and will not filter the listbox."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid "This search string will filter the listbox to contain music files whose artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid "This search string will filter the listbox to contain music files whose genre is empty and whose year is 2022 (Year and Track properties will validate if the value string is a number)."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid "This search string will filter the listbox to contain music files whose title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid "This search string will filter the listbox to contain music files that contain a custom property with the name <code>mbrd</code>."
 msgstr ""
 

--- a/NickvisionTagger.Shared/Docs/po/tr.po
+++ b/NickvisionTagger.Shared/Docs/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-19 11:01-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -145,54 +145,71 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:54
+msgid "Limit File Name Characters"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/configuration.page:55
+msgid ""
+"Whether or not filename characters should be limited to those only supported "
+"by Windows."
+msgstr ""
+
+#. (itstool) path: note/p
+#: yelp/C/configuration.page:57
+msgid "This option is only available on non-Windows systems."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/configuration.page:61
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "MusicBrainz ile Etiketin Üzerine Yaz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:55
+#: yelp/C/configuration.page:62
 msgid ""
 "Whether or not to overwrite existing tag metadata with data found from "
 "MusicBrainz. If disabled, only blank tag properties will be filled."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:58
+#: yelp/C/configuration.page:65
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "MusicBrainz ile Albüm Kapağının Üzerine Yaz"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:59
+#: yelp/C/configuration.page:66
 msgid ""
 "Whether or not to overwrite overwrite existing album art with art found from "
 "MusicBrainz."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:62
+#: yelp/C/configuration.page:69
 msgid "Overwrite Lyrics With Web Service"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:63
+#: yelp/C/configuration.page:70
 msgid ""
 "Whether or not to overwrite a tag's existing lyric data with data from the "
 "web."
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/configuration.page:66
+#: yelp/C/configuration.page:73
 msgid "AcoustId User API Key"
 msgstr "AcoustId Kullanıcı API Anahtarı"
 
 #. (itstool) path: item/p
-#: yelp/C/configuration.page:67
+#: yelp/C/configuration.page:74
 msgid ""
 "An AcoustId User API key to use when fingerprinting music files and looking "
 "up song information."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/configuration.page:69
+#: yelp/C/configuration.page:76
 msgid ""
 "A key can be obtained <link href=\"https://acoustid.org/api-key\">here</link>"
 msgstr ""

--- a/NickvisionTagger.Shared/Docs/po/tr.po
+++ b/NickvisionTagger.Shared/Docs/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-16 20:35-0400\n"
+"POT-Creation-Date: 2023-10-19 11:01-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -290,7 +290,7 @@ msgid "Strings of any format with properties wrapped in percent signs (%)."
 msgstr ""
 
 #. (itstool) path: note/title
-#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:59
+#: yelp/C/format-strings.page:26 yelp/C/format-strings.page:61
 msgid "Example"
 msgstr ""
 
@@ -379,50 +379,60 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:47 yelp/C/search.page:43
-msgid "<code>publisher</code>"
+msgid "<code>discnumber</code>"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/format-strings.page:48 yelp/C/search.page:44
+msgid "<code>disctotal</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:49 yelp/C/search.page:45
+msgid "<code>publisher</code>"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/format-strings.page:50 yelp/C/search.page:46
 msgid "<code>publishingdate</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:51
+#: yelp/C/format-strings.page:53
 msgid "When using conversions, custom property names can also be used."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:52
+#: yelp/C/format-strings.page:54
 msgid ""
 "For example, a custom property who's name is <code>ENCODER</code> can be "
 "used as <code>%encoder%</code>."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/format-strings.page:56
+#: yelp/C/format-strings.page:58
 msgid "Ignoring in File Name to Tag Conversion"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/format-strings.page:57
+#: yelp/C/format-strings.page:59
 msgid ""
 "When running <code>File Name to Tag</code> conversion, an empty <code>%%</"
 "code> can be specified to ignore part of the file name when reading it."
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:60
+#: yelp/C/format-strings.page:62
 msgid "Format String: <code>%%- %track%. %%</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:61
+#: yelp/C/format-strings.page:63
 msgid "Filename: <code>Artist1- 05. Song1.mp3</code>"
 msgstr ""
 
 #. (itstool) path: note/p
-#: yelp/C/format-strings.page:62
+#: yelp/C/format-strings.page:64
 msgid ""
 "This format string and this file name will create a tag with a track of "
 "<code>05</code> and ignore the rest of the file name."
@@ -755,22 +765,22 @@ msgid "<code>filename</code>"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/search.page:45
+#: yelp/C/search.page:47
 msgid "<code>custom</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:47
+#: yelp/C/search.page:49
 msgid "Properties are case-insensitive."
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:49
+#: yelp/C/search.page:51
 msgid "Syntax Checking"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:50
+#: yelp/C/search.page:52
 msgid ""
 "If the syntax of your string is valid, the textbox will turn green and will "
 "filter the listbox with your search. If the syntax of your string is "
@@ -778,29 +788,29 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/title
-#: yelp/C/search.page:52
+#: yelp/C/search.page:54
 msgid "Examples"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:53
+#: yelp/C/search.page:55
 msgid "<code>!artist=\"\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:54
+#: yelp/C/search.page:56
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "artist is empty."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:55
+#: yelp/C/search.page:57
 msgid "<code>!genre=\"\";year=\"2022\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:56
+#: yelp/C/search.page:58
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "genre is empty and whose year is 2022 (Year and Track properties will "
@@ -808,24 +818,24 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:57
+#: yelp/C/search.page:59
 msgid "<code>!title=\"\";artist=\"bob\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:58
+#: yelp/C/search.page:60
 msgid ""
 "This search string will filter the listbox to contain music files whose "
 "title is empty and whose artist is <code>bob</code>."
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:59
+#: yelp/C/search.page:61
 msgid "<code>!custom=\"mbrd\"</code>"
 msgstr ""
 
 #. (itstool) path: section/p
-#: yelp/C/search.page:60
+#: yelp/C/search.page:62
 msgid ""
 "This search string will filter the listbox to contain music files that "
 "contain a custom property with the name <code>mbrd</code>."

--- a/NickvisionTagger.Shared/Docs/yelp/C/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/C/configuration.page
@@ -51,6 +51,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Overwrite Tag With MusicBrainz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/C/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/C/format-strings.page
@@ -44,6 +44,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/C/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/C/search.page
@@ -40,6 +40,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/cs/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/cs/configuration.page
@@ -54,6 +54,13 @@
 		<p>Zda aktualizovat časové razítko úpravy souboru při uložení značky.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Přepsat značku s MusicBrainz</title>
 		<p>Zda přepsat existující metadata značek daty nalezenými na MusicBrainz. Při zakázání budou vyplněny pouze prázdné vlastnosti značek.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/cs/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/cs/format-strings.page
@@ -47,6 +47,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/cs/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/cs/search.page
@@ -43,6 +43,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/de/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/configuration.page
@@ -48,6 +48,13 @@
 		<p>Legt fest, ob das Änderungsdatem der Datei aktualisiert werden soll wenn ein Tag gespeichert wird.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Tag mit MusicBrainz überschreiben</title>
 		<p>Legt fest of existierende Metadaten mit Daten von MusicBrainz überschrieben werden sollen. Wenn die Option deaktiviert ist werden nur leere Tag-Felder gefüllt.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/de/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/de/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/de/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/es/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/configuration.page
@@ -54,6 +54,13 @@
 		<p>Si actualizar o no la marca de tiempo de escritura (modificado) de un archivo cuando se guarda su etiqueta.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Sobreescribir etiqueta con MusicBrainz</title>
 		<p>Si sobreescribir o no los metadatos de las etiquetas existentes con los datos encontrados en MusicBrainz. Si se desactiva, sólo se rellenarán las propiedades de etiqueta en blanco.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/es/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/configuration.page
@@ -42,9 +42,9 @@
             <item><p><code>Nombre de archivo</code></p></item>
             <item><p><code>Ruta del archivo</code></p></item>
             <item><p><code>Título</code></p></item>
-            <item><p><code>Artist</code></p></item>
+            <item><p><code>Artista</code></p></item>
             <item><p><code>Álbum</code></p></item>
-            <item><p><code>Year</code></p></item>
+            <item><p><code>Año</code></p></item>
             <item><p><code>Pista</code></p></item>
             <item><p><code>Género</code></p></item>
         </list>

--- a/NickvisionTagger.Shared/Docs/yelp/es/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/format-strings.page
@@ -47,6 +47,8 @@
         <item><p><code>pulsacionesporminuto (ppm)</code></p></item>
         <item><p><code>compositor</code></p></item>
         <item><p><code>descripción</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>editor</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/es/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/format-strings.page
@@ -50,7 +50,7 @@
         <item><p><code>discnumber</code></p></item>
         <item><p><code>disctotal</code></p></item>
         <item><p><code>editor</code></p></item>
-        <item><p><code>publishingdate</code></p></item>
+        <item><p><code>fecha de publicación</code></p></item>
     </list>
     <note>
         <p>Cuando se usan las conversiones, también se pueden usar los nombres de las propiedades personalizadas.</p>

--- a/NickvisionTagger.Shared/Docs/yelp/es/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/search.page
@@ -46,7 +46,7 @@
 <item><p><code>discnumber</code></p></item>
 <item><p><code>disctotal</code></p></item>
 <item><p><code>editor</code></p></item>
-<item><p><code>publishingdate</code></p></item>
+<item><p><code>fecha de publicación</code></p></item>
 <item><p><code>personalizado</code></p></item>
 </list>
 <p>Las propiedades distinguen entre mayúsculas y minúsculas.</p></section>

--- a/NickvisionTagger.Shared/Docs/yelp/es/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/search.page
@@ -43,6 +43,8 @@
 <item><p><code>pulsacionesporminuto (ppm)</code></p></item>
 <item><p><code>compositor</code></p></item>
 <item><p><code>descripción</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>editor</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>personalizado</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/fi/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fi/configuration.page
@@ -48,6 +48,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Overwrite Tag With MusicBrainz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/fi/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fi/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/fi/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fi/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/fr/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fr/configuration.page
@@ -54,6 +54,13 @@
 		<p>Indique s’il faut ou non mettre à jour l’horodatage de la dernière écriture (modification) d’un fichier lorsqu’une balise est enregistrée.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Écraser la balise avec MusicBrainz</title>
 		<p>Indique s’il faut ou non écraser les métadonnées des balises existantes avec les données récupérées depuis MusicBrainz. Si cette option est désactivée, seules les propriétés des balises laissées vides seront remplies.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/fr/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fr/format-strings.page
@@ -47,6 +47,8 @@
         <item><p><code>battementsparminute (bpm)</code></p></item>
         <item><p><code>compositeur</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>maisondedisques</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/fr/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/fr/search.page
@@ -43,6 +43,8 @@
 <item><p><code>battementsparminute (bpm)</code></p></item>
 <item><p><code>compositeur</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>maisondedisques</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>personnalisé</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/he/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/he/configuration.page
@@ -48,6 +48,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>דריסת תג עם MusicBrainz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/he/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/he/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/he/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/he/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/hr/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/hr/configuration.page
@@ -48,6 +48,13 @@
 		<p>Da li aktualizirati vremensku oznaku pisanja (promjene) datoteke kada je njezina oznaka spremljena.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Prepiši oznaku s MusicBrainz</title>
 		<p>Da li prepisati postojeće metapodatke oznake podacima pronađenim na MusicBrainz. Ako je aktivirano, ispunit će se samo prazna svojstva oznake.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/hr/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/hr/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>broje otkucaja u minuti (bmp)</code></p></item>
         <item><p><code>skladatelj</code></p></item>
         <item><p><code>opis</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>izdavač</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/hr/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/hr/search.page
@@ -37,6 +37,8 @@
 <item><p><code>broje otkucaja u minuti (bmp)</code></p></item>
 <item><p><code>skladatelj</code></p></item>
 <item><p><code>opis</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>izdavač</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>prilagođeno</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/it/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/it/configuration.page
@@ -48,6 +48,13 @@
 		<p>Se aggiornare o meno l'istante temporale di scrittura quando un tag è stato modificato.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Sovrascrivi i tag con With MusicBrainz</title>
 		<p>Se sovrascrivere i tag esistenti con i dati provenienti da MusicBrainz. Se disabilitato, verranno riempiti solo i campi lasciati vuoti.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/it/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/it/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>battiti al minuto</code></p></item>
         <item><p><code>compositore</code></p></item>
         <item><p><code>descrizione</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>editore</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/it/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/it/search.page
@@ -37,6 +37,8 @@
 <item><p><code>battiti al minuto</code></p></item>
 <item><p><code>compositore</code></p></item>
 <item><p><code>descrizione</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>editore</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>personalizzato</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/nl/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/nl/configuration.page
@@ -48,6 +48,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Overwrite Tag With MusicBrainz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/nl/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/nl/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/nl/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/nl/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/pl/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/pl/configuration.page
@@ -48,6 +48,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Overwrite Tag With MusicBrainz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/pl/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/pl/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/pl/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/pl/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/configuration.page
@@ -60,6 +60,13 @@
 		<p>Следует ли не обновлять временную метку записи (модификации) файла при сохранении его метки.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>Перезапись тегов с помощью MusicBrainz</title>
 		<p>Следует ли перезаписывать существующие метаданные тегов данными, полученными из MusicBrainz. Если отключено, то будут заполняться только пустые свойства тегов.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/configuration.page
@@ -12,7 +12,19 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
+
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
 
 <title>Конфигурация</title>
 <p>Эта страница описывает, что можно изменить в конфигурации приложения.</p>
@@ -36,9 +48,9 @@
             <item><p><code>Имя файла</code></p></item>
             <item><p><code>Путь к файлу</code></p></item>
             <item><p><code>Название</code></p></item>
-            <item><p><code>Artist</code></p></item>
+            <item><p><code>Исполнитель</code></p></item>
             <item><p><code>Альбом</code></p></item>
-            <item><p><code>Year</code></p></item>
+            <item><p><code>Год</code></p></item>
             <item><p><code>Дорожка</code></p></item>
             <item><p><code>Жанр</code></p></item>
         </list>
@@ -61,7 +73,7 @@
     </item>
     <item>
 		<title>Ключ API пользователя AcoustId</title>
-		<p>An AcoustId User API key to use when fingerprinting music files and looking up song information.</p>
+		<p>Пользовательский ключ API AcoustId для определения музыкальных файлов и нахождения информации о музыке.</p>
 		<note>
 			<p>Получить ключ можно <link href="https://acoustid.org/api-key">здесь</link></p>
 		</note>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/corrupted.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/corrupted.page
@@ -2,7 +2,7 @@
 <page xmlns="http://projectmallard.org/1.0/" xmlns:its="http://www.w3.org/2005/11/its" type="topic" id="corrupted" its:version="2.0" xml:lang="ru">
 <info>
 	<link type="guide" xref="index"/>
-	<title type="link">Corrupted Files 🪲</title>
+	<title type="link">Повреждённые файлы 🪲</title>
 	<credit type="author copyright">
 		<name>Nicholas Logozzo</name>
 		<years its:translate="no">2023</years>
@@ -12,9 +12,21 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
 
-<title>Corrupted Files</title>
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
+
+<title>Повреждённые файлы</title>
 <p>This page explains music files with corrupted data.</p>
 <section>
     <title>Invalid Data</title>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/format-strings.page
@@ -12,7 +12,19 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
+
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
 
 <title>Format Strings</title>
 <p>This page explains the use of format strings for <code>File Name to Tag</code> and <code>Tag to File Name</code> conversions.</p>
@@ -22,29 +34,29 @@
     <note>
         <title>Пример</title>
         <p>Format String: <code>%artist%- %title%</code></p>
-        <p>Filename: <code>Artist1 - Song1.mp3</code></p>
-        <p>When running <code>File Name to Tag</code> conversion, this format string and this file name will create a tag with an artist of <code>Artist1</code> and a title of <code>Song1</code>.</p>
+        <p>Имя файла: <code>Исполнитель1 - Композиция1.mp3</code></p>
+        <p>При использовании преобразования <code>Имён файлов в теги</code> эта строка и это имя файла создадут тег исполнителя <code>Исполнитель1</code> и название <code>Композиция1</code>.</p>
     </note>
 </section>
 <section>
     <title>Поддерживаемые свойства</title>
     <list>
-        <item><p><code>title</code></p></item>
-        <item><p><code>artist</code></p></item>
-        <item><p><code>альбом</code></p></item>
-        <item><p><code>год</code></p></item>
-        <item><p><code>track</code></p></item>
-        <item><p><code>tracktotal</code></p></item>
-        <item><p><code>albumartist</code></p></item>
-        <item><p><code>жанр</code></p></item>
-        <item><p><code>comment</code></p></item>
-        <item><p><code>beatsperminute (bpm)</code></p></item>
-        <item><p><code>composer</code></p></item>
-        <item><p><code>описание</code></p></item>
+        <item><p><code>title</code> (название)</p></item>
+        <item><p><code>artist</code> (исполнитель)</p></item>
+        <item><p><code>album</code> (альбом)</p></item>
+        <item><p><code>year</code> (год)</p></item>
+        <item><p><code>track</code> (дорожка)</p></item>
+        <item><p><code>tracktotal</code> (количество дорожек)</p></item>
+        <item><p><code>albumartist</code> (исполнитель альбома)</p></item>
+        <item><p><code>genre</code> (жанр)</p></item>
+        <item><p><code>comment</code> (комментарий)</p></item>
+        <item><p><code>beatsperminute (bpm)</code> (ударов в минуту)</p></item>
+        <item><p><code>composer</code> (композитор)</p></item>
+        <item><p><code>description</code> (описание)</p></item>
         <item><p><code>discnumber</code></p></item>
         <item><p><code>disctotal</code></p></item>
-        <item><p><code>издатель</code></p></item>
-        <item><p><code>датапубликации</code></p></item>
+        <item><p><code>publisher</code> (издатель)</p></item>
+        <item><p><code>publishingdate</code> (дата публикации)</p></item>
     </list>
     <note>
         <p>When using conversions, custom property names can also be used.</p>
@@ -57,7 +69,7 @@
     <note>
         <title>Пример</title>
         <p>Format String: <code>%%- %track%. %%</code></p>
-        <p>Filename: <code>Artist1- 05. Song1.mp3</code></p>
+        <p>Имя файла: <code>Исполнитель1- 05. Композиция1.mp3</code></p>
         <p>This format string and this file name will create a tag with a track of <code>05</code> and ignore the rest of the file name.</p>
     </note>
 </section>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>описание</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>издатель</code></p></item>
         <item><p><code>датапубликации</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/index.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/index.page
@@ -12,9 +12,21 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
 
-<title><media its:translate="no" type="image" src="figures/tagger.png"/> Tagger Help</title>
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
+
+<title><media its:translate="no" type="image" src="figures/tagger.png"/> Помощь с Tagger</title>
 <p>This documentation will help you understand how to configure <app>Tagger</app> to get the most of the application.</p>
 <p>To get support, use <link href="https://github.com/NickvisionApps/Tagger/issues">issues</link> or <link href="https://github.com/NickvisionApps/Tagger/discussions">discussions</link> on Github, or <link href="https://bit.ly/3GrfEid">join our Matrix channel</link>.</p>
 <p/>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/search.page
@@ -12,35 +12,47 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
+
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
 
 <title>Расширенный поиск</title>
 <p>This page explains how to use Advanced Search in <app>Tagger</app>.</p>
 
 <p>Advanced Search is a powerful feature provided by <app>Tagger</app> that allows users to search files' tag contents for certain values, using a powerful tag-based syntax:</p>
-<p><code>!prop1="value1";prop2="value2"</code></p>
+<p><code>!prop1="значение1";prop2="значение2"</code></p>
 <p>Where <code>prop1</code>, <code>prop2</code> are valid tag properties and <code>value1</code>, <code>value2</code> are the values to search wrapped in quotes. Each property is separated by a semicolon. Notice how the last property does not end with a semicolon.</p>
 
 <section>
 <title>Valid Properties</title>
 <list>
 <item><p><code>filename</code></p></item>
-<item><p><code>title</code></p></item>
-<item><p><code>artist</code></p></item>
-<item><p><code>альбом</code></p></item>
-<item><p><code>год</code></p></item>
-<item><p><code>track</code></p></item>
-<item><p><code>tracktotal</code></p></item>
-<item><p><code>albumartist</code></p></item>
-<item><p><code>жанр</code></p></item>
-<item><p><code>comment</code></p></item>
-<item><p><code>beatsperminute (bpm)</code></p></item>
-<item><p><code>composer</code></p></item>
-<item><p><code>описание</code></p></item>
+<item><p><code>title</code> (название)</p></item>
+<item><p><code>artist</code> (исполнитель)</p></item>
+<item><p><code>album</code> (альбом)</p></item>
+<item><p><code>year</code> (год)</p></item>
+<item><p><code>track</code> (дорожка)</p></item>
+<item><p><code>tracktotal</code> (количество дорожек)</p></item>
+<item><p><code>albumartist</code> (исполнитель альбома)</p></item>
+<item><p><code>genre</code> (жанр)</p></item>
+<item><p><code>comment</code> (комментарий)</p></item>
+<item><p><code>beatsperminute (bpm)</code> (ударов в минуту)</p></item>
+<item><p><code>composer</code> (композитор)</p></item>
+<item><p><code>description</code> (описание)</p></item>
 <item><p><code>discnumber</code></p></item>
 <item><p><code>disctotal</code></p></item>
-<item><p><code>издатель</code></p></item>
-<item><p><code>датапубликации</code></p></item>
+<item><p><code>publisher</code> (издатель)</p></item>
+<item><p><code>publishingdate</code> (дата публикации)</p></item>
 <item><p><code>custom</code></p></item>
 </list>
 <p>Properties are case-insensitive.</p></section>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>описание</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>издатель</code></p></item>
 <item><p><code>датапубликации</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/unsupported.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/unsupported.page
@@ -12,7 +12,19 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
+
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
 
 <title>Неподдерживаемые файлы</title>
 <p>This page explains music files that are currently unsupported by <app>Tagger</app>.</p>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/web-services.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/web-services.page
@@ -12,7 +12,19 @@
 		<years its:translate="no">2023</years>
 	</credit>
 	<license href="http://creativecommons.org/licenses/by/4.0/" its:translate="no"><p>Creative Commons Attribution 4.0 International License</p></license>
-</info>
+
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>Давид Лапшин</mal:name>
+      <mal:email>ddaudix@gmail.com</mal:email>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  
+    <mal:credit xmlns:mal="http://projectmallard.org/1.0/" type="translator copyright">
+      <mal:name>0куе</mal:name>
+      <mal:email/>
+      <mal:years>2023</mal:years>
+    </mal:credit>
+  </info>
 
 <title>Веб-сервисы</title>
 <p>Эта страница описывает веб-службы, поддерживаемые Tagger</p>

--- a/NickvisionTagger.Shared/Docs/yelp/tr/configuration.page
+++ b/NickvisionTagger.Shared/Docs/yelp/tr/configuration.page
@@ -48,6 +48,13 @@
 		<p>Whether or not to not update a file's write (modified) timestamp when its tag is saved.</p>
 	</item>
     <item>
+        <title>Limit File Name Characters</title>
+        <p>Whether or not filename characters should be limited to those only supported by Windows.</p>
+        <note>
+            <p>This option is only available on non-Windows systems.</p>
+        </note>
+    </item>
+    <item>
 		<title>MusicBrainz ile Etiketin Üzerine Yaz</title>
 		<p>Whether or not to overwrite existing tag metadata with data found from MusicBrainz. If disabled, only blank tag properties will be filled.</p>
 	</item>

--- a/NickvisionTagger.Shared/Docs/yelp/tr/format-strings.page
+++ b/NickvisionTagger.Shared/Docs/yelp/tr/format-strings.page
@@ -41,6 +41,8 @@
         <item><p><code>beatsperminute (bpm)</code></p></item>
         <item><p><code>composer</code></p></item>
         <item><p><code>description</code></p></item>
+        <item><p><code>discnumber</code></p></item>
+        <item><p><code>disctotal</code></p></item>
         <item><p><code>publisher</code></p></item>
         <item><p><code>publishingdate</code></p></item>
     </list>

--- a/NickvisionTagger.Shared/Docs/yelp/tr/search.page
+++ b/NickvisionTagger.Shared/Docs/yelp/tr/search.page
@@ -37,6 +37,8 @@
 <item><p><code>beatsperminute (bpm)</code></p></item>
 <item><p><code>composer</code></p></item>
 <item><p><code>description</code></p></item>
+<item><p><code>discnumber</code></p></item>
+<item><p><code>disctotal</code></p></item>
 <item><p><code>publisher</code></p></item>
 <item><p><code>publishingdate</code></p></item>
 <item><p><code>custom</code></p></item>

--- a/NickvisionTagger.Shared/Models/AlbumArt.cs
+++ b/NickvisionTagger.Shared/Models/AlbumArt.cs
@@ -1,0 +1,145 @@
+﻿using ATL;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace NickvisionTagger.Shared.Models;
+
+/// <summary>
+/// Types of album arts
+/// </summary>
+public enum AlbumArtType
+{
+    Front = 0,
+    Back
+}
+
+/// <summary>
+/// A model of an AlbumArt
+/// </summary>
+public class AlbumArt : IEquatable<AlbumArt>
+{
+    /// <summary>
+    /// The byte[] of the album art image
+    /// </summary>
+    public byte[] Image { get; init; }
+    /// <summary>
+    /// The type of the album art
+    /// </summary>
+    public AlbumArtType Type { get; init; }
+    /// <summary>
+    /// The width of the album art
+    /// </summary>
+    public int Width { get; private set; }
+    /// <summary>
+    /// The height of the album art
+    /// </summary>
+    public int Height { get; private set; }
+    /// <summary>
+    /// The ATL.PictureInfo object of the album art
+    /// </summary>
+    public PictureInfo ATLPictureInfo { get; private set; }
+
+    /// <summary>
+    /// Whether or not the album art is empty
+    /// </summary>
+    public bool IsEmpty => Image.Length == 0;
+    /// <summary>
+    /// The mime type of the album art
+    /// </summary>
+    public string MimeType => ATLPictureInfo.MimeType;
+
+    /// <summary>
+    /// Constructs an AlbumArt
+    /// </summary>
+    /// <param name="data">The byte[] of the album art image</param>
+    public AlbumArt(byte[] data, AlbumArtType type)
+    {
+        Image = data;
+        Type = type;
+        if(Image.Length > 0)
+        {
+            using var image = SixLabors.ImageSharp.Image.Load(Image);
+            Width = image.Width;
+            Height = image.Height;
+        }
+        else
+        {
+            Width = 0; 
+            Height = 0;
+        }
+        ATLPictureInfo = PictureInfo.fromBinaryData(Image, Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back);
+    }
+
+    /// <summary>
+    /// Constructs an AlbumArt
+    /// </summary>
+    /// <param name="pictureInfo">The ATL.PictureInfo object</param>
+    public AlbumArt(PictureInfo pictureInfo)
+    {
+        Image = pictureInfo.PictureData;
+        Type = pictureInfo.PicType == PictureInfo.PIC_TYPE.Back ? AlbumArtType.Back : AlbumArtType.Front; //PIC_TYPE.Generic classifies as AlbumArtTpye.Front
+        if (Image.Length > 0)
+        {
+            using var image = SixLabors.ImageSharp.Image.Load(Image);
+            Width = image.Width;
+            Height = image.Height;
+        }
+        else
+        {
+            Width = 0;
+            Height = 0;
+        }
+        ATLPictureInfo = pictureInfo;
+        ATLPictureInfo.PicType = Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back; //ensure PicType incase of generic
+    }
+
+    /// <summary>
+    /// Gets a string representation of the AlbumArt
+    /// </summary>
+    /// <returns>The string representation of the AlbumArt</returns>
+    public override string ToString() => Encoding.UTF8.GetString(Image);
+
+    /// <summary>
+    /// Gets whether or not an object is equal to this AlbumArt
+    /// </summary>
+    /// <param name="obj">The object to compare</param>
+    /// <returns>True if equals, else false</returns>
+    public override bool Equals(object? obj)
+    {
+        if (obj is AlbumArt toCompare)
+        {
+            return Equals(toCompare);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Gets whether or not an object is equal to this AlbumArt
+    /// </summary>
+    /// <param name="obj">The AlbumArt? object to compare</param>
+    /// <returns>True if equals, else false</returns>
+    public bool Equals(AlbumArt? obj) => Image.SequenceEqual(obj?.Image ?? Array.Empty<byte>());
+
+    /// <summary>
+    /// Gets a hash code for the object
+    /// </summary>
+    /// <returns>The hash code for the object</returns>
+    public override int GetHashCode() => Image.GetHashCode();
+
+    /// <summary>
+    /// Compares two AlbumArt objects by ==
+    /// </summary>
+    /// <param name="a">The first AlbumArt object</param>
+    /// <param name="b">The second AlbumArt object</param>
+    /// <returns>True if a == b, else false</returns>
+    public static bool operator ==(AlbumArt? a, AlbumArt? b) => (a?.Image ?? Array.Empty<byte>()).SequenceEqual(b?.Image ?? Array.Empty<byte>());
+
+    /// <summary>
+    /// Compares two AlbumArt objects by !=
+    /// </summary>
+    /// <param name="a">The first AlbumArt object</param>
+    /// <param name="b">The second AlbumArt object</param>
+    /// <returns>True if a != b, else false</returns>
+    public static bool operator !=(AlbumArt? a, AlbumArt? b) => !(a?.Image ?? Array.Empty<byte>()).SequenceEqual(b?.Image ?? Array.Empty<byte>());
+}

--- a/NickvisionTagger.Shared/Models/AlbumArt.cs
+++ b/NickvisionTagger.Shared/Models/AlbumArt.cs
@@ -1,5 +1,8 @@
 ﻿using ATL;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -35,6 +38,10 @@ public class AlbumArt : IEquatable<AlbumArt>
     /// The height of the album art
     /// </summary>
     public int Height { get; private set; }
+    /// <summary>
+    /// <see cref="Image"/> converted to 32x32 JPEG, as byte[]
+    /// </summary>
+    public byte[] Icon { get; init; }
     /// <summary>
     /// The ATL.PictureInfo object of the album art
     /// </summary>
@@ -84,11 +91,16 @@ public class AlbumArt : IEquatable<AlbumArt>
             using var image = SixLabors.ImageSharp.Image.Load(Image);
             Width = image.Width;
             Height = image.Height;
+            image.Mutate(x => x.Resize(32, 32));
+            using var ms = new MemoryStream();
+            image.SaveAsJpeg(ms);
+            Icon = ms.ToArray();
         }
         else
         {
             Width = 0;
             Height = 0;
+            Icon = Array.Empty<byte>();
         }
         ATLPictureInfo = pictureInfo;
         ATLPictureInfo.PicType = Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back; //ensure PicType in case of generic

--- a/NickvisionTagger.Shared/Models/AlbumArt.cs
+++ b/NickvisionTagger.Shared/Models/AlbumArt.cs
@@ -91,7 +91,7 @@ public class AlbumArt : IEquatable<AlbumArt>
             Height = 0;
         }
         ATLPictureInfo = pictureInfo;
-        ATLPictureInfo.PicType = Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back; //ensure PicType incase of generic
+        ATLPictureInfo.PicType = Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back; //ensure PicType in case of generic
     }
 
     /// <summary>

--- a/NickvisionTagger.Shared/Models/AlbumArt.cs
+++ b/NickvisionTagger.Shared/Models/AlbumArt.cs
@@ -57,7 +57,7 @@ public class AlbumArt : IEquatable<AlbumArt>
     {
         Image = data;
         Type = type;
-        if(Image.Length > 0)
+        if (Image.Length > 0)
         {
             using var image = SixLabors.ImageSharp.Image.Load(Image);
             Width = image.Width;
@@ -65,7 +65,7 @@ public class AlbumArt : IEquatable<AlbumArt>
         }
         else
         {
-            Width = 0; 
+            Width = 0;
             Height = 0;
         }
         ATLPictureInfo = PictureInfo.fromBinaryData(Image, Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back);

--- a/NickvisionTagger.Shared/Models/AlbumArt.cs
+++ b/NickvisionTagger.Shared/Models/AlbumArt.cs
@@ -22,10 +22,8 @@ public enum AlbumArtType
 /// </summary>
 public class AlbumArt : IEquatable<AlbumArt>
 {
-    /// <summary>
-    /// The byte[] of the album art image
-    /// </summary>
-    public byte[] Image { get; init; }
+    private byte[] _image;
+
     /// <summary>
     /// The type of the album art
     /// </summary>
@@ -33,11 +31,11 @@ public class AlbumArt : IEquatable<AlbumArt>
     /// <summary>
     /// The width of the album art
     /// </summary>
-    public int Width { get; private set; }
+    public int Width { get; init; }
     /// <summary>
     /// The height of the album art
     /// </summary>
-    public int Height { get; private set; }
+    public int Height { get; init; }
     /// <summary>
     /// <see cref="Image"/> converted to 32x32 JPEG, as byte[]
     /// </summary>
@@ -45,7 +43,7 @@ public class AlbumArt : IEquatable<AlbumArt>
     /// <summary>
     /// The ATL.PictureInfo object of the album art
     /// </summary>
-    public PictureInfo ATLPictureInfo { get; private set; }
+    public PictureInfo ATLPictureInfo { get; init; }
 
     /// <summary>
     /// Whether or not the album art is empty
@@ -64,17 +62,6 @@ public class AlbumArt : IEquatable<AlbumArt>
     {
         Image = data;
         Type = type;
-        if (Image.Length > 0)
-        {
-            using var image = SixLabors.ImageSharp.Image.Load(Image);
-            Width = image.Width;
-            Height = image.Height;
-        }
-        else
-        {
-            Width = 0;
-            Height = 0;
-        }
         ATLPictureInfo = PictureInfo.fromBinaryData(Image, Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back);
     }
 
@@ -86,24 +73,37 @@ public class AlbumArt : IEquatable<AlbumArt>
     {
         Image = pictureInfo.PictureData;
         Type = pictureInfo.PicType == PictureInfo.PIC_TYPE.Back ? AlbumArtType.Back : AlbumArtType.Front; //PIC_TYPE.Generic classifies as AlbumArtTpye.Front
-        if (Image.Length > 0)
-        {
-            using var image = SixLabors.ImageSharp.Image.Load(Image);
-            Width = image.Width;
-            Height = image.Height;
-            image.Mutate(x => x.Resize(32, 32));
-            using var ms = new MemoryStream();
-            image.SaveAsJpeg(ms);
-            Icon = ms.ToArray();
-        }
-        else
-        {
-            Width = 0;
-            Height = 0;
-            Icon = Array.Empty<byte>();
-        }
         ATLPictureInfo = pictureInfo;
         ATLPictureInfo.PicType = Type == AlbumArtType.Front ? PictureInfo.PIC_TYPE.Front : PictureInfo.PIC_TYPE.Back; //ensure PicType in case of generic
+    }
+
+    /// <summary>
+    /// The byte[] of the album art image
+    /// </summary>
+    public byte[] Image
+    {
+        get => _image;
+
+        init
+        {
+            _image = value;
+            if (_image.Length > 0)
+            {
+                using var image = SixLabors.ImageSharp.Image.Load(_image);
+                Width = image.Width;
+                Height = image.Height;
+                image.Mutate(x => x.Resize(32, 32));
+                using var ms = new MemoryStream();
+                image.SaveAsJpeg(ms);
+                Icon = ms.ToArray();
+            }
+            else
+            {
+                Width = 0;
+                Height = 0;
+                Icon = Array.Empty<byte>();
+            }
+        }
     }
 
     /// <summary>

--- a/NickvisionTagger.Shared/Models/Configuration.cs
+++ b/NickvisionTagger.Shared/Models/Configuration.cs
@@ -65,6 +65,10 @@ public class Configuration : ConfigurationBase
     /// </summary>
     public bool PreserveModificationTimestamp { get; set; }
     /// <summary>
+    /// Whether or not filename characters should be limited to those only supported by Windows
+    /// </summary>
+    public bool LimitFilenameCharacters { get; set; }
+    /// <summary>
     /// Whether or not to overwrite a tag's existing data with data from MusicBrainz
     /// </summary>
     public bool OverwriteTagWithMusicBrainz { get; set; }
@@ -101,6 +105,7 @@ public class Configuration : ConfigurationBase
         SortFilesBy = SortBy.Path;
         LastOpenedFolder = "";
         PreserveModificationTimestamp = false;
+        LimitFilenameCharacters = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         OverwriteTagWithMusicBrainz = true;
         OverwriteAlbumArtWithMusicBrainz = true;
         OverwriteLyricsWithWebService = true;

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -790,7 +790,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         {
             string value = match.Value.Remove(0, 1); //remove first %
             value = value.Remove(value.Length - 1, 1); //remove last %;
-            if (_validProperties.Contains(value.ToLower()))
+            if (_validProperties.Contains(value.ToLower()) && value.ToLower() != "lyrics" && value.ToLower() != _("lyrics"))
             {
                 value = value.ToLower();
                 var replace = "";

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -150,7 +150,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 newFilename += _dotExtension;
             }
             var invalidCharacters = _invalidSystemFilenameCharacters;
-            if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && LimitFilenameCharacters)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && LimitFilenameCharacters)
             {
                 invalidCharacters = _invalidSystemFilenameCharacters.Union(_invalidWindowsFilenameCharacters);
             }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using static Nickvision.Aura.Localization.Gettext;
@@ -124,7 +123,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             }
             foreach (var invalidChar in _invalidFilenameCharacters)
             {
-                if(newFilename.Contains(invalidChar))
+                if (newFilename.Contains(invalidChar))
                 {
                     newFilename = newFilename.Replace(invalidChar, '_');
                 }
@@ -136,7 +135,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             _filename = newFilename;
         }
     }
-    
+
     /// <summary>
     /// The title of the music file
     /// </summary>

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -43,6 +43,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     private DateTime _modificationTimestamp;
     private Process? _fpcalc;
     private string _fingerprint;
+    private AlbumArt? _frontArt;
+    private AlbumArt? _backArt;
 
     /// <summary>
     /// What to sort files in a music folder by
@@ -108,6 +110,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         _modificationTimestamp = File.GetLastWriteTime(Path);
         _fpcalc = null;
         _fingerprint = "";
+        _frontArt = FrontAlbumArt;
+        _backArt = BackAlbumArt;
     }
 
     /// <summary>
@@ -317,19 +321,28 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     {
         get
         {
-            var generic = new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
+            if (_frontArt != null)
+            {
+                return _frontArt;
+            }
+            AlbumArt? art = null;
             foreach (var picture in _track.EmbeddedPictures)
             {
                 if (picture.PicType == PictureInfo.PIC_TYPE.Front)
                 {
-                    return new AlbumArt(picture);
+                    art = new AlbumArt(picture);
+                    break;
                 }
                 if (picture.PicType == PictureInfo.PIC_TYPE.Generic)
                 {
-                    generic = new AlbumArt(picture);
+                    art = new AlbumArt(picture);
                 }
             }
-            return generic;
+            if (art == null)
+            {
+                art = new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
+            }
+            return art;
         }
 
         set
@@ -344,6 +357,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 _track.EmbeddedPictures.Add(backAlbumArt.ATLPictureInfo);
             }
+            _frontArt = value;
         }
     }
 
@@ -354,6 +368,10 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     {
         get
         {
+            if (_backArt != null)
+            {
+                return _backArt;
+            }
             var back = _track.EmbeddedPictures.FirstOrDefault(x => x.PicType == PictureInfo.PIC_TYPE.Back);
             if (back == null)
             {
@@ -374,6 +392,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 _track.EmbeddedPictures.Add(frontAlbumArt.ATLPictureInfo);
             }
+            _backArt = value;
         }
     }
 

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -43,8 +43,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     private DateTime _modificationTimestamp;
     private Process? _fpcalc;
     private string _fingerprint;
-    private AlbumArt? _frontArt;
-    private AlbumArt? _backArt;
+    private AlbumArt _frontAlbumArt;
+    private AlbumArt _backAlbumArt;
 
     /// <summary>
     /// What to sort files in a music folder by
@@ -110,8 +110,24 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         _modificationTimestamp = File.GetLastWriteTime(Path);
         _fpcalc = null;
         _fingerprint = "";
-        _frontArt = FrontAlbumArt;
-        _backArt = BackAlbumArt;
+        //Load Front Album Art
+        PictureInfo? front = null;
+        foreach (var picture in _track.EmbeddedPictures)
+        {
+            if (picture.PicType == PictureInfo.PIC_TYPE.Front)
+            {
+                front = picture;
+                break;
+            }
+            if (picture.PicType == PictureInfo.PIC_TYPE.Generic)
+            {
+                front = picture;
+            }
+        }
+        _frontAlbumArt = front != null ? new AlbumArt(front) : new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
+        //Load Back Album Art
+        var back = _track.EmbeddedPictures.FirstOrDefault(x => x.PicType == PictureInfo.PIC_TYPE.Back);
+        _backAlbumArt = back != null ? new AlbumArt(back) : new AlbumArt(Array.Empty<byte>(), AlbumArtType.Back);
     }
 
     /// <summary>
@@ -319,31 +335,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// </summary>
     public AlbumArt FrontAlbumArt
     {
-        get
-        {
-            if (_frontArt != null)
-            {
-                return _frontArt;
-            }
-            AlbumArt? art = null;
-            foreach (var picture in _track.EmbeddedPictures)
-            {
-                if (picture.PicType == PictureInfo.PIC_TYPE.Front)
-                {
-                    art = new AlbumArt(picture);
-                    break;
-                }
-                if (picture.PicType == PictureInfo.PIC_TYPE.Generic)
-                {
-                    art = new AlbumArt(picture);
-                }
-            }
-            if (art == null)
-            {
-                art = new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
-            }
-            return art;
-        }
+        get => _frontAlbumArt;
 
         set
         {
@@ -357,7 +349,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 _track.EmbeddedPictures.Add(backAlbumArt.ATLPictureInfo);
             }
-            _frontArt = value;
+            _frontAlbumArt = value;
         }
     }
 
@@ -366,19 +358,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// </summary>
     public AlbumArt BackAlbumArt
     {
-        get
-        {
-            if (_backArt != null)
-            {
-                return _backArt;
-            }
-            var back = _track.EmbeddedPictures.FirstOrDefault(x => x.PicType == PictureInfo.PIC_TYPE.Back);
-            if (back == null)
-            {
-                return new AlbumArt(Array.Empty<byte>(), AlbumArtType.Back);
-            }
-            return new AlbumArt(back);
-        }
+        get => _backAlbumArt;
 
         set
         {
@@ -392,7 +372,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 _track.EmbeddedPictures.Add(frontAlbumArt.ATLPictureInfo);
             }
-            _backArt = value;
+            _backAlbumArt = value;
         }
     }
 

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -64,14 +64,14 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     /// <summary>
     /// Whether or not the tag is empty
     /// </summary>
-    public bool IsTagEmpty => Title == "" && Artist == "" && Album == "" && Year == 0 && Track == 0 && TrackTotal == 0 && AlbumArtist == "" && Genre == "" && Comment == "" && BeatsPerMinute == 0 && Composer == "" && Description == "" && Publisher == "" && PublishingDate == DateTime.MinValue && FrontAlbumArt.Length == 0 && BackAlbumArt.Length == 0 && _track.AdditionalFields.Count == 0 && string.IsNullOrEmpty(Lyrics.Description) && string.IsNullOrEmpty(Lyrics.UnsynchronizedLyrics) && Lyrics.SynchronizedLyrics.Count == 0;
+    public bool IsTagEmpty => Title == "" && Artist == "" && Album == "" && Year == 0 && Track == 0 && TrackTotal == 0 && AlbumArtist == "" && Genre == "" && Comment == "" && BeatsPerMinute == 0 && Composer == "" && Description == "" && DiscNumber == 0 && DiscTotal == 0 && Publisher == "" && PublishingDate == DateTime.MinValue && FrontAlbumArt.Length == 0 && BackAlbumArt.Length == 0 && _track.AdditionalFields.Count == 0 && string.IsNullOrEmpty(Lyrics.Description) && string.IsNullOrEmpty(Lyrics.UnsynchronizedLyrics) && Lyrics.SynchronizedLyrics.Count == 0;
 
     /// <summary>
     /// Constructs a static MusicFile
     /// </summary>
     static MusicFile()
     {
-        _validProperties = new string[] { "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "publisher", _("publisher"), "publishingdate", _("publishingdate"), "lyrics", _("lyrics") };
+        _validProperties = new string[] { "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "discnumber", _("discnumber"), "disctotal", _("disctotal"), "publisher", _("publisher"), "publishingdate", _("publishingdate"), "lyrics", _("lyrics") };
         _invalidFilenameCharacters = System.IO.Path.GetInvalidPathChars().Union(System.IO.Path.GetInvalidFileNameChars());
         SortFilesBy = SortBy.Path;
         ATL.Settings.UseFileNameWhenNoTitle = false;
@@ -136,7 +136,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             _filename = newFilename;
         }
     }
-
+    
     /// <summary>
     /// The title of the music file
     /// </summary>
@@ -255,6 +255,26 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         get => _track.Description ?? "";
 
         set => _track.Description = value;
+    }
+
+    /// <summary>
+    /// The disc number of the music file
+    /// </summary>
+    public int DiscNumber
+    {
+        get => _track.DiscNumber ?? 0;
+
+        set => _track.DiscNumber = value;
+    }
+
+    /// <summary>
+    /// The disc total of the music file
+    /// </summary>
+    public int DiscTotal
+    {
+        get => _track.DiscTotal ?? 0;
+
+        set => _track.DiscTotal = value;
     }
 
     /// <summary>
@@ -450,6 +470,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 BeatsPerMinute = BeatsPerMinute == 0 ? "" : BeatsPerMinute.ToString(),
                 Composer = Composer,
                 Description = Description,
+                DiscNumber = DiscNumber == 0 ? "" : DiscNumber.ToString(),
+                DiscTotal = DiscTotal == 0 ? "" : DiscTotal.ToString(),
                 Publisher = Publisher,
                 PublishingDate = PublishingDate == DateTime.MinValue ? "" : PublishingDate.ToShortDateString(),
                 FrontAlbumArt = Encoding.UTF8.GetString(FrontAlbumArt),
@@ -545,6 +567,8 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         BeatsPerMinute = 0;
         Composer = "";
         Description = "";
+        DiscNumber = 0;
+        DiscTotal = 0;
         Publisher = "";
         PublishingDate = DateTime.MinValue;
         _track.EmbeddedPictures.Clear();
@@ -707,6 +731,22 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 Description = filename.Substring(0, len);
             }
+            else if (value == "discnumber" || value == _("discnumber"))
+            {
+                try
+                {
+                    DiscNumber = int.Parse(filename.Substring(0, len));
+                }
+                catch { }
+            }
+            else if (value == "disctotal" || value == _("disctotal"))
+            {
+                try
+                {
+                    DiscTotal = int.Parse(filename.Substring(0, len));
+                }
+                catch { }
+            }
             else if (value == "publisher" || value == _("publisher"))
             {
                 Publisher = filename.Substring(0, len);
@@ -801,6 +841,14 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 else if (value == "description" || value == _("description"))
                 {
                     replace = Description;
+                }
+                else if (value == "discnumber" || value == _("discnumber"))
+                {
+                    replace = DiscNumber.ToString("D2");
+                }
+                else if (value == "disctotal" || value == _("disctotal"))
+                {
+                    replace = DiscTotal.ToString("D2");
                 }
                 else if (value == "publisher" || value == _("publisher"))
                 {
@@ -920,7 +968,6 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 if (recording.FirstReleaseDate != null)
                 {
                     Year = recording.FirstReleaseDate.Year ?? 0;
-                    PublishingDate = recording.FirstReleaseDate.NearestDate;
                 }
             }
             if (overwriteTagWithMusicBrainz || string.IsNullOrEmpty(AlbumArtist))
@@ -935,6 +982,13 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 if (recording.Genres != null && recording.Genres.Count > 0)
                 {
                     Genre = recording.Genres[0].Name ?? "";
+                }
+            }
+            if (overwriteTagWithMusicBrainz || PublishingDate == DateTime.MinValue)
+            {
+                if (recording.FirstReleaseDate != null)
+                {
+                    PublishingDate = recording.FirstReleaseDate.NearestDate;
                 }
             }
             if (overwriteAlbumArtWithMusicBrainz || FrontAlbumArt.Length == 0)

--- a/NickvisionTagger.Shared/Models/PropertyMap.cs
+++ b/NickvisionTagger.Shared/Models/PropertyMap.cs
@@ -63,6 +63,14 @@ public class PropertyMap : IEquatable<PropertyMap>
     /// </summary>
     public string Description { get; set; }
     /// <summary>
+    /// The disc number of the file
+    /// </summary>
+    public string DiscNumber { get; set; }
+    /// <summary>
+    /// The disc total of the file
+    /// </summary>
+    public string DiscTotal { get; set; }
+    /// <summary>
     /// The publisher of the file
     /// </summary>
     public string Publisher { get; set; }
@@ -122,6 +130,8 @@ public class PropertyMap : IEquatable<PropertyMap>
         BeatsPerMinute = "";
         Composer = "";
         Description = "";
+        DiscNumber = "";
+        DiscTotal = "";
         Publisher = "";
         PublishingDate = "";
         FrontAlbumArt = "";
@@ -151,15 +161,17 @@ public class PropertyMap : IEquatable<PropertyMap>
         s += $"BeatsPerMinute: {BeatsPerMinute}\n";
         s += $"Composer: {Composer}\n";
         s += $"Description: {Description}\n";
+        s += $"DiscNumber: {DiscNumber}\n";
+        s += $"DiscTotal: {DiscNumber}\n";
         s += $"Publisher: {Publisher}\n";
-        s += $"Publishing Date: {PublishingDate}\n";
+        s += $"PublishingDate: {PublishingDate}\n";
         s += $"FrontAlbumArt: {FrontAlbumArt}\n";
         s += $"BackAlbumArt: {BackAlbumArt}\n";
         s += $"CustomPropertiesCount: {CustomProperties.Count}\n";
         s += $"Duration: {Duration}\n";
         s += $"Fingerprint: {Fingerprint}\n";
         s += $"FileSize: {FileSize}\n";
-        s += "=========";
+        s += "=================";
         return s;
     }
 
@@ -197,6 +209,8 @@ public class PropertyMap : IEquatable<PropertyMap>
             obj.BeatsPerMinute == BeatsPerMinute &&
             obj.Composer == Composer &&
             obj.Description == Description &&
+            obj.DiscNumber == DiscNumber &&
+            obj.DiscTotal == DiscTotal &&
             obj.Publisher == Publisher &&
             obj.PublishingDate == PublishingDate &&
             obj.CustomProperties.Count == CustomProperties.Count && !obj.CustomProperties.Except(CustomProperties).Any();

--- a/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
+++ b/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="GetText.NET" Version="1.9.14" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     <PackageReference Include="AcoustID.NET" Version="1.3.3" />
     <PackageReference Include="Nickvision.Aura" Version="2023.10.1.3" />

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-18 21:31+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "Vybráno {0} z {1}"
@@ -37,63 +37,67 @@ msgstr "Vybráno {0} z {1}"
 msgid "{0} Playlist (*{1})"
 msgstr "{0} playlist (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<ponechat>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "O aplikaci {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -128,18 +132,18 @@ msgid "AcoustId User API Key"
 msgstr "Klíč API uživatele AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Přidat novou vlastnost"
 
@@ -150,7 +154,7 @@ msgid "Add to Playlist"
 msgstr "Přidat do playlistu"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Další vlastnosti"
 
@@ -159,10 +163,10 @@ msgstr "Další vlastnosti"
 msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -184,21 +188,21 @@ msgstr "Obal alba"
 msgid "Album Artist"
 msgstr "Umělec alba"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "umělecalba"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Všechny soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Všechny podporované soubory"
 
@@ -206,58 +210,58 @@ msgstr "Všechny podporované soubory"
 msgid "An application restart is required to change the theme."
 msgstr "Pro změnu motivu je vyžadován restart aplikace."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "umělec"
 
@@ -277,70 +281,70 @@ msgstr "Automaticky kontrolovat aktualizace"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Zadní"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Vypočítávání..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Zrušit"
@@ -363,27 +367,27 @@ msgstr "Vymazat všechny texty"
 msgid "Close Library"
 msgstr "Zavřít knihovnu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "komentář"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Komentář"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "skladatel"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Skladatel"
 
@@ -392,20 +396,20 @@ msgstr "Skladatel"
 msgid "Configure"
 msgstr "Nastavit"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -413,7 +417,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -421,11 +425,11 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr "Převod názvů souborů na značky..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr "Převod značek na názvy souborů..."
 
@@ -433,8 +437,8 @@ msgstr "Převod značek na názvy souborů..."
 msgid "Copied debug info to clipboard."
 msgstr "Informace o ladění zkopírovány do schránky."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Zkopírovat otisk do schránky"
 
@@ -458,8 +462,8 @@ msgstr "Vytvořit playlist"
 msgid "Credits"
 msgstr "Poděkování"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "vlastní"
 
@@ -471,21 +475,21 @@ msgid "Custom"
 msgstr "Vlastní"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Vlastní vlastnosti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr "Vlastní vlastnosti lze upravit pouze u individuálních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -497,21 +501,21 @@ msgstr "Odstranit značku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Odstranit značku (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Odstraňování značek..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "popis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Popis"
 
@@ -542,23 +546,28 @@ msgstr ""
 "Překladatelé:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Zrušit"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Zrušit"
 
@@ -570,9 +579,24 @@ msgstr "Zrušit nepoužité změny"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Zrušit nepoužité změny (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Zahazování značek..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "celkemstop"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -598,25 +622,25 @@ msgstr "Stáhnout metadata z MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Stáhnout metadata z MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Texty pro {0} souborů úspěšně staženy"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Stahování textů..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr "Přesuňte sem pro otevření knihovny"
 
@@ -684,6 +708,16 @@ msgstr "Sem zadejte vlastní volbu"
 msgid "Enter description here"
 msgstr "Sem zadejte popis"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Sem zadejte název souboru"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Sem zadejte celkový počet stop"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr "Sem zadejte název souboru"
@@ -704,7 +738,7 @@ msgstr "Sem zadejte jazykový kód"
 msgid "Enter offset here"
 msgstr "Sem zadejte odsazení"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr "Sem zadejte vydavatele"
 
@@ -724,12 +758,12 @@ msgstr "Sem zadejte celkový počet stop"
 msgid "Enter year here"
 msgstr "Sem zadejte rok"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -744,19 +778,19 @@ msgstr "Opustit"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Exportovat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportovat zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
@@ -767,11 +801,11 @@ msgstr "Exportovat přední obal alba"
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
@@ -780,19 +814,19 @@ msgstr "Přední obal alba úspěšně exportován do souboru"
 msgid "Exported successfully to: {0}"
 msgstr "Úspěšně exportováno do: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšná vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
@@ -808,9 +842,9 @@ msgstr "Soubor"
 msgid "File Name"
 msgstr "Název souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
@@ -825,28 +859,28 @@ msgstr "Název souboru na značku (Ctrl+F)"
 msgid "File Path"
 msgstr "Cesta k souboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "názevsouboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Otisk"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Otisk byl zkopírován do schránky."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr "Režim složek"
 
@@ -855,29 +889,29 @@ msgstr "Režim složek"
 msgid "Format"
 msgstr "Formát"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Formátový řetězec"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Přední"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "žánr"
 
@@ -898,19 +932,19 @@ msgstr "Získat nový klíč API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub repozitář"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -918,7 +952,7 @@ msgid "Help"
 msgstr "Nápověda"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr "Skrýt extra panel"
 
@@ -933,31 +967,31 @@ msgstr "Importovat z LRC"
 msgid "Include Only Selected Files"
 msgstr "Zahrnout pouze vybrané soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Informace"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Vložit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Vložit zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Vkládání obalu alba..."
 
@@ -975,11 +1009,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kód jazyka"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr "Knihovna byla změněna na disku."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -987,8 +1021,8 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
@@ -996,7 +1030,7 @@ msgstr "Načítání hudebních souborů z knihovny..."
 msgid "Lryics"
 msgstr "Texty"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "texty"
 
@@ -1022,7 +1056,7 @@ msgstr "Spravovat texty"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Spravovat texty (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -1040,13 +1074,13 @@ msgstr "Hudební soubor"
 msgid "Music Library"
 msgstr "Hudební knihovna"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
@@ -1055,24 +1089,24 @@ msgstr "Nová vlastní vlastnost"
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr "Dostupná nová aktualizace."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
@@ -1080,20 +1114,20 @@ msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 msgid "No file selected"
 msgstr "Není vybrán žádný soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Nebyly vybrány žádné soubory k odstranění."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Nebyly staženy žádné texty"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Nejsou vybrány žádné hudební soubory."
 
@@ -1102,11 +1136,11 @@ msgstr "Nejsou vybrány žádné hudební soubory."
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "Žádné hudební soubory v knihovně."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
@@ -1115,7 +1149,7 @@ msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr "Není nastaven žádný uživatelský klíč API."
 
@@ -1140,11 +1174,11 @@ msgstr "Vyp"
 msgid "Offset (in milliseconds)"
 msgstr "Posun (v milisekundách)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1160,8 +1194,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Zap"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1169,8 +1203,8 @@ msgstr ""
 "Do AcoustId lze najednou odeslat pouze jeden soubor. Vyberte prosím pouze "
 "jeden soubor a zkuste to znovu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Otevřít"
 
@@ -1180,7 +1214,7 @@ msgid "Open a library with music to get started"
 msgstr "Začněte otevřením hudební knihovny"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1190,11 +1224,11 @@ msgstr "Začněte otevřením hudební knihovny"
 msgid "Open Folder"
 msgstr "Otevřít složku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Otevřít hudební soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1228,10 +1262,10 @@ msgstr "Cesta"
 msgid "Path (Empty)"
 msgstr "Cesta (prázdná)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr "Vyberte datum"
 
@@ -1241,23 +1275,23 @@ msgstr "Vyberte datum"
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Soubor playlistu úspěšně vytvořen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr "Režim playlistů"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr "Cesta playlistu nemůže být prázdná."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Vyberte prosím formátový řetězec."
 
@@ -1270,37 +1304,37 @@ msgstr "Zachovat časové razítko změny"
 msgid "PREVIEW"
 msgstr "NÁHLED"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "vydavatel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 msgid "Publishing Date"
 msgstr "Datum vydání"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 msgid "publishingdate"
 msgstr "datumvydání"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr "Znovu načíst"
 
@@ -1312,20 +1346,20 @@ msgstr "Znovu načíst knihovnu"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Odebrat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Odstranit soubory?"
 
@@ -1339,7 +1373,7 @@ msgstr "Odebrat z playlistu"
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr "Odebírání obalu alba..."
 
@@ -1365,8 +1399,8 @@ msgstr "Uložit značku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Uložit značku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
@@ -1385,27 +1419,27 @@ msgstr "Vyberte nějaké soubory"
 msgid "Settings"
 msgstr "Nastavení"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr "Zobrazit extra panel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1417,43 +1451,43 @@ msgstr "Některé hudební soubory mají stále čekající změny. Co chcete ud
 msgid "Sort Files By"
 msgstr "Řadit soubory podle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Potvrdit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Přepnout na zadní obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Přepnout na přední obal"
 
@@ -1466,9 +1500,9 @@ msgstr "Synchronizované"
 msgid "Tag"
 msgstr "Značka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Značka na název souboru"
@@ -1477,9 +1511,8 @@ msgstr "Značka na název souboru"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Značka na název souboru (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označte svou hudbu"
 
@@ -1488,9 +1521,8 @@ msgstr "Označte svou hudbu"
 msgid "Tag Your Music"
 msgstr "Označte svou hudbu"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Označovač"
 
@@ -1499,8 +1531,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1513,7 +1545,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Motiv"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Tento soubor nemá platný otisk"
 
@@ -1535,10 +1567,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "název"
 
@@ -1550,15 +1582,15 @@ msgstr "název"
 msgid "Title"
 msgstr "Název"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "stopa"
 
@@ -1570,14 +1602,14 @@ msgstr "stopa"
 msgid "Track"
 msgstr "Stopa"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "celkemstop"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
@@ -1596,15 +1628,15 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Zadejte ! pro pokročilé vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Nepodařilo se přidat soubor do playlistu. Možná v něm již existuje."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Nepodařilo se vytvořit playlist."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1618,29 +1650,29 @@ msgstr "Nepodařilo se exportovat do souboru LRC."
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Nepodařilo se odstranit některé soubory z playlistu."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -1649,7 +1681,7 @@ msgstr "Neznámé"
 msgid "Unsynchronized"
 msgstr "Nesynchronizované"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr "Aktualizace"
 
@@ -1663,8 +1695,8 @@ msgstr "Použít texty LRC"
 msgid "Use Relative Paths"
 msgstr "Použít relativní cesty"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr "Použít relativní cesty?"
 
@@ -1698,8 +1730,8 @@ msgstr ""
 "Chcete restartovat aplikaci {0} pro použití nového motivu?\n"
 "Jakákoli neuložená práce bude ztracena."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1708,10 +1740,10 @@ msgstr ""
 "Chcete uložit přidaný soubor do playlistu pomocí jeho relativní cesty?\n"
 "Pokud ne, bude využita plná cesta."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "rok"
 
@@ -1723,10 +1755,10 @@ msgstr "rok"
 msgid "Year"
 msgstr "Rok"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Ano"
@@ -1859,15 +1891,24 @@ msgstr "Vybrat všechny soubory"
 msgid "Track Total"
 msgstr "Celkem stop"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Celkem stop"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Přepnout panel značek"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Akce značky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Použít změny u značky (Ctrl+S)"
 
@@ -1875,46 +1916,40 @@ msgstr "Použít změny u značky (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Značka;Hudba;Editor;Knihovna;Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Podpora několika typů hudebních souborů (mp3, ogg, flac, wma, wav a další)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Podpora několika typů hudebních souborů (mp3, ogg, flac, wma, wav a "
+#~ "další)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Úprava značek a obalů alb více souborů najednou, a to i v podsložkách"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Úprava značek a obalů alb více souborů najednou, a to i v podsložkách"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Úprava nesynchronizovaných a synchronizovaných textů u souboru (s podporou "
-"importu a exportu LRC)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Úprava nesynchronizovaných a synchronizovaných textů u souboru (s "
+#~ "podporou importu a exportu LRC)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "— Snadný převod názvů souborů na značky a značkek na názvy souborů"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "— Snadný převod názvů souborů na značky a značkek na názvy souborů"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Vyhledávání informací o souborech pomocí MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Vyhledávání informací o souborech pomocí MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Vyhledávání informací o textech pomocí Music163 a Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Vyhledávání informací o textech pomocí Music163 a Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Otevírání, správa a vytváření playlistů v několika formátech (m3u, pls, "
-"xspf a další)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Otevírání, správa a vytváření playlistů v několika formátech (m3u, pls, "
+#~ "xspf a další)"
 
 #~ msgid "Getting Started"
 #~ msgstr "Začínáme"

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,91 +19,103 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "Vybráno {0} z {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr "{0} playlist (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<ponechat>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "O aplikaci {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -128,18 +140,18 @@ msgid "AcoustId User API Key"
 msgstr "Klíč API uživatele AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Přidat novou vlastnost"
 
@@ -149,28 +161,28 @@ msgstr "Přidat novou vlastnost"
 msgid "Add to Playlist"
 msgstr "Přidat do playlistu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Další vlastnosti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -179,26 +191,26 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Obal alba"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Umělec alba"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "umělecalba"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Všechny soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Všechny podporované soubory"
 
@@ -206,66 +218,66 @@ msgstr "Všechny podporované soubory"
 msgid "An application restart is required to change the theme."
 msgstr "Pro změnu motivu je vyžadován restart aplikace."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Použít změny?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "umělec"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Umělec"
 
@@ -277,70 +289,72 @@ msgstr "Automaticky kontrolovat aktualizace"
 msgid "B"
 msgstr "B"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Zadní"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Vypočítávání..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Zrušit"
@@ -349,7 +363,7 @@ msgstr "Zrušit"
 msgid "Changelog"
 msgstr "Seznam změn"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr "Zkontrolovat aktualizace"
 
@@ -358,32 +372,36 @@ msgstr "Zkontrolovat aktualizace"
 msgid "Clear All Lyrics"
 msgstr "Vymazat všechny texty"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Zavřít knihovnu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "komentář"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Komentář"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "skladatel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Skladatel"
 
@@ -392,20 +410,20 @@ msgstr "Skladatel"
 msgid "Configure"
 msgstr "Nastavit"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -413,7 +431,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -421,11 +439,11 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr "Převod názvů souborů na značky..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr "Převod značek na názvy souborů..."
 
@@ -433,8 +451,8 @@ msgstr "Převod značek na názvy souborů..."
 msgid "Copied debug info to clipboard."
 msgstr "Informace o ladění zkopírovány do schránky."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Zkopírovat otisk do schránky"
 
@@ -458,8 +476,8 @@ msgstr "Vytvořit playlist"
 msgid "Credits"
 msgstr "Poděkování"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "vlastní"
 
@@ -470,22 +488,22 @@ msgstr "vlastní"
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Vlastní vlastnosti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr "Vlastní vlastnosti lze upravit pouze u individuálních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -493,25 +511,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Odstranit značku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Odstranit značku (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Odstraňování značek..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "popis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Popis"
 
@@ -542,23 +560,28 @@ msgstr ""
 "Překladatelé:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Disc"
+msgstr "Zrušit"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Zrušit"
 
@@ -566,57 +589,72 @@ msgstr "Zrušit"
 msgid "Discard Unapplied Changed"
 msgstr "Zrušit nepoužité změny"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Zrušit nepoužité změny (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Zahazování značek..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
+#, fuzzy
+msgid "disctotal"
+msgstr "celkemstop"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Diskuze"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Dokumentace"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Stáhnout texty"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Stáhnout metadata z MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Stáhnout metadata z MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Texty pro {0} souborů úspěšně staženy"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Stahování textů..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr "Přesuňte sem pro otevření knihovny"
 
@@ -651,27 +689,27 @@ msgstr ""
 "Povolte pro přepsání metadat existující značky metadaty nalezenými na "
 "MusicBrainz. Při zakázání budou vyplněny pouze prázdné vlastnosti značek."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr "Sem zadejte umělce alba"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr "Sem zadejte album"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr "Sem zadejte umělce"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr "Sem zadejte údery za minutu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr "Sem zadejte komentář"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr "Sem zadejte skladatele"
 
@@ -680,15 +718,25 @@ msgid "Enter custom choice here"
 msgstr "Sem zadejte vlastní volbu"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr "Sem zadejte popis"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Sem zadejte název souboru"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Sem zadejte celkový počet stop"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr "Sem zadejte název souboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr "Sem zadejte žánr"
 
@@ -704,32 +752,32 @@ msgstr "Sem zadejte jazykový kód"
 msgid "Enter offset here"
 msgstr "Sem zadejte odsazení"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr "Sem zadejte vydavatele"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr "Sem zadejte název"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr "Sem zadejte stopu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr "Sem zadejte celkový počet stop"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr "Sem zadejte rok"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -743,20 +791,20 @@ msgid "Exit"
 msgstr "Opustit"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Exportovat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportovat zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
@@ -767,11 +815,11 @@ msgstr "Exportovat přední obal alba"
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
@@ -780,19 +828,19 @@ msgstr "Přední obal alba úspěšně exportován do souboru"
 msgid "Exported successfully to: {0}"
 msgstr "Úspěšně exportováno do: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšná vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
@@ -801,21 +849,21 @@ msgid "File"
 msgstr "Soubor"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Název souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Název souboru na značku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Název souboru na značku (Ctrl+F)"
 
@@ -825,28 +873,28 @@ msgstr "Název souboru na značku (Ctrl+F)"
 msgid "File Path"
 msgstr "Cesta k souboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "názevsouboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Otisk"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Otisk byl zkopírován do schránky."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Režim složek"
 
@@ -855,37 +903,39 @@ msgstr "Režim složek"
 msgid "Format"
 msgstr "Formát"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formátový řetězec"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Přední"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "žánr"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Žánr"
 
@@ -898,27 +948,33 @@ msgstr "Získat nový klíč API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub repozitář"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Světlý"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr "Skrýt extra panel"
 
@@ -933,31 +989,37 @@ msgstr "Importovat z LRC"
 msgid "Include Only Selected Files"
 msgstr "Zahrnout pouze vybrané soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Informace"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Vložit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Vložit zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Vkládání obalu alba..."
 
@@ -975,11 +1037,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kód jazyka"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr "Knihovna byla změněna na disku."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -987,8 +1049,8 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
@@ -996,39 +1058,45 @@ msgstr "Načítání hudebních souborů z knihovny..."
 msgid "Lryics"
 msgstr "Texty"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "texty"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Texty"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Hlavní vlastnosti"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Spravovat texty"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Spravovat texty (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Typ"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1040,13 +1108,13 @@ msgstr "Hudební soubor"
 msgid "Music Library"
 msgstr "Hudební knihovna"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
@@ -1055,24 +1123,24 @@ msgstr "Nová vlastní vlastnost"
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr "Dostupná nová aktualizace."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
@@ -1080,42 +1148,42 @@ msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 msgid "No file selected"
 msgstr "Není vybrán žádný soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Nebyly vybrány žádné soubory k odstranění."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Nebyly staženy žádné texty"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Nejsou vybrány žádné hudební soubory."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "Žádné hudební soubory v knihovně."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr "Není nastaven žádný uživatelský klíč API."
 
@@ -1140,11 +1208,11 @@ msgstr "Vyp"
 msgid "Offset (in milliseconds)"
 msgstr "Posun (v milisekundách)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1160,8 +1228,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Zap"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1169,37 +1237,37 @@ msgstr ""
 "Do AcoustId lze najednou odeslat pouze jeden soubor. Vyberte prosím pouze "
 "jeden soubor a zkuste to znovu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otevřít"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Začněte otevřením hudební knihovny"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Otevřít složku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Otevřít hudební soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Otevřít playlist"
 
@@ -1228,10 +1296,10 @@ msgstr "Cesta"
 msgid "Path (Empty)"
 msgstr "Cesta (prázdná)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr "Vyberte datum"
 
@@ -1241,23 +1309,23 @@ msgstr "Vyberte datum"
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Soubor playlistu úspěšně vytvořen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Režim playlistů"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr "Cesta playlistu nemůže být prázdná."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Vyberte prosím formátový řetězec."
 
@@ -1270,37 +1338,37 @@ msgstr "Zachovat časové razítko změny"
 msgid "PREVIEW"
 msgstr "NÁHLED"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "vydavatel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Publishing Date"
 msgstr "Datum vydání"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 msgid "publishingdate"
 msgstr "datumvydání"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Znovu načíst"
 
@@ -1311,21 +1379,21 @@ msgid "Reload Library"
 msgstr "Znovu načíst knihovnu"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Odebrat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Odstranit soubory?"
 
@@ -1339,11 +1407,11 @@ msgstr "Odebrat z playlistu"
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr "Odebírání obalu alba..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr "Nahlásit problém"
 
@@ -1356,17 +1424,17 @@ msgid "Save Playlist"
 msgstr "Uložit playlist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Uložit značku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr "Uložit značku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
@@ -1375,8 +1443,8 @@ msgstr "Ukládání značek..."
 msgid "Select Save Location"
 msgstr "Vyberte místo uložení"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Vyberte nějaké soubory"
 
@@ -1385,27 +1453,27 @@ msgstr "Vyberte nějaké soubory"
 msgid "Settings"
 msgstr "Nastavení"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr "Zobrazit extra panel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1417,43 +1485,43 @@ msgstr "Některé hudební soubory mají stále čekající změny. Co chcete ud
 msgid "Sort Files By"
 msgstr "Řadit soubory podle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Potvrdit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Přepnout na zadní obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Přepnout na přední obal"
 
@@ -1466,43 +1534,43 @@ msgstr "Synchronizované"
 msgid "Tag"
 msgstr "Značka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Značka na název souboru"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Značka na název souboru (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označte svou hudbu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Označte svou hudbu"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Označovač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 "Dokumentace a kanály podpory aplikace Označovač jsou dostupné v nabídce "
 "nápovědy."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1515,7 +1583,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Motiv"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Tento soubor nemá platný otisk"
 
@@ -1537,54 +1605,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "název"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Název"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "stopa"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Stopa"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "celkemstop"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Zkuste jinou knihovnu"
 
@@ -1593,20 +1661,20 @@ msgstr "Zkuste jinou knihovnu"
 msgid "Type"
 msgstr "Typ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr "Zadejte ! pro pokročilé vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Nepodařilo se přidat soubor do playlistu. Možná v něm již existuje."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Nepodařilo se vytvořit playlist."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1620,29 +1688,29 @@ msgstr "Nepodařilo se exportovat do souboru LRC."
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Nepodařilo se odstranit některé soubory z playlistu."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -1651,7 +1719,7 @@ msgstr "Neznámé"
 msgid "Unsynchronized"
 msgstr "Nesynchronizované"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr "Aktualizace"
 
@@ -1665,8 +1733,8 @@ msgstr "Použít texty LRC"
 msgid "Use Relative Paths"
 msgstr "Použít relativní cesty"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Použít relativní cesty?"
 
@@ -1675,10 +1743,10 @@ msgstr "Použít relativní cesty?"
 msgid "User Interface"
 msgstr "Uživatelské rozhraní"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Webové služby"
 
@@ -1691,6 +1759,11 @@ msgstr ""
 "Co chcete, aby Označovač udělal s texty nalezenými v souboru LRC, které jsou "
 "v konfliktu s existujícími texty ve stejném čase?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1700,8 +1773,8 @@ msgstr ""
 "Chcete restartovat aplikaci {0} pro použití nového motivu?\n"
 "Jakákoli neuložená práce bude ztracena."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1710,25 +1783,25 @@ msgstr ""
 "Chcete uložit přidaný soubor do playlistu pomocí jeho relativní cesty?\n"
 "Pokud ne, bude využita plná cesta."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "rok"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Rok"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Ano"
@@ -1802,7 +1875,7 @@ msgid "Remove Front Album Art"
 msgstr "Odebrat přední obal alba"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Přepnout obal alba"
 
@@ -1833,43 +1906,52 @@ msgstr "Opustit"
 msgid "About Tagger"
 msgstr "O aplikaci Označovač"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Nabídka knihovny"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Knihovna"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Hlavní nabídka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Otevřít složku (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Otevřít playlist (Ctrl+Shift+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Vybrat všechny soubory"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Celkem stop"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
+#, fuzzy
+msgid "Disc Total"
+msgstr "Celkem stop"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Přepnout panel značek"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Akce značky"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Použít změny u značky (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -61,26 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -135,7 +135,7 @@ msgstr ""
 "s otiskem."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "Klíč API uživatele AcoustId"
 
@@ -172,9 +172,9 @@ msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -197,9 +197,9 @@ msgid "Album Artist"
 msgstr "Umělec alba"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "umělecalba"
 
@@ -218,7 +218,7 @@ msgstr "Všechny podporované soubory"
 msgid "An application restart is required to change the theme."
 msgstr "Pro změnu motivu je vyžadován restart aplikace."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
@@ -267,9 +267,9 @@ msgid "Apply Changes?"
 msgstr "Použít změny?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "umělec"
 
@@ -305,21 +305,21 @@ msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -382,9 +382,9 @@ msgid "Close Library"
 msgstr "Zavřít knihovnu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "komentář"
 
@@ -394,9 +394,9 @@ msgid "Comment"
 msgstr "Komentář"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "skladatel"
 
@@ -423,7 +423,7 @@ msgstr "Přispěvatelé na GitHubu ❤️"
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -431,7 +431,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -439,11 +439,11 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr "Převod názvů souborů na značky..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr "Převod značek na názvy souborů..."
 
@@ -477,7 +477,7 @@ msgid "Credits"
 msgstr "Poděkování"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "vlastní"
 
@@ -515,14 +515,14 @@ msgstr "Odstranit značku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Odstranit značku (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Odstraňování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "popis"
 
@@ -593,21 +593,21 @@ msgstr "Zrušit nepoužité změny"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Zrušit nepoužité změny (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Zahazování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "celkemstop"
@@ -636,21 +636,21 @@ msgstr "Stáhnout metadata z MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Stáhnout metadata z MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Texty pro {0} souborů úspěšně staženy"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Stahování textů..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
@@ -666,13 +666,13 @@ msgid "Edit"
 msgstr "Upravit"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Povolte pro přepsání existujícího obalu alba nalezeného na MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -681,7 +681,7 @@ msgstr ""
 "budou vyplněny pouze prázdné texty."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -772,12 +772,12 @@ msgstr "Sem zadejte celkový počet stop"
 msgid "Enter year here"
 msgstr "Sem zadejte rok"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -815,11 +815,11 @@ msgstr "Exportovat přední obal alba"
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
@@ -836,11 +836,11 @@ msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšná vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
@@ -879,7 +879,7 @@ msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "názevsouboru"
 
@@ -925,9 +925,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "žánr"
 
@@ -940,7 +940,7 @@ msgid "Genre"
 msgstr "Žánr"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Získat nový klíč API"
 
@@ -1019,7 +1019,7 @@ msgstr "Vložit zadní obal alba"
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Vkládání obalu alba..."
 
@@ -1037,11 +1037,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kód jazyka"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr "Knihovna byla změněna na disku."
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1049,8 +1049,8 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
@@ -1058,7 +1058,7 @@ msgstr "Načítání hudebních souborů z knihovny..."
 msgid "Lryics"
 msgstr "Texty"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "texty"
 
@@ -1123,7 +1123,7 @@ msgstr "Nová vlastní vlastnost"
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr "Dostupná nová aktualizace."
 
@@ -1140,7 +1140,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
@@ -1153,15 +1153,15 @@ msgstr "Není vybrán žádný soubor"
 msgid "No files selected for removal."
 msgstr "Nebyly vybrány žádné soubory k odstranění."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Nebyly staženy žádné texty"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Nejsou vybrány žádné hudební soubory."
 
@@ -1170,11 +1170,11 @@ msgstr "Nejsou vybrány žádné hudební soubory."
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "Žádné hudební soubory v knihovně."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
@@ -1183,7 +1183,7 @@ msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr "Není nastaven žádný uživatelský klíč API."
 
@@ -1272,17 +1272,17 @@ msgid "Open Playlist"
 msgstr "Otevřít playlist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Přepsat obal alba s MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Přepsat texty z webové služby"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Přepsat značku s MusicBrainz"
 
@@ -1309,7 +1309,7 @@ msgstr "Vyberte datum"
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Soubor playlistu úspěšně vytvořen."
 
@@ -1318,7 +1318,7 @@ msgstr "Soubor playlistu úspěšně vytvořen."
 msgid "Playlist Mode"
 msgstr "Režim playlistů"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr "Cesta playlistu nemůže být prázdná."
 
@@ -1344,9 +1344,9 @@ msgid "Property Name"
 msgstr "Název vlastnosti"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -1361,9 +1361,9 @@ msgid "Publishing Date"
 msgstr "Datum vydání"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 msgid "publishingdate"
 msgstr "datumvydání"
 
@@ -1407,7 +1407,7 @@ msgstr "Odebrat z playlistu"
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr "Odebírání obalu alba..."
 
@@ -1433,8 +1433,8 @@ msgstr "Uložit značku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Uložit značku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
@@ -1498,11 +1498,11 @@ msgstr "Potvrdit"
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Motiv"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Tento soubor nemá platný otisk"
 
@@ -1606,9 +1606,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "název"
 
@@ -1626,9 +1626,9 @@ msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "stopa"
 
@@ -1641,9 +1641,9 @@ msgid "Track"
 msgstr "Stopa"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -1666,15 +1666,15 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Zadejte ! pro pokročilé vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Nepodařilo se přidat soubor do playlistu. Možná v něm již existuje."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Nepodařilo se vytvořit playlist."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1688,29 +1688,29 @@ msgstr "Nepodařilo se exportovat do souboru LRC."
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Nepodařilo se odstranit některé soubory z playlistu."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -1745,7 +1745,7 @@ msgstr "Uživatelské rozhraní"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Webové služby"
@@ -1784,9 +1784,9 @@ msgstr ""
 "Pokud ne, bude využita plná cesta."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "rok"
 
@@ -1841,6 +1841,14 @@ msgstr "Zapamatovat naposledy otevřenou knihovnu"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Zahrnout podsložky"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "O aplikaci {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -140,7 +140,7 @@ msgid "AcoustId User API Key"
 msgstr "Klíč API uživatele AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -172,9 +172,9 @@ msgid "Advanced Search Info"
 msgstr "Informace o pokročilém vyhledávání"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -197,9 +197,9 @@ msgid "Album Artist"
 msgstr "Umělec alba"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "umělecalba"
 
@@ -209,8 +209,8 @@ msgstr "umělecalba"
 msgid "All files"
 msgstr "Všechny soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Všechny podporované soubory"
 
@@ -218,18 +218,18 @@ msgstr "Všechny podporované soubory"
 msgid "An application restart is required to change the theme."
 msgstr "Pro změnu motivu je vyžadován restart aplikace."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -246,14 +246,14 @@ msgstr "Službě MusicBrainz bylo poskytnuto neplatné RecordingId"
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -267,9 +267,9 @@ msgid "Apply Changes?"
 msgstr "Použít změny?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "umělec"
 
@@ -290,8 +290,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -305,40 +305,40 @@ msgid "Beats Per Minute"
 msgstr "Údery za minutu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Vypočítávání..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -382,9 +382,9 @@ msgid "Close Library"
 msgstr "Zavřít knihovnu"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "komentář"
 
@@ -394,9 +394,9 @@ msgid "Comment"
 msgstr "Komentář"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "skladatel"
 
@@ -414,8 +414,8 @@ msgstr "Nastavit"
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -423,7 +423,7 @@ msgstr "Přispěvatelé na GitHubu ❤️"
 msgid "Convert"
 msgstr "Převést"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -431,7 +431,7 @@ msgstr[0] "Úspěšně převeden {0} název souboru na značku"
 msgstr[1] "Úspěšně převedeny {0} názvy souborů na značky"
 msgstr[2] "Úspěšně převedeno {0} názvů souborů na značky"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -439,11 +439,11 @@ msgstr[0] "Úspěšně převedena {0} značka na název souboru"
 msgstr[1] "Úspěšně převedeny {0} značky na názvy souborů"
 msgstr[2] "Úspěšně převedeno {0} značek na názvy souborů"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr "Převod názvů souborů na značky..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr "Převod značek na názvy souborů..."
 
@@ -477,7 +477,7 @@ msgid "Credits"
 msgstr "Poděkování"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "vlastní"
 
@@ -515,14 +515,14 @@ msgstr "Odstranit značku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Odstranit značku (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Odstraňování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "popis"
 
@@ -565,14 +565,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Zrušit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -593,21 +593,21 @@ msgstr "Zrušit nepoužité změny"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Zrušit nepoužité změny (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Zahazování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "celkemstop"
@@ -636,21 +636,21 @@ msgstr "Stáhnout metadata z MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Stáhnout metadata z MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Texty pro {0} souborů úspěšně staženy"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadata pro {0} souborů úspěšně stažena"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Stahování textů..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Stahování metadat z MusicBrainz..."
 
@@ -772,12 +772,12 @@ msgstr "Sem zadejte celkový počet stop"
 msgid "Enter year here"
 msgstr "Sem zadejte rok"
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -799,12 +799,12 @@ msgstr "Opustit"
 msgid "Export"
 msgstr "Exportovat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportovat zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
@@ -815,11 +815,11 @@ msgstr "Exportovat přední obal alba"
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Zadní obal alba úspěšně exportován do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
@@ -832,15 +832,15 @@ msgstr "Úspěšně exportováno do: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Neúspěšné vyhledávání ve službě MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Neúspěšná vyhledávání ve službě MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Nepodařilo se exportovat zadní obal alba do souboru"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Nepodařilo se exportovat přední obal alba do souboru"
 
@@ -856,7 +856,7 @@ msgstr "Soubor"
 msgid "File Name"
 msgstr "Název souboru"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -879,7 +879,7 @@ msgid "File Properties"
 msgstr "Vlastnosti souboru"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "názevsouboru"
 
@@ -888,12 +888,12 @@ msgstr "názevsouboru"
 msgid "Fingerprint"
 msgstr "Otisk"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Otisk byl zkopírován do schránky."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Režim složek"
@@ -903,16 +903,16 @@ msgstr "Režim složek"
 msgid "Format"
 msgstr "Formát"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formátový řetězec"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -925,9 +925,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "žánr"
 
@@ -948,7 +948,7 @@ msgstr "Získat nový klíč API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub repozitář"
@@ -959,9 +959,9 @@ msgstr "GitHub repozitář"
 msgid "Height"
 msgstr "Světlý"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -989,7 +989,7 @@ msgstr "Importovat z LRC"
 msgid "Include Only Selected Files"
 msgstr "Zahrnout pouze vybrané soubory"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1009,17 +1009,17 @@ msgstr "Informace"
 msgid "Insert"
 msgstr "Vložit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Vložit zadní obal alba"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vložit přední obal alba"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Vkládání obalu alba..."
 
@@ -1037,11 +1037,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kód jazyka"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr "Knihovna byla změněna na disku."
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1049,8 +1049,8 @@ msgstr[0] "Načten {0} hudební soubor."
 msgstr[1] "Načteny {0} hudební soubory."
 msgstr[2] "Načteno {0} hudebních souborů."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
@@ -1058,7 +1058,7 @@ msgstr "Načítání hudebních souborů z knihovny..."
 msgid "Lryics"
 msgstr "Texty"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "texty"
 
@@ -1072,6 +1072,10 @@ msgstr "Texty"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Hlavní vlastnosti"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1108,12 +1112,12 @@ msgstr "Hudební soubor"
 msgid "Music Library"
 msgstr "Hudební knihovna"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID nahrávky MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
@@ -1123,7 +1127,7 @@ msgstr "Nová vlastní vlastnost"
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr "Dostupná nová aktualizace."
 
@@ -1132,15 +1136,15 @@ msgstr "Dostupná nová aktualizace."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Ne"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 
@@ -1148,20 +1152,20 @@ msgstr "Pro otisk souboru nebylo nalezeno žádné AcoustId"
 msgid "No file selected"
 msgstr "Není vybrán žádný soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Nebyly vybrány žádné soubory k odstranění."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Nebyly staženy žádné texty"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Nebyla stažena žádná metadata"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Nejsou vybrány žádné hudební soubory."
 
@@ -1170,11 +1174,11 @@ msgstr "Nejsou vybrány žádné hudební soubory."
 msgid "No Music Files Found"
 msgstr "Nenalezeny žádné hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "Žádné hudební soubory v knihovně."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 
@@ -1183,7 +1187,7 @@ msgstr "Záznamu AcoustId nebylo poskytnuto žádné MusicBrainz RecordingId"
 msgid "No Selected Music Files"
 msgstr "Žádné vybrané hudební soubory"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr "Není nastaven žádný uživatelský klíč API."
 
@@ -1208,7 +1212,7 @@ msgstr "Vyp"
 msgid "Offset (in milliseconds)"
 msgstr "Posun (v milisekundách)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1228,7 +1232,7 @@ msgstr "OK"
 msgid "On"
 msgstr "Zap"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1237,7 +1241,7 @@ msgstr ""
 "Do AcoustId lze najednou odeslat pouze jeden soubor. Vyberte prosím pouze "
 "jeden soubor a zkuste to znovu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otevřít"
@@ -1248,7 +1252,7 @@ msgid "Open a library with music to get started"
 msgstr "Začněte otevřením hudební knihovny"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1258,11 +1262,11 @@ msgstr "Začněte otevřením hudební knihovny"
 msgid "Open Folder"
 msgstr "Otevřít složku"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Otevřít hudební soubor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1296,8 +1300,8 @@ msgstr "Cesta"
 msgid "Path (Empty)"
 msgstr "Cesta (prázdná)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1309,21 +1313,21 @@ msgstr "Vyberte datum"
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Soubor playlistu úspěšně vytvořen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Režim playlistů"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr "Cesta playlistu nemůže být prázdná."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1338,15 +1342,15 @@ msgstr "Zachovat časové razítko změny"
 msgid "PREVIEW"
 msgstr "NÁHLED"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Název vlastnosti"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -1361,13 +1365,13 @@ msgid "Publishing Date"
 msgstr "Datum vydání"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 msgid "publishingdate"
 msgstr "datumvydání"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Znovu načíst"
@@ -1387,12 +1391,12 @@ msgstr "Znovu načíst knihovnu"
 msgid "Remove"
 msgstr "Odebrat"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Odebrat vlastní vlastnost"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Odstranit soubory?"
@@ -1407,7 +1411,7 @@ msgstr "Odebrat z playlistu"
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr "Odebírání obalu alba..."
 
@@ -1433,8 +1437,8 @@ msgstr "Uložit značku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Uložit značku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Ukládání značek..."
 
@@ -1457,14 +1461,14 @@ msgstr "Nastavení"
 msgid "Show Extras Pane"
 msgstr "Zobrazit extra panel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1485,12 +1489,12 @@ msgstr "Některé hudební soubory mají stále čekající změny. Co chcete ud
 msgid "Sort Files By"
 msgstr "Řadit soubory podle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Potvrdit"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1498,15 +1502,15 @@ msgstr "Potvrdit"
 msgid "Submit to AcoustId"
 msgstr "Odeslat do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadata úspěšně odeslána do AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Odesílání dat do AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1517,7 +1521,7 @@ msgstr "Odesílání dat do AcoustId..."
 msgid "Switch to Back Cover"
 msgstr "Přepnout na zadní obal"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1534,7 +1538,7 @@ msgstr "Synchronizované"
 msgid "Tag"
 msgstr "Značka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1569,7 +1573,7 @@ msgstr ""
 "Dokumentace a kanály podpory aplikace Označovač jsou dostupné v nabídce "
 "nápovědy."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1583,7 +1587,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Motiv"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Tento soubor nemá platný otisk"
 
@@ -1606,9 +1610,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "název"
 
@@ -1620,15 +1624,15 @@ msgstr "název"
 msgid "Title"
 msgstr "Název"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Vybráno příliš mnoho souborů"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "stopa"
 
@@ -1641,9 +1645,9 @@ msgid "Track"
 msgstr "Stopa"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -1666,15 +1670,15 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Zadejte ! pro pokročilé vyhledávání"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Nepodařilo se přidat soubor do playlistu. Možná v něm již existuje."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Nepodařilo se vytvořit playlist."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
@@ -1688,29 +1692,29 @@ msgstr "Nepodařilo se exportovat do souboru LRC."
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Nepodařilo se načíst soubor s obrázkem"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Nepodařilo se odstranit některé soubory z playlistu."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Nepodařilo se uložit soubor {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Nepodařilo se uložit {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Nepodařilo se odeslat AcoustId. Zkontrolujte klíč API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -1733,7 +1737,7 @@ msgstr "Použít texty LRC"
 msgid "Use Relative Paths"
 msgstr "Použít relativní cesty"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Použít relativní cesty?"
@@ -1773,7 +1777,7 @@ msgstr ""
 "Chcete restartovat aplikaci {0} pro použití nového motivu?\n"
 "Jakákoli neuložená práce bude ztracena."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1784,9 +1788,9 @@ msgstr ""
 "Pokud ne, bude využita plná cesta."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "rok"
 
@@ -1798,8 +1802,8 @@ msgstr "rok"
 msgid "Year"
 msgstr "Rok"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:40+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr "{0} � {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Über {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Nutzer-API-Key"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Album-Interpret"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "albumkünstler"
 
@@ -210,8 +210,8 @@ msgstr "albumkünstler"
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Alle unterstützten Dateien"
 
@@ -219,18 +219,18 @@ msgstr "Alle unterstützten Dateien"
 msgid "An application restart is required to change the theme."
 msgstr "Ein Neustart der App ist notwendig um das Farbschema zu ändern."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -247,14 +247,14 @@ msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "künstler"
 
@@ -291,8 +291,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -306,40 +306,40 @@ msgid "Beats Per Minute"
 msgstr "Schläge pro Minute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Berechne..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Bibliothek schließen"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "kommentar"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Kommentar"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "Komponist"
 
@@ -415,8 +415,8 @@ msgstr "Konfigurieren"
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -424,25 +424,25 @@ msgstr "Mitwirkende auf GitHub ❤️"
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr "Konvertiere Dateinamen zu Tags..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr "Konvertiere Tags zu Dateinamen..."
 
@@ -476,7 +476,7 @@ msgid "Credits"
 msgstr "Credits"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "andere"
 
@@ -516,14 +516,14 @@ msgstr "Tag löschen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Tag löschen (Umschalt+Entfernen)"
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Tags werden gelöscht..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "Beschreibung"
 
@@ -566,14 +566,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Verwerfen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -594,21 +594,21 @@ msgstr "Nicht angewandte Änderungen verwerfen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Nicht angewandte Änderungen verwerfen (Strg+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Tags werden verworfen..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "songanzahl"
@@ -637,21 +637,21 @@ msgstr "Metadaten von MusicBrainz herunterladen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Metadaten von MusicBrainz herunterladen (Strg+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Songtexte für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Songtexte werden heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
@@ -773,12 +773,12 @@ msgstr "Trackanzahl hier eintragen"
 msgid "Enter year here"
 msgstr "Jahr hier eintragen"
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -800,12 +800,12 @@ msgstr "Verlassen"
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Rückseite des Albumcovers exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vorderseite des Albumcovers exportieren"
@@ -816,11 +816,11 @@ msgstr "Vorderseite des Albumcovers exportieren"
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Rückseite des Albumcovers erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
@@ -833,15 +833,15 @@ msgstr "Erfolgreich exportiert nach: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Suche mit MusicBrainz fehlgeschlagen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim Exportieren des Rückseite des Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim Exportieren der Vorderseite des Albumcovers zur Datei"
 
@@ -857,7 +857,7 @@ msgstr "Datei"
 msgid "File Name"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -880,7 +880,7 @@ msgid "File Properties"
 msgstr "Dateieigenschaften"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "Dateiname"
 
@@ -889,12 +889,12 @@ msgstr "Dateiname"
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Ordnermodus"
@@ -904,16 +904,16 @@ msgstr "Ordnermodus"
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formatvorlage"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -926,9 +926,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "genre"
 
@@ -949,7 +949,7 @@ msgstr "Neuen API-Key anfordern"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
@@ -960,9 +960,9 @@ msgstr "GitHub-Repo"
 msgid "Height"
 msgstr "Hell"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -990,7 +990,7 @@ msgstr "Von LRC importieren"
 msgid "Include Only Selected Files"
 msgstr "Nur ausgewählte Dateien berücksichtigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1010,17 +1010,17 @@ msgstr "Info"
 msgid "Insert"
 msgstr "Einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Rückseite des Albumcovers einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vorderseite des Albumcovers einfügen"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Albumcover wird eingefügt..."
 
@@ -1038,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Sprachcode"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr "Bibliothek wurde auf der Platte verändert."
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Lade Musikdateien von Bibliothek..."
 
@@ -1058,7 +1058,7 @@ msgstr "Lade Musikdateien von Bibliothek..."
 msgid "Lryics"
 msgstr "Songtext"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "Songtext"
 
@@ -1072,6 +1072,10 @@ msgstr "Songtext"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Haupteigenschaften"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1108,12 +1112,12 @@ msgstr "Musikdatei"
 msgid "Music Library"
 msgstr "Musikbibliothek"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
@@ -1123,7 +1127,7 @@ msgstr "Neue Andere Eigenschaft"
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr "Neue Updates verfügbar."
 
@@ -1132,15 +1136,15 @@ msgstr "Neue Updates verfügbar."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
@@ -1148,20 +1152,20 @@ msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 msgid "No file selected"
 msgstr "Keine Dateien ausgewählt"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Keine zu entfernenden Dateien ausgewählt."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Es wurden keine Songtexte heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Es sind keine Musikdateien ausgewählt."
 
@@ -1170,11 +1174,11 @@ msgstr "Es sind keine Musikdateien ausgewählt."
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "Keine Musikdateien in Bibliothek."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
@@ -1183,7 +1187,7 @@ msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr "Kein Benutzer-API-Key konfiguriert."
 
@@ -1208,7 +1212,7 @@ msgstr "Aus"
 msgid "Offset (in milliseconds)"
 msgstr "Verschiebung (in Millisekunden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1228,7 +1232,7 @@ msgstr "OK"
 msgid "On"
 msgstr "An"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1237,7 +1241,7 @@ msgstr ""
 "Es kann jeweils nur eine Datei an AcoustID übermittelt werden. Bitte wähle "
 "nur eine Datei aus und versuche es erneut."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Öffnen"
@@ -1248,7 +1252,7 @@ msgid "Open a library with music to get started"
 msgstr "Öffne eine Bibliothek mit Musik um loszulegen"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1258,11 +1262,11 @@ msgstr "Öffne eine Bibliothek mit Musik um loszulegen"
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Öffne Musikdatei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1296,8 +1300,8 @@ msgstr "Pfad"
 msgid "Path (Empty)"
 msgstr "Pfad (Leer)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1309,21 +1313,21 @@ msgstr ""
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Wiedergabelistendatei erfolgreich erstellt."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Wiedergabelisten-Modus"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr "Wiedergabelistenpfad darf nicht leer sein."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1338,15 +1342,15 @@ msgstr "Änderungs-Zeitstempel erhalten"
 msgid "PREVIEW"
 msgstr "VORSCHAU"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "Verlag"
 
@@ -1362,14 +1366,14 @@ msgid "Publishing Date"
 msgstr "Verlag"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Neu laden"
@@ -1389,12 +1393,12 @@ msgstr "Bibliothek neu laden"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Dateien entfernen?"
@@ -1409,7 +1413,7 @@ msgstr "Aus Wiedergabeliste entfernen"
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr "Albumcover wird entfernt..."
 
@@ -1435,8 +1439,8 @@ msgstr "Tag speichern"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tag speichern (Strg+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
@@ -1459,14 +1463,14 @@ msgstr "Einstellungen"
 msgid "Show Extras Pane"
 msgstr "Extras-Bereich anzeigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1488,12 +1492,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dateien sortieren nach"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1501,15 +1505,15 @@ msgstr "Senden"
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1520,7 +1524,7 @@ msgstr "Daten werden zu AcoustId gesendet..."
 msgid "Switch to Back Cover"
 msgstr "Zur Rückseite wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1537,7 +1541,7 @@ msgstr "Synchronisiert"
 msgid "Tag"
 msgstr "Tag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1570,7 +1574,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1584,7 +1588,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Farbschema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Die Datei hat keinen gültigen Fingerabdruck"
 
@@ -1607,9 +1611,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "titel"
 
@@ -1621,15 +1625,15 @@ msgstr "titel"
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "nummer"
 
@@ -1642,9 +1646,9 @@ msgid "Track"
 msgstr "Track"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -1667,17 +1671,17 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Tippe ! für die erweiterte Suche"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Datei konnte nicht zur Wiedergabeliste hinzugefügt werden. Vielleicht "
 "existiert die Datei bereits in der Wiedergabeliste."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Wiedergabeliste konnte nicht erstellt werden."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr "Update konnte nicht heruntergeladen und installiert werden."
 
@@ -1691,29 +1695,29 @@ msgstr "Export nach LRC fehlgeschlagen."
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Manche Dateien konnten nicht aus der Wiedergabeliste entfernt werden."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1736,7 +1740,7 @@ msgstr "Lyrics aus LRC-Datei nutzen"
 msgid "Use Relative Paths"
 msgstr "Relative Pfade verwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Relative Pfade verwenden?"
@@ -1776,7 +1780,7 @@ msgstr ""
 "Möchtest du {0} neustarten um das neue Farbschema anzuwenden?\n"
 "Ungespeicherte Änderungen gehen dabei verloren."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1788,9 +1792,9 @@ msgstr ""
 "Wenn nicht wird stattdessen der vollständige Pfad verwendet."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "Jahr"
 
@@ -1802,8 +1806,8 @@ msgstr "Jahr"
 msgid "Year"
 msgstr "Jahr"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-12 17:40+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -61,26 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "Verbindung mit dem Fingerabdruck übermitteln."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "AcoustId Nutzer-API-Key"
 
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Album-Interpret"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "albumkünstler"
 
@@ -219,7 +219,7 @@ msgstr "Alle unterstützten Dateien"
 msgid "An application restart is required to change the theme."
 msgstr "Ein Neustart der App ist notwendig um das Farbschema zu ändern."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "künstler"
 
@@ -306,21 +306,21 @@ msgid "Beats Per Minute"
 msgstr "Schläge pro Minute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Bibliothek schließen"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "kommentar"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Kommentar"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "Komponist"
 
@@ -424,25 +424,25 @@ msgstr "Mitwirkende auf GitHub ❤️"
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr "Konvertiere Dateinamen zu Tags..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr "Konvertiere Tags zu Dateinamen..."
 
@@ -476,7 +476,7 @@ msgid "Credits"
 msgstr "Credits"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "andere"
 
@@ -516,14 +516,14 @@ msgstr "Tag löschen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Tag löschen (Umschalt+Entfernen)"
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Tags werden gelöscht..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "Beschreibung"
 
@@ -594,21 +594,21 @@ msgstr "Nicht angewandte Änderungen verwerfen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Nicht angewandte Änderungen verwerfen (Strg+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Tags werden verworfen..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "songanzahl"
@@ -637,21 +637,21 @@ msgstr "Metadaten von MusicBrainz herunterladen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Metadaten von MusicBrainz herunterladen (Strg+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Songtexte für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Songtexte werden heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
@@ -667,12 +667,12 @@ msgid "Edit"
 msgstr "Bearbeiten"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr "Aktivieren um Albumcover mit Bildern von MusicBrainz zu überschreiben."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -682,7 +682,7 @@ msgstr ""
 "Songtexte befüllt."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -773,12 +773,12 @@ msgstr "Trackanzahl hier eintragen"
 msgid "Enter year here"
 msgstr "Jahr hier eintragen"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -816,11 +816,11 @@ msgstr "Vorderseite des Albumcovers exportieren"
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Rückseite des Albumcovers erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
@@ -837,11 +837,11 @@ msgstr "Suche mit MusicBrainz fehlgeschlagen"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim Exportieren des Rückseite des Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim Exportieren der Vorderseite des Albumcovers zur Datei"
 
@@ -880,7 +880,7 @@ msgid "File Properties"
 msgstr "Dateieigenschaften"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "Dateiname"
 
@@ -926,9 +926,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "genre"
 
@@ -941,7 +941,7 @@ msgid "Genre"
 msgstr "Genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Neuen API-Key anfordern"
 
@@ -1020,7 +1020,7 @@ msgstr "Rückseite des Albumcovers einfügen"
 msgid "Insert Front Album Art"
 msgstr "Vorderseite des Albumcovers einfügen"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Albumcover wird eingefügt..."
 
@@ -1038,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Sprachcode"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr "Bibliothek wurde auf der Platte verändert."
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Lade Musikdateien von Bibliothek..."
 
@@ -1058,7 +1058,7 @@ msgstr "Lade Musikdateien von Bibliothek..."
 msgid "Lryics"
 msgstr "Songtext"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "Songtext"
 
@@ -1123,7 +1123,7 @@ msgstr "Neue Andere Eigenschaft"
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr "Neue Updates verfügbar."
 
@@ -1140,7 +1140,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
@@ -1153,15 +1153,15 @@ msgstr "Keine Dateien ausgewählt"
 msgid "No files selected for removal."
 msgstr "Keine zu entfernenden Dateien ausgewählt."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Es wurden keine Songtexte heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Es sind keine Musikdateien ausgewählt."
 
@@ -1170,11 +1170,11 @@ msgstr "Es sind keine Musikdateien ausgewählt."
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "Keine Musikdateien in Bibliothek."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
@@ -1183,7 +1183,7 @@ msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr "Kein Benutzer-API-Key konfiguriert."
 
@@ -1272,17 +1272,17 @@ msgid "Open Playlist"
 msgstr "Öffne Wiedergabeliste"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Albumcover mit MusicBrainz überschreiben"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Songtexte von Web-Service überschreiben"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Tag mit MusicBrainz überschreiben"
 
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Wiedergabelistendatei erfolgreich erstellt."
 
@@ -1318,7 +1318,7 @@ msgstr "Wiedergabelistendatei erfolgreich erstellt."
 msgid "Playlist Mode"
 msgstr "Wiedergabelisten-Modus"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr "Wiedergabelistenpfad darf nicht leer sein."
 
@@ -1344,9 +1344,9 @@ msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "Verlag"
 
@@ -1362,9 +1362,9 @@ msgid "Publishing Date"
 msgstr "Verlag"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "Verlag"
@@ -1409,7 +1409,7 @@ msgstr "Aus Wiedergabeliste entfernen"
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr "Albumcover wird entfernt..."
 
@@ -1435,8 +1435,8 @@ msgstr "Tag speichern"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tag speichern (Strg+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
@@ -1501,11 +1501,11 @@ msgstr "Senden"
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Farbschema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Die Datei hat keinen gültigen Fingerabdruck"
 
@@ -1607,9 +1607,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "titel"
 
@@ -1627,9 +1627,9 @@ msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "nummer"
 
@@ -1642,9 +1642,9 @@ msgid "Track"
 msgstr "Track"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -1667,17 +1667,17 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Tippe ! für die erweiterte Suche"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Datei konnte nicht zur Wiedergabeliste hinzugefügt werden. Vielleicht "
 "existiert die Datei bereits in der Wiedergabeliste."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Wiedergabeliste konnte nicht erstellt werden."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr "Update konnte nicht heruntergeladen und installiert werden."
 
@@ -1691,29 +1691,29 @@ msgstr "Export nach LRC fehlgeschlagen."
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Manche Dateien konnten nicht aus der Wiedergabeliste entfernt werden."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1748,7 +1748,7 @@ msgstr "Nutzerinterface"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web-Dienste"
@@ -1788,9 +1788,9 @@ msgstr ""
 "Wenn nicht wird stattdessen der vollständige Pfad verwendet."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "Jahr"
 
@@ -1845,6 +1845,14 @@ msgstr "Zuletzt geöffnete Bibliothek merken"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Unterordner mit einbeziehen"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-12 17:40+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} � {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} von {1} ausgewählt"
@@ -37,63 +37,67 @@ msgstr "{0} von {1} ausgewählt"
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Wiedergabeliste (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist%-%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<behalten>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Über {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Nutzer-API-Key"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Neue Eigenschaft hinzufügen"
 
@@ -151,7 +155,7 @@ msgid "Add to Playlist"
 msgstr "Zu Wiedergabeliste hinzufügen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Zusätzliche Eigenschaften"
 
@@ -160,10 +164,10 @@ msgstr "Zusätzliche Eigenschaften"
 msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -185,21 +189,21 @@ msgstr "Albumcover"
 msgid "Album Artist"
 msgstr "Album-Interpret"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "albumkünstler"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Alle unterstützten Dateien"
 
@@ -207,58 +211,58 @@ msgstr "Alle unterstützten Dateien"
 msgid "An application restart is required to change the theme."
 msgstr "Ein Neustart der App ist notwendig um das Farbschema zu ändern."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "künstler"
 
@@ -278,70 +282,70 @@ msgstr "Automatisch auf Updates prüfen"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Hinten"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Schläge pro Minute"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Berechne..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -364,27 +368,27 @@ msgstr "Alle Songtexte enfernen"
 msgid "Close Library"
 msgstr "Bibliothek schließen"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "kommentar"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "Komponist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Komponist"
 
@@ -393,38 +397,38 @@ msgstr "Komponist"
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr "Konvertiere Dateinamen zu Tags..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr "Konvertiere Tags zu Dateinamen..."
 
@@ -432,8 +436,8 @@ msgstr "Konvertiere Tags zu Dateinamen..."
 msgid "Copied debug info to clipboard."
 msgstr "Debuginformationen wurden in die Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Fingerabdruck in die Zwischenablage kopieren"
 
@@ -457,8 +461,8 @@ msgstr "Wiedergabeliste erstellen"
 msgid "Credits"
 msgstr "Credits"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "andere"
 
@@ -470,23 +474,23 @@ msgid "Custom"
 msgstr "Andere"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Andere Eigenschaften"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Benutzerdefinierte Eigenschaften können nur für individuelle Dateien "
 "bearbeitet werden."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -498,21 +502,21 @@ msgstr "Tag löschen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Tag löschen (Umschalt+Entfernen)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Tags werden gelöscht..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "Beschreibung"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -543,23 +547,28 @@ msgstr ""
 "Übersetzer:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Verwerfen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Verwerfen"
 
@@ -571,9 +580,24 @@ msgstr "Nicht angewandte Änderungen verwerfen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Nicht angewandte Änderungen verwerfen (Strg+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Tags werden verworfen..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "songanzahl"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -599,25 +623,25 @@ msgstr "Metadaten von MusicBrainz herunterladen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Metadaten von MusicBrainz herunterladen (Strg+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Songtexte für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Songtexte werden heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr "Hier loslassen um die Bibliothek zu öffnen"
 
@@ -685,6 +709,16 @@ msgstr "Benutzerdefinierte Auswahl hier eintragen"
 msgid "Enter description here"
 msgstr "Beschreibung hier eintragen"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Dateinamen hier eintragen"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Trackanzahl hier eintragen"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr "Dateinamen hier eintragen"
@@ -705,7 +739,7 @@ msgstr "Sprachcode hier eintragen"
 msgid "Enter offset here"
 msgstr "Verschiebung hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr "Verlag hier eintragen"
 
@@ -725,12 +759,12 @@ msgstr "Trackanzahl hier eintragen"
 msgid "Enter year here"
 msgstr "Jahr hier eintragen"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -745,19 +779,19 @@ msgstr "Verlassen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Rückseite des Albumcovers exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vorderseite des Albumcovers exportieren"
@@ -768,11 +802,11 @@ msgstr "Vorderseite des Albumcovers exportieren"
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Rückseite des Albumcovers erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
@@ -781,19 +815,19 @@ msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 msgid "Exported successfully to: {0}"
 msgstr "Erfolgreich exportiert nach: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr "Suche mit MusicBrainz fehlgeschlagen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim Exportieren des Rückseite des Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim Exportieren der Vorderseite des Albumcovers zur Datei"
 
@@ -809,9 +843,9 @@ msgstr "Datei"
 msgid "File Name"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
@@ -826,28 +860,28 @@ msgstr "Dateiname zu Tag (Strg+F)"
 msgid "File Path"
 msgstr "Dateipfad"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Dateieigenschaften"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr "Ordnermodus"
 
@@ -856,29 +890,29 @@ msgstr "Ordnermodus"
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Formatvorlage"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Vorne"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "genre"
 
@@ -899,19 +933,19 @@ msgstr "Neuen API-Key anfordern"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -919,7 +953,7 @@ msgid "Help"
 msgstr "Hilfe"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr "Extras-Bereich verstecken"
 
@@ -934,31 +968,31 @@ msgstr "Von LRC importieren"
 msgid "Include Only Selected Files"
 msgstr "Nur ausgewählte Dateien berücksichtigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Rückseite des Albumcovers einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vorderseite des Albumcovers einfügen"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Albumcover wird eingefügt..."
 
@@ -976,19 +1010,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Sprachcode"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr "Bibliothek wurde auf der Platte verändert."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Lade Musikdateien von Bibliothek..."
 
@@ -996,7 +1030,7 @@ msgstr "Lade Musikdateien von Bibliothek..."
 msgid "Lryics"
 msgstr "Songtext"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "Songtext"
 
@@ -1022,7 +1056,7 @@ msgstr "Songtexte Verwalten"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Songtexte Verwalten (Strg+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
@@ -1040,13 +1074,13 @@ msgstr "Musikdatei"
 msgid "Music Library"
 msgstr "Musikbibliothek"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
@@ -1055,24 +1089,24 @@ msgstr "Neue Andere Eigenschaft"
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr "Neue Updates verfügbar."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
@@ -1080,20 +1114,20 @@ msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 msgid "No file selected"
 msgstr "Keine Dateien ausgewählt"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Keine zu entfernenden Dateien ausgewählt."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Es wurden keine Songtexte heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Es sind keine Musikdateien ausgewählt."
 
@@ -1102,11 +1136,11 @@ msgstr "Es sind keine Musikdateien ausgewählt."
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "Keine Musikdateien in Bibliothek."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
@@ -1115,7 +1149,7 @@ msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr "Kein Benutzer-API-Key konfiguriert."
 
@@ -1140,11 +1174,11 @@ msgstr "Aus"
 msgid "Offset (in milliseconds)"
 msgstr "Verschiebung (in Millisekunden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1160,8 +1194,8 @@ msgstr "OK"
 msgid "On"
 msgstr "An"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1169,8 +1203,8 @@ msgstr ""
 "Es kann jeweils nur eine Datei an AcoustID übermittelt werden. Bitte wähle "
 "nur eine Datei aus und versuche es erneut."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Öffnen"
 
@@ -1180,7 +1214,7 @@ msgid "Open a library with music to get started"
 msgstr "Öffne eine Bibliothek mit Musik um loszulegen"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1190,11 +1224,11 @@ msgstr "Öffne eine Bibliothek mit Musik um loszulegen"
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Öffne Musikdatei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1228,10 +1262,10 @@ msgstr "Pfad"
 msgid "Path (Empty)"
 msgstr "Pfad (Leer)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1241,23 +1275,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Wiedergabelistendatei erfolgreich erstellt."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr "Wiedergabelisten-Modus"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr "Wiedergabelistenpfad darf nicht leer sein."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Bitte Formatvorlage auswählen."
 
@@ -1270,39 +1304,39 @@ msgstr "Änderungs-Zeitstempel erhalten"
 msgid "PREVIEW"
 msgstr "VORSCHAU"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Verlag"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr "Neu laden"
 
@@ -1314,20 +1348,20 @@ msgstr "Bibliothek neu laden"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Dateien entfernen?"
 
@@ -1341,7 +1375,7 @@ msgstr "Aus Wiedergabeliste entfernen"
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr "Albumcover wird entfernt..."
 
@@ -1367,8 +1401,8 @@ msgstr "Tag speichern"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tag speichern (Strg+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
@@ -1387,27 +1421,27 @@ msgstr "Wähle Dateien aus"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr "Extras-Bereich anzeigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1420,43 +1454,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dateien sortieren nach"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Zur Rückseite wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Zur Vorderseite wechseln"
 
@@ -1469,9 +1503,9 @@ msgstr "Synchronisiert"
 msgid "Tag"
 msgstr "Tag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Tag zu Dateiname"
@@ -1480,9 +1514,8 @@ msgstr "Tag zu Dateiname"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Tag zu Dateiname (Strg+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tagge deine Musik"
 
@@ -1491,9 +1524,8 @@ msgstr "Tagge deine Musik"
 msgid "Tag Your Music"
 msgstr "Tagge Deine Musik"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1502,8 +1534,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1516,7 +1548,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Farbschema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Die Datei hat keinen gültigen Fingerabdruck"
 
@@ -1538,10 +1570,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "titel"
 
@@ -1553,15 +1585,15 @@ msgstr "titel"
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "nummer"
 
@@ -1573,14 +1605,14 @@ msgstr "nummer"
 msgid "Track"
 msgstr "Track"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "songanzahl"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
@@ -1599,17 +1631,17 @@ msgstr "Typ"
 msgid "Type ! for advanced search"
 msgstr "Tippe ! für die erweiterte Suche"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Datei konnte nicht zur Wiedergabeliste hinzugefügt werden. Vielleicht "
 "existiert die Datei bereits in der Wiedergabeliste."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Wiedergabeliste konnte nicht erstellt werden."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr "Update konnte nicht heruntergeladen und installiert werden."
 
@@ -1623,29 +1655,29 @@ msgstr "Export nach LRC fehlgeschlagen."
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Manche Dateien konnten nicht aus der Wiedergabeliste entfernt werden."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1654,7 +1686,7 @@ msgstr "Unbekannt"
 msgid "Unsynchronized"
 msgstr "Nicht Synchronisiert"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr "Update"
 
@@ -1668,8 +1700,8 @@ msgstr "Lyrics aus LRC-Datei nutzen"
 msgid "Use Relative Paths"
 msgstr "Relative Pfade verwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr "Relative Pfade verwenden?"
 
@@ -1703,8 +1735,8 @@ msgstr ""
 "Möchtest du {0} neustarten um das neue Farbschema anzuwenden?\n"
 "Ungespeicherte Änderungen gehen dabei verloren."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1714,10 +1746,10 @@ msgstr ""
 "Wiedergabeliste speichern?\n"
 "Wenn nicht wird stattdessen der vollständige Pfad verwendet."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "Jahr"
 
@@ -1729,10 +1761,10 @@ msgstr "Jahr"
 msgid "Year"
 msgstr "Jahr"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Ja"
@@ -1865,15 +1897,24 @@ msgstr "Alle Dateien auswählen"
 msgid "Track Total"
 msgstr "Song-Anzahl"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Song-Anzahl"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Tag-Bereich zeigen/verstecken"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Tag-Aktionen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Änderungen auf Tag anwenden (Strg+S)"
 
@@ -1881,48 +1922,41 @@ msgstr "Änderungen auf Tag anwenden (Strg+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Eigenschaft;Music;Editor;Bibliothek;Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Unterstützung von vielen Musik-Dateitypen (mp3, ogg, flac, wma, wav und "
-"mehr)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Unterstützung von vielen Musik-Dateitypen (mp3, ogg, flac, wma, wav und "
+#~ "mehr)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Editiere Tags und Albumcover mehrerer Dateien, selbst Ordnerübergreifend, "
-"zur selben Zeit"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Editiere Tags und Albumcover mehrerer Dateien, selbst "
+#~ "Ordnerübergreifend, zur selben Zeit"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Bearbeite unsynchronisierte und synchronisierte Songtexte (mit "
-"Unterstützung für LRC Import und Export)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Bearbeite unsynchronisierte und synchronisierte Songtexte (mit "
+#~ "Unterstützung für LRC Import und Export)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Lade Dateinformationen von MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Lade Dateinformationen von MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Lade Songtextinformationen mit Music163 und Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Lade Songtextinformationen mit Music163 und Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Öffne, verwalte und erstelle Wiedergabelisten in vielen Formaten (m3u, "
-"pls, xspf und mehr)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Öffne, verwalte und erstelle Wiedergabelisten in vielen Formaten (m3u, "
+#~ "pls, xspf und mehr)"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Öffne eine Bibliothek mit Musik um loszulegen."

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:40+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,81 +19,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} � {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} von {1} ausgewählt"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Wiedergabeliste (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist%-%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<behalten>"
 
@@ -101,13 +109,13 @@ msgstr "<behalten>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "Über {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -133,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Nutzer-API-Key"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Neue Eigenschaft hinzufügen"
 
@@ -154,28 +162,28 @@ msgstr "Neue Eigenschaft hinzufügen"
 msgid "Add to Playlist"
 msgstr "Zu Wiedergabeliste hinzufügen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Zusätzliche Eigenschaften"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Info zur erweiterten Suche"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -184,26 +192,26 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Albumcover"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Album-Interpret"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "albumkünstler"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Alle unterstützten Dateien"
 
@@ -211,66 +219,66 @@ msgstr "Alle unterstützten Dateien"
 msgid "An application restart is required to change the theme."
 msgstr "Ein Neustart der App ist notwendig um das Farbschema zu ändern."
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Die von MusicBrainz bereitgestellte RecordingId ist nicht valide"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Änderungen anwenden?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "künstler"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Künstler"
 
@@ -282,70 +290,72 @@ msgstr "Automatisch auf Updates prüfen"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Hinten"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Schläge pro Minute"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Berechne..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -354,7 +364,7 @@ msgstr "Abbrechen"
 msgid "Changelog"
 msgstr "Änderungshistorie"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr "Auf Updates prüfen"
 
@@ -363,32 +373,36 @@ msgstr "Auf Updates prüfen"
 msgid "Clear All Lyrics"
 msgstr "Alle Songtexte enfernen"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Bibliothek schließen"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "kommentar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Kommentar"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "Komponist"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Komponist"
 
@@ -397,38 +411,38 @@ msgstr "Komponist"
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Mitwirkende auf GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} Dateiname erfolgreich in Tags konvertiert"
 msgstr[1] "{0} Dateinamen erfolgreich in Tags konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} Tag erfolgreich zu Dateiname konvertiert"
 msgstr[1] "{0} Tags erfolgreich zu Dateiname konvertiert"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr "Konvertiere Dateinamen zu Tags..."
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr "Konvertiere Tags zu Dateinamen..."
 
@@ -436,8 +450,8 @@ msgstr "Konvertiere Tags zu Dateinamen..."
 msgid "Copied debug info to clipboard."
 msgstr "Debuginformationen wurden in die Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Fingerabdruck in die Zwischenablage kopieren"
 
@@ -461,8 +475,8 @@ msgstr "Wiedergabeliste erstellen"
 msgid "Credits"
 msgstr "Credits"
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "andere"
 
@@ -473,24 +487,24 @@ msgstr "andere"
 msgid "Custom"
 msgstr "Andere"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Andere Eigenschaften"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Benutzerdefinierte Eigenschaften können nur für individuelle Dateien "
 "bearbeitet werden."
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -498,25 +512,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Tag löschen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Tag löschen (Umschalt+Entfernen)"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Tags werden gelöscht..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "Beschreibung"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -547,28 +561,28 @@ msgstr ""
 "Übersetzer:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Verwerfen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Verwerfen"
 
@@ -576,72 +590,72 @@ msgstr "Verwerfen"
 msgid "Discard Unapplied Changed"
 msgstr "Nicht angewandte Änderungen verwerfen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Nicht angewandte Änderungen verwerfen (Strg+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Tags werden verworfen..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "songanzahl"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Diskussionen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Songtexte herunterladen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Metadaten von MusicBrainz herunterladen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Metadaten von MusicBrainz herunterladen (Strg+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Songtexte für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadaten für {0} Dateien erfolgreich heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Songtexte werden heruntergeladen..."
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Metadaten werden von MusicBrainz heruntergeladen..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr "Hier loslassen um die Bibliothek zu öffnen"
 
@@ -676,27 +690,27 @@ msgstr ""
 "Aktivieren um Tag-Metadaten mit Daten von MusicBrainz zu überschreiben. Wenn "
 "ausgeschaltet werden nur leere Eigenschaften ausgefüllt."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr "Albumkünstler hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr "Album hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr "Künstler hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr "Schläge pro Minute hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr "Kommentar hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr "Komponist hier eintragen"
 
@@ -705,25 +719,25 @@ msgid "Enter custom choice here"
 msgstr "Benutzerdefinierte Auswahl hier eintragen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr "Beschreibung hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "Dateinamen hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "Trackanzahl hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr "Dateinamen hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr "Genre hier eintragen"
 
@@ -739,32 +753,32 @@ msgstr "Sprachcode hier eintragen"
 msgid "Enter offset here"
 msgstr "Verschiebung hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr "Verlag hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr "Titel hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr "Track hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr "Trackanzahl hier eintragen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr "Jahr hier eintragen"
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -778,20 +792,20 @@ msgid "Exit"
 msgstr "Verlassen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Rückseite des Albumcovers exportieren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vorderseite des Albumcovers exportieren"
@@ -802,11 +816,11 @@ msgstr "Vorderseite des Albumcovers exportieren"
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Rückseite des Albumcovers erfolgreich zu Datei exportiert"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
@@ -815,19 +829,19 @@ msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 msgid "Exported successfully to: {0}"
 msgstr "Erfolgreich exportiert nach: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr "Suche mit MusicBrainz fehlgeschlagen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Konnte nicht mit MusicBrainz suchen"
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Fehler beim Exportieren des Rückseite des Albumcovers zur Datei"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Fehler beim Exportieren der Vorderseite des Albumcovers zur Datei"
 
@@ -836,21 +850,21 @@ msgid "File"
 msgstr "Datei"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Dateiname zu Tag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Dateiname zu Tag (Strg+F)"
 
@@ -860,28 +874,28 @@ msgstr "Dateiname zu Tag (Strg+F)"
 msgid "File Path"
 msgstr "Dateipfad"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Dateieigenschaften"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Fingerabdruck zur Zwischenablage kopiert."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Ordnermodus"
 
@@ -890,37 +904,39 @@ msgstr "Ordnermodus"
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formatvorlage"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Vorne"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Genre"
 
@@ -933,27 +949,33 @@ msgstr "Neuen API-Key anfordern"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Hell"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr "Extras-Bereich verstecken"
 
@@ -968,31 +990,37 @@ msgstr "Von LRC importieren"
 msgid "Include Only Selected Files"
 msgstr "Nur ausgewählte Dateien berücksichtigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Rückseite des Albumcovers einfügen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Vorderseite des Albumcovers einfügen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Albumcover wird eingefügt..."
 
@@ -1010,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Sprachcode"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr "Bibliothek wurde auf der Platte verändert."
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} Musikdatei geladen."
 msgstr[1] "{0} Musikdateien geladen."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Lade Musikdateien von Bibliothek..."
 
@@ -1030,39 +1058,45 @@ msgstr "Lade Musikdateien von Bibliothek..."
 msgid "Lryics"
 msgstr "Songtext"
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "Songtext"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Songtext"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Haupteigenschaften"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Songtexte Verwalten"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Songtexte Verwalten (Strg+L)"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Typ"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1074,13 +1108,13 @@ msgstr "Musikdatei"
 msgid "Music Library"
 msgstr "Musikbibliothek"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-Aufnahme-ID"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
@@ -1089,24 +1123,24 @@ msgstr "Neue Andere Eigenschaft"
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr "Neue Updates verfügbar."
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nein"
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 
@@ -1114,42 +1148,42 @@ msgstr "Kein AccoustId-Eintrag für den Fingerabdruck der Datei gefunden"
 msgid "No file selected"
 msgstr "Keine Dateien ausgewählt"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Keine zu entfernenden Dateien ausgewählt."
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Es wurden keine Songtexte heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Keine Metadaten heruntergeladen"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Es sind keine Musikdateien ausgewählt."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Keine Musikdateien gefunden"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "Keine Musikdateien in Bibliothek."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Für den AcoustId-Eintrag wurde keine MusicBrainz-RecordingId gefunden"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Keine ausgewählten Musikdateien"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr "Kein Benutzer-API-Key konfiguriert."
 
@@ -1174,11 +1208,11 @@ msgstr "Aus"
 msgid "Offset (in milliseconds)"
 msgstr "Verschiebung (in Millisekunden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1194,8 +1228,8 @@ msgstr "OK"
 msgid "On"
 msgstr "An"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1203,37 +1237,37 @@ msgstr ""
 "Es kann jeweils nur eine Datei an AcoustID übermittelt werden. Bitte wähle "
 "nur eine Datei aus und versuche es erneut."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Öffnen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Öffne eine Bibliothek mit Musik um loszulegen"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Ordner öffnen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Öffne Musikdatei"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Öffne Wiedergabeliste"
 
@@ -1262,10 +1296,10 @@ msgstr "Pfad"
 msgid "Path (Empty)"
 msgstr "Pfad (Leer)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1275,23 +1309,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Wiedergabelistendatei erfolgreich erstellt."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Wiedergabelisten-Modus"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr "Wiedergabelistenpfad darf nicht leer sein."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Bitte Formatvorlage auswählen."
 
@@ -1304,39 +1338,39 @@ msgstr "Änderungs-Zeitstempel erhalten"
 msgid "PREVIEW"
 msgstr "VORSCHAU"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Eigenschaft-Name"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Verlag"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "Verlag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Neu laden"
 
@@ -1347,21 +1381,21 @@ msgid "Reload Library"
 msgstr "Bibliothek neu laden"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Entferne Andere Eigenschaft"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Dateien entfernen?"
 
@@ -1375,11 +1409,11 @@ msgstr "Aus Wiedergabeliste entfernen"
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr "Albumcover wird entfernt..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr "Problem melden"
 
@@ -1392,17 +1426,17 @@ msgid "Save Playlist"
 msgstr "Wiedergabeliste speichern"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Tag speichern"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tag speichern (Strg+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Tags werden gespeichert..."
 
@@ -1411,8 +1445,8 @@ msgstr "Tags werden gespeichert..."
 msgid "Select Save Location"
 msgstr "Speicherort auswählen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Wähle Dateien aus"
 
@@ -1421,27 +1455,27 @@ msgstr "Wähle Dateien aus"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr "Extras-Bereich anzeigen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1454,43 +1488,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dateien sortieren nach"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Senden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "An AcoustId senden"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadaten erfolgreich zu AcoustId abgesendet"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Daten werden zu AcoustId gesendet..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Zur Rückseite wechseln"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Zur Vorderseite wechseln"
 
@@ -1503,39 +1537,41 @@ msgstr "Synchronisiert"
 msgid "Tag"
 msgstr "Tag"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Tag zu Dateiname"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Tag zu Dateiname (Strg+T)"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tagge deine Musik"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Tagge Deine Musik"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1548,7 +1584,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Farbschema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Die Datei hat keinen gültigen Fingerabdruck"
 
@@ -1570,54 +1606,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "titel"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Zu viele Dateien ausgewählt"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "nummer"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Track"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "songanzahl"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Feliks Weber <feliks@notabit.eu>"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Versuche eine andere Bibliothek"
 
@@ -1626,22 +1662,22 @@ msgstr "Versuche eine andere Bibliothek"
 msgid "Type"
 msgstr "Typ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr "Tippe ! für die erweiterte Suche"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Datei konnte nicht zur Wiedergabeliste hinzugefügt werden. Vielleicht "
 "existiert die Datei bereits in der Wiedergabeliste."
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Wiedergabeliste konnte nicht erstellt werden."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr "Update konnte nicht heruntergeladen und installiert werden."
 
@@ -1655,29 +1691,29 @@ msgstr "Export nach LRC fehlgeschlagen."
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Konnte Bilddatei nicht laden"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Manche Dateien konnten nicht aus der Wiedergabeliste entfernt werden."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Konnte {0} nicht speichern"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Konnte {0} nicht speichern."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Konnte nicht zu AcoustId senden. Prüfe API-Key"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1686,7 +1722,7 @@ msgstr "Unbekannt"
 msgid "Unsynchronized"
 msgstr "Nicht Synchronisiert"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr "Update"
 
@@ -1700,8 +1736,8 @@ msgstr "Lyrics aus LRC-Datei nutzen"
 msgid "Use Relative Paths"
 msgstr "Relative Pfade verwenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Relative Pfade verwenden?"
 
@@ -1710,10 +1746,10 @@ msgstr "Relative Pfade verwenden?"
 msgid "User Interface"
 msgstr "Nutzerinterface"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web-Dienste"
 
@@ -1726,6 +1762,11 @@ msgstr ""
 "Wie soll Tagger mit Songtexten aus der LRC-Datei umgehen, die mit "
 "existierenden Songtexten mit demselben Zeitstempel in Konflikt stehen?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1735,8 +1776,8 @@ msgstr ""
 "Möchtest du {0} neustarten um das neue Farbschema anzuwenden?\n"
 "Ungespeicherte Änderungen gehen dabei verloren."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1746,25 +1787,25 @@ msgstr ""
 "Wiedergabeliste speichern?\n"
 "Wenn nicht wird stattdessen der vollständige Pfad verwendet."
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "Jahr"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Jahr"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Ja"
@@ -1838,7 +1879,7 @@ msgid "Remove Front Album Art"
 msgstr "Vorderseite des Albumcovers entfernen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Albumcover wechseln"
 
@@ -1869,52 +1910,52 @@ msgstr "Beenden"
 msgid "About Tagger"
 msgstr "Über Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Bibliotheksmenü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Bibliothek"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Ordner öffnen (Strg+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Wiedergabeliste öffnen (Strg+Umschalt+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Alle Dateien auswählen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Song-Anzahl"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Song-Anzahl"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Tag-Bereich zeigen/verstecken"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Tag-Aktionen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Änderungen auf Tag anwenden (Strg+S)"
 
@@ -1922,41 +1963,48 @@ msgstr "Änderungen auf Tag anwenden (Strg+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Eigenschaft;Music;Editor;Bibliothek;Nickvision;"
 
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "— Unterstützung von vielen Musik-Dateitypen (mp3, ogg, flac, wma, wav und "
-#~ "mehr)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+"— Unterstützung von vielen Musik-Dateitypen (mp3, ogg, flac, wma, wav und "
+"mehr)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "— Editiere Tags und Albumcover mehrerer Dateien, selbst "
-#~ "Ordnerübergreifend, zur selben Zeit"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"— Editiere Tags und Albumcover mehrerer Dateien, selbst Ordnerübergreifend, "
+"zur selben Zeit"
 
-#~ msgid ""
-#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-#~ "and export support)"
-#~ msgstr ""
-#~ "— Bearbeite unsynchronisierte und synchronisierte Songtexte (mit "
-#~ "Unterstützung für LRC Import und Export)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+"— Bearbeite unsynchronisierte und synchronisierte Songtexte (mit "
+"Unterstützung für LRC Import und Export)"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr "— Konvertiere Dateinamen einfach zu Tags und Tags zu Dateinamen"
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "— Lade Dateinformationen von MusicBrainz"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "— Lade Dateinformationen von MusicBrainz"
 
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "— Lade Songtextinformationen mit Music163 und Letras"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "— Lade Songtextinformationen mit Music163 und Letras"
 
-#~ msgid ""
-#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-#~ "more)"
-#~ msgstr ""
-#~ "— Öffne, verwalte und erstelle Wiedergabelisten in vielen Formaten (m3u, "
-#~ "pls, xspf und mehr)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
+"— Öffne, verwalte und erstelle Wiedergabelisten in vielen Formaten (m3u, "
+"pls, xspf und mehr)"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Öffne eine Bibliothek mit Musik um loszulegen."

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Acerca de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "Clave API de usuario de AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "álbum"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Artista del álbum"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "artistadelálbum"
 
@@ -210,8 +210,8 @@ msgstr "artistadelálbum"
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Todos los archivos compatibles"
 
@@ -219,18 +219,18 @@ msgstr "Todos los archivos compatibles"
 msgid "An application restart is required to change the theme."
 msgstr "Para cambiar el tema es necesario reiniciar la aplicación."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -247,14 +247,14 @@ msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artista"
 
@@ -291,8 +291,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -306,40 +306,40 @@ msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Calculando..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Cerrar la biblioteca"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "comentario"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Comentario"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "compositor"
 
@@ -415,8 +415,8 @@ msgstr "Configurar"
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -424,25 +424,25 @@ msgstr "Colaboradores en GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr "Convertir los nombres de los archivo en etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr "Convertir las etiquetas en nombres de archivo..."
 
@@ -476,7 +476,7 @@ msgid "Credits"
 msgstr "Créditos"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "personalizado"
 
@@ -516,14 +516,14 @@ msgstr "Eliminar la etiqueta"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Eliminar la etiqueta (Mayús+Supr)"
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Borrando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "descripción"
 
@@ -566,14 +566,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Descartar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -594,21 +594,21 @@ msgstr "Descartar los cambios no aplicados"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Descartar los cambios no aplicados (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Descartando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "pistatotal"
@@ -637,21 +637,21 @@ msgstr "Descargar metadatos de MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Descargar los metadatos de MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Letras descargadas para {0} archivos correctamente"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Descargando las letras..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
@@ -776,12 +776,12 @@ msgstr "Introduce aquí la totalidad de la pista"
 msgid "Enter year here"
 msgstr "Introduce aquí el año"
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -803,12 +803,12 @@ msgstr "Salir"
 msgid "Export"
 msgstr "Exportar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportar contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
@@ -819,11 +819,11 @@ msgstr "Exportar portada del álbum"
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
@@ -836,15 +836,15 @@ msgstr "Exportado con éxito a: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Búsqueda fallida en MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
@@ -860,7 +860,7 @@ msgstr "Archivo"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -883,7 +883,7 @@ msgid "File Properties"
 msgstr "Propiedades del archivo"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "nombredearchivo"
 
@@ -892,12 +892,12 @@ msgstr "nombredearchivo"
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Modo de carpeta"
@@ -907,16 +907,16 @@ msgstr "Modo de carpeta"
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Cadena de formato"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -929,9 +929,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "género"
 
@@ -952,7 +952,7 @@ msgstr "Obtener clave API nueva"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
@@ -963,9 +963,9 @@ msgstr "Repo de GitHub"
 msgid "Height"
 msgstr "Claro"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -993,7 +993,7 @@ msgstr "Importar desde LRC"
 msgid "Include Only Selected Files"
 msgstr "Incluir solo los archivos seleccionados"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1013,17 +1013,17 @@ msgstr "Información"
 msgid "Insert"
 msgstr "Insertar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insertar la contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Insertando portadas…"
 
@@ -1041,19 +1041,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Código de idioma"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr "La biblioteca se ha modificado en el disco."
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
@@ -1061,7 +1061,7 @@ msgstr "Cargando los archivos de música de la biblioteca..."
 msgid "Lryics"
 msgstr "Letras"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "letras"
 
@@ -1075,6 +1075,10 @@ msgstr "Letras"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Propiedades principales"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1111,12 +1115,12 @@ msgstr "Archivo de música"
 msgid "Music Library"
 msgstr "Biblioteca musical"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
@@ -1126,7 +1130,7 @@ msgstr "Propiedad personalizada nueva"
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
@@ -1135,15 +1139,15 @@ msgstr "Nueva actualización disponible."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
@@ -1151,20 +1155,20 @@ msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 msgid "No file selected"
 msgstr "Ningún archivo seleccionado"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "No hay archivos seleccionados para la eliminación."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "No se ha descargado ninguna letra"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "No hay archivos de música seleccionados."
 
@@ -1173,11 +1177,11 @@ msgstr "No hay archivos de música seleccionados."
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "No hay archivos de música en la biblioteca."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr "No hay una clave api para el usuario configurada."
 
@@ -1213,7 +1217,7 @@ msgstr "Apagar"
 msgid "Offset (in milliseconds)"
 msgstr "Desfase (en milisegundos)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1233,7 +1237,7 @@ msgstr "Vale"
 msgid "On"
 msgstr "Encender"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1242,7 +1246,7 @@ msgstr ""
 "Sólo se puede enviar un archivo a AcoustID cada vez. Seleccione sólo un "
 "archivo e inténtelo de nuevo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Abrir"
@@ -1253,7 +1257,7 @@ msgid "Open a library with music to get started"
 msgstr "Abra una biblioteca con música para empezar"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1263,11 +1267,11 @@ msgstr "Abra una biblioteca con música para empezar"
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Abrir un archivo de música"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1301,8 +1305,8 @@ msgstr "Ruta"
 msgid "Path (Empty)"
 msgstr "Ruta (Vacía)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1314,21 +1318,21 @@ msgstr "Selecciona una fecha"
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Archivo de la lista de reproducción creado correctamente."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Modo de la lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr "La ruta de la lista de reproducción no puede estar vacía."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1343,15 +1347,15 @@ msgstr "Conservar fecha de modificación"
 msgid "PREVIEW"
 msgstr "VISTA PREVIA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "editor"
 
@@ -1366,13 +1370,13 @@ msgid "Publishing Date"
 msgstr "Fecha de la publicación"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 msgid "publishingdate"
 msgstr "Fecha de la publicación"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Recargar"
@@ -1392,12 +1396,12 @@ msgstr "Recargar la biblioteca"
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "¿Eliminar los archivos?"
@@ -1412,7 +1416,7 @@ msgstr "Eliminar de la lista de reproducción"
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr "Quitando las carátulas del álbum..."
 
@@ -1438,8 +1442,8 @@ msgstr "Guardar etiqueta"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Guardar la etiqueta (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
@@ -1462,14 +1466,14 @@ msgstr "Ajustes"
 msgid "Show Extras Pane"
 msgstr "Mostrar el panel de Extras"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1492,12 +1496,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordenar archivos por"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Enviar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1505,15 +1509,15 @@ msgstr "Enviar"
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1524,7 +1528,7 @@ msgstr "Enviando datos a AcoustId..."
 msgid "Switch to Back Cover"
 msgstr "Cambiar a la contraportada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1541,7 +1545,7 @@ msgstr "Sincronizado"
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1576,7 +1580,7 @@ msgstr ""
 "Se puede acceder a la documentación y los canales de soporte de Tagger a "
 "través del menú Ayuda."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1590,7 +1594,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Este archivo no tiene una huella digital válida"
 
@@ -1614,9 +1618,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "título"
 
@@ -1628,15 +1632,15 @@ msgstr "título"
 msgid "Title"
 msgstr "Título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "pista"
 
@@ -1649,9 +1653,9 @@ msgid "Track"
 msgstr "Pista"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -1674,17 +1678,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Escribe ! para la búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "No se puede añadir un archivo a la lista de reproducción. Es posible que el "
 "archivo ya exista en la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "No se puede crear la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
@@ -1698,29 +1702,29 @@ msgstr "No se puede exportar al LRC."
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "No se pueden eliminar algunos archivos de la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1743,7 +1747,7 @@ msgstr "Usa las letras del LRC"
 msgid "Use Relative Paths"
 msgstr "Usar rutas relativas"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "¿Utilizar rutas relativas?"
@@ -1783,7 +1787,7 @@ msgstr ""
 "¿Deseas reiniciar {0} para aplicar el nuevo tema?\n"
 "Cualquier trabajo no guardado se perderá."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1795,9 +1799,9 @@ msgstr ""
 "En caso contrario, se utilizará la ruta completa."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "año"
 
@@ -1809,8 +1813,8 @@ msgstr "año"
 msgid "Year"
 msgstr "Año"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,91 +19,103 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} de {1} seleccionados"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Lista de reproducción (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<mantener>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "Acerca de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "Clave API de usuario de AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Añadir una nueva propiedad"
 
@@ -150,28 +162,28 @@ msgstr "Añadir una nueva propiedad"
 msgid "Add to Playlist"
 msgstr "Añadir a la lista de reproducción"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Propiedades adicionales"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "álbum"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Álbum"
 
@@ -180,26 +192,26 @@ msgstr "Álbum"
 msgid "Album Art"
 msgstr "Portada"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Artista del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "artistadelálbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Todos los archivos compatibles"
 
@@ -207,66 +219,66 @@ msgstr "Todos los archivos compatibles"
 msgid "An application restart is required to change the theme."
 msgstr "Para cambiar el tema es necesario reiniciar la aplicación."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artista"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Artista"
 
@@ -278,70 +290,72 @@ msgstr "Buscar automáticamente actualizaciones"
 msgid "B"
 msgstr "B"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Trasera"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Calculando..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Cancelar"
@@ -350,7 +364,7 @@ msgstr "Cancelar"
 msgid "Changelog"
 msgstr "Registro de cambios"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
@@ -359,32 +373,36 @@ msgstr "Buscar actualizaciones"
 msgid "Clear All Lyrics"
 msgstr "Borrar todas las letras"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Cerrar la biblioteca"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "comentario"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Comentario"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "compositor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Compositor"
 
@@ -393,38 +411,38 @@ msgstr "Compositor"
 msgid "Configure"
 msgstr "Configurar"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr "Convertir los nombres de los archivo en etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr "Convertir las etiquetas en nombres de archivo..."
 
@@ -432,8 +450,8 @@ msgstr "Convertir las etiquetas en nombres de archivo..."
 msgid "Copied debug info to clipboard."
 msgstr "Información de depuración copiada en el portapapeles."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copiar firma al portapapeles"
 
@@ -457,8 +475,8 @@ msgstr "Crear una lista de reproducción"
 msgid "Credits"
 msgstr "Créditos"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "personalizado"
 
@@ -469,24 +487,24 @@ msgstr "personalizado"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Propiedades personalizadas"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Las propiedades personalizadas solo pueden editarse para los archivos "
 "individuales."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -494,25 +512,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Eliminar la etiqueta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Eliminar la etiqueta (Mayús+Supr)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Borrando las etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "descripción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Descripción"
 
@@ -543,23 +561,28 @@ msgstr ""
 "Traductores:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Disc"
+msgstr "Descartar"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Descartar"
 
@@ -567,57 +590,72 @@ msgstr "Descartar"
 msgid "Discard Unapplied Changed"
 msgstr "Descartar los cambios no aplicados"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Descartar los cambios no aplicados (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Descartando las etiquetas..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
+#, fuzzy
+msgid "disctotal"
+msgstr "pistatotal"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Debates"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Documentación"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Descargar las letras"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Descargar metadatos de MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Descargar los metadatos de MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Letras descargadas para {0} archivos correctamente"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Descargando las letras..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr "Haz clic aquí para abrir la biblioteca"
 
@@ -655,27 +693,27 @@ msgstr ""
 "datos encontrados en MusicBrainz. Si se desactiva, sólo se rellenarán las "
 "propiedades en blanco de las etiquetas."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr "Introduce aquí el artista del álbum"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr "Introduce aquí el álbum"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr "Introduce aquí el artista"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr "Introduce aquí las pulsaciones por minuto"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr "Introduce aquí tu comentario"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr "Introduce aquí el compositor"
 
@@ -684,15 +722,25 @@ msgid "Enter custom choice here"
 msgstr "Introduce aquí tu opción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr "Introduce aquí la descripción"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Introduce aquí el nombre del archivo"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Introduce aquí la totalidad de la pista"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr "Introduce aquí el nombre del archivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr "Introduce aquí el género"
 
@@ -708,32 +756,32 @@ msgstr "Introduce aquí el código del idioma"
 msgid "Enter offset here"
 msgstr "Introduce aquí el offset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr "Introduce aquí el editor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr "Introduce aquí el título"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr "Introduce aquí la pista"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr "Introduce aquí la totalidad de la pista"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr "Introduce aquí el año"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -747,20 +795,20 @@ msgid "Exit"
 msgstr "Salir"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Exportar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportar contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
@@ -771,11 +819,11 @@ msgstr "Exportar portada del álbum"
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
@@ -784,19 +832,19 @@ msgstr "Exportada correctamente la portada del álbum al archivo"
 msgid "Exported successfully to: {0}"
 msgstr "Exportado con éxito a: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr "Búsqueda fallida en MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
@@ -805,21 +853,21 @@ msgid "File"
 msgstr "Archivo"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Nombre de un archivo a una etiqueta (Ctrl+F)"
 
@@ -829,28 +877,28 @@ msgstr "Nombre de un archivo a una etiqueta (Ctrl+F)"
 msgid "File Path"
 msgstr "Ruta del archivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Propiedades del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "nombredearchivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Modo de carpeta"
 
@@ -859,37 +907,39 @@ msgstr "Modo de carpeta"
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Cadena de formato"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Frontal"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "género"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Género"
 
@@ -902,27 +952,33 @@ msgstr "Obtener clave API nueva"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Claro"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr "Ocultar el panel de Extras"
 
@@ -937,31 +993,37 @@ msgstr "Importar desde LRC"
 msgid "Include Only Selected Files"
 msgstr "Incluir solo los archivos seleccionados"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Información"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Insertar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insertar la contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Insertando portadas…"
 
@@ -979,19 +1041,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Código de idioma"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr "La biblioteca se ha modificado en el disco."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
@@ -999,39 +1061,45 @@ msgstr "Cargando los archivos de música de la biblioteca..."
 msgid "Lryics"
 msgstr "Letras"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "letras"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Letras"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Propiedades principales"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Gestionar letras"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gestionar las letras (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Tipo"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1043,13 +1111,13 @@ msgstr "Archivo de música"
 msgid "Music Library"
 msgstr "Biblioteca musical"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
@@ -1058,24 +1126,24 @@ msgstr "Propiedad personalizada nueva"
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
@@ -1083,44 +1151,44 @@ msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 msgid "No file selected"
 msgstr "Ningún archivo seleccionado"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "No hay archivos seleccionados para la eliminación."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "No se ha descargado ninguna letra"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "No hay archivos de música seleccionados."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "No hay archivos de música en la biblioteca."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
 "AcoustId"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr "No hay una clave api para el usuario configurada."
 
@@ -1145,11 +1213,11 @@ msgstr "Apagar"
 msgid "Offset (in milliseconds)"
 msgstr "Desfase (en milisegundos)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "Vale"
 
@@ -1165,8 +1233,8 @@ msgstr "Vale"
 msgid "On"
 msgstr "Encender"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1174,37 +1242,37 @@ msgstr ""
 "Sólo se puede enviar un archivo a AcoustID cada vez. Seleccione sólo un "
 "archivo e inténtelo de nuevo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Abrir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Abra una biblioteca con música para empezar"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Abrir un archivo de música"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Abrir la lista de reproducción"
 
@@ -1233,10 +1301,10 @@ msgstr "Ruta"
 msgid "Path (Empty)"
 msgstr "Ruta (Vacía)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr "Selecciona una fecha"
 
@@ -1246,23 +1314,23 @@ msgstr "Selecciona una fecha"
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Archivo de la lista de reproducción creado correctamente."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Modo de la lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr "La ruta de la lista de reproducción no puede estar vacía."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Seleccione una cadena de formato."
 
@@ -1275,37 +1343,37 @@ msgstr "Conservar fecha de modificación"
 msgid "PREVIEW"
 msgstr "VISTA PREVIA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "editor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Editor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Publishing Date"
 msgstr "Fecha de la publicación"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 msgid "publishingdate"
 msgstr "Fecha de la publicación"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Recargar"
 
@@ -1316,21 +1384,21 @@ msgid "Reload Library"
 msgstr "Recargar la biblioteca"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "¿Eliminar los archivos?"
 
@@ -1344,11 +1412,11 @@ msgstr "Eliminar de la lista de reproducción"
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr "Quitando las carátulas del álbum..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr "Informar de un error"
 
@@ -1361,17 +1429,17 @@ msgid "Save Playlist"
 msgstr "Guardar la lista de reproducción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Guardar etiqueta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr "Guardar la etiqueta (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
@@ -1380,8 +1448,8 @@ msgstr "Guardando etiquetas…"
 msgid "Select Save Location"
 msgstr "Seleccione la ubicación de guardado"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Seleccione algunos archivos"
 
@@ -1390,27 +1458,27 @@ msgstr "Seleccione algunos archivos"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr "Mostrar el panel de Extras"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1424,43 +1492,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordenar archivos por"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Enviar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Cambiar a la contraportada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Cambiar a la portada"
 
@@ -1473,43 +1541,43 @@ msgstr "Sincronizado"
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Etiqueta a nombre de archivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Etiqueta un nombre de un archivo (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Etiqueta tu música"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Etiquetar Tu Música"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 "Se puede acceder a la documentación y los canales de soporte de Tagger a "
 "través del menú Ayuda."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1522,7 +1590,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Este archivo no tiene una huella digital válida"
 
@@ -1545,54 +1613,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "título"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "pista"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Pista"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "pistatotal"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Pruebe con otra biblioteca"
 
@@ -1601,22 +1669,22 @@ msgstr "Pruebe con otra biblioteca"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr "Escribe ! para la búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "No se puede añadir un archivo a la lista de reproducción. Es posible que el "
 "archivo ya exista en la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "No se puede crear la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
@@ -1630,29 +1698,29 @@ msgstr "No se puede exportar al LRC."
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "No se pueden eliminar algunos archivos de la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1661,7 +1729,7 @@ msgstr "Desconocido"
 msgid "Unsynchronized"
 msgstr "Desincronizado"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr "Actualización"
 
@@ -1675,8 +1743,8 @@ msgstr "Usa las letras del LRC"
 msgid "Use Relative Paths"
 msgstr "Usar rutas relativas"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "¿Utilizar rutas relativas?"
 
@@ -1685,10 +1753,10 @@ msgstr "¿Utilizar rutas relativas?"
 msgid "User Interface"
 msgstr "Interfaz de usuario"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Servicios web"
 
@@ -1701,6 +1769,11 @@ msgstr ""
 "¿Qué quiere que haga Tagger con las letras encontradas en el archivo LRC que "
 "entran en conflicto con letras existentes de la misma marca de tiempo?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1710,8 +1783,8 @@ msgstr ""
 "¿Deseas reiniciar {0} para aplicar el nuevo tema?\n"
 "Cualquier trabajo no guardado se perderá."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1721,25 +1794,25 @@ msgstr ""
 "ruta relativa?\n"
 "En caso contrario, se utilizará la ruta completa."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "año"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Año"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Sí"
@@ -1813,7 +1886,7 @@ msgid "Remove Front Album Art"
 msgstr "Quitar la portada del álbum"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Cambiar portada del álbum"
 
@@ -1844,43 +1917,52 @@ msgstr "Abandonar"
 msgid "About Tagger"
 msgstr "Acerca de Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Menú de la biblioteca"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Biblioteca"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Menú principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Abrir la carpeta (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Abrir la lista de reproducción (Ctrl+Mayús+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Seleccionar todos los archivos"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Pista total"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
+#, fuzzy
+msgid "Disc Total"
+msgstr "Pista total"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Conmutar panel de etiquetas"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Acciones de etiqueta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-19 15:16+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -61,26 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "la firma."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "Clave API de usuario de AcoustId"
 
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "álbum"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Artista del álbum"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "artistadelálbum"
 
@@ -219,7 +219,7 @@ msgstr "Todos los archivos compatibles"
 msgid "An application restart is required to change the theme."
 msgstr "Para cambiar el tema es necesario reiniciar la aplicación."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artista"
 
@@ -306,21 +306,21 @@ msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Cerrar la biblioteca"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "comentario"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Comentario"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "compositor"
 
@@ -424,25 +424,25 @@ msgstr "Colaboradores en GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr "Convertir los nombres de los archivo en etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr "Convertir las etiquetas en nombres de archivo..."
 
@@ -476,7 +476,7 @@ msgid "Credits"
 msgstr "Créditos"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "personalizado"
 
@@ -516,14 +516,14 @@ msgstr "Eliminar la etiqueta"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Eliminar la etiqueta (Mayús+Supr)"
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Borrando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "descripción"
 
@@ -594,21 +594,21 @@ msgstr "Descartar los cambios no aplicados"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Descartar los cambios no aplicados (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Descartando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "pistatotal"
@@ -637,21 +637,21 @@ msgstr "Descargar metadatos de MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Descargar los metadatos de MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Letras descargadas para {0} archivos correctamente"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Descargando las letras..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
@@ -667,14 +667,14 @@ msgid "Edit"
 msgstr "Editar"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Activar para sobreescribir las portadas de los álbumes existentes con "
 "portadas encontradas en MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -684,7 +684,7 @@ msgstr ""
 "letras en blanco."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -776,12 +776,12 @@ msgstr "Introduce aquí la totalidad de la pista"
 msgid "Enter year here"
 msgstr "Introduce aquí el año"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -819,11 +819,11 @@ msgstr "Exportar portada del álbum"
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
@@ -840,11 +840,11 @@ msgstr "Búsqueda fallida en MusicBrainz"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
@@ -883,7 +883,7 @@ msgid "File Properties"
 msgstr "Propiedades del archivo"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "nombredearchivo"
 
@@ -929,9 +929,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "género"
 
@@ -944,7 +944,7 @@ msgid "Genre"
 msgstr "Género"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Obtener clave API nueva"
 
@@ -1023,7 +1023,7 @@ msgstr "Insertar la contraportada del álbum"
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Insertando portadas…"
 
@@ -1041,19 +1041,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Código de idioma"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr "La biblioteca se ha modificado en el disco."
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
@@ -1061,7 +1061,7 @@ msgstr "Cargando los archivos de música de la biblioteca..."
 msgid "Lryics"
 msgstr "Letras"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "letras"
 
@@ -1126,7 +1126,7 @@ msgstr "Propiedad personalizada nueva"
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
@@ -1143,7 +1143,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
@@ -1156,15 +1156,15 @@ msgstr "Ningún archivo seleccionado"
 msgid "No files selected for removal."
 msgstr "No hay archivos seleccionados para la eliminación."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "No se ha descargado ninguna letra"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "No hay archivos de música seleccionados."
 
@@ -1173,11 +1173,11 @@ msgstr "No hay archivos de música seleccionados."
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "No hay archivos de música en la biblioteca."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
@@ -1188,7 +1188,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr "No hay una clave api para el usuario configurada."
 
@@ -1277,17 +1277,17 @@ msgid "Open Playlist"
 msgstr "Abrir la lista de reproducción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Sobreescribir la portada del álbum con MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Sobrescribir letras desde el servicio web"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Sobreescribir etiqueta con MusicBrainz"
 
@@ -1314,7 +1314,7 @@ msgstr "Selecciona una fecha"
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Archivo de la lista de reproducción creado correctamente."
 
@@ -1323,7 +1323,7 @@ msgstr "Archivo de la lista de reproducción creado correctamente."
 msgid "Playlist Mode"
 msgstr "Modo de la lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr "La ruta de la lista de reproducción no puede estar vacía."
 
@@ -1349,9 +1349,9 @@ msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "editor"
 
@@ -1366,9 +1366,9 @@ msgid "Publishing Date"
 msgstr "Fecha de la publicación"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 msgid "publishingdate"
 msgstr "Fecha de la publicación"
 
@@ -1412,7 +1412,7 @@ msgstr "Eliminar de la lista de reproducción"
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr "Quitando las carátulas del álbum..."
 
@@ -1438,8 +1438,8 @@ msgstr "Guardar etiqueta"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Guardar la etiqueta (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
@@ -1505,11 +1505,11 @@ msgstr "Enviar"
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Este archivo no tiene una huella digital válida"
 
@@ -1614,9 +1614,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "título"
 
@@ -1634,9 +1634,9 @@ msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "pista"
 
@@ -1649,9 +1649,9 @@ msgid "Track"
 msgstr "Pista"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -1674,17 +1674,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Escribe ! para la búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "No se puede añadir un archivo a la lista de reproducción. Es posible que el "
 "archivo ya exista en la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "No se puede crear la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
@@ -1698,29 +1698,29 @@ msgstr "No se puede exportar al LRC."
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "No se pueden eliminar algunos archivos de la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1755,7 +1755,7 @@ msgstr "Interfaz de usuario"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Servicios web"
@@ -1795,9 +1795,9 @@ msgstr ""
 "En caso contrario, se utilizará la ruta completa."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "año"
 
@@ -1852,6 +1852,14 @@ msgstr "Recordar la última biblioteca abierta"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Incluir subcarpetas"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} � {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} de {1} seleccionados"
@@ -37,63 +37,67 @@ msgstr "{0} de {1} seleccionados"
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Lista de reproducción (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<mantener>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Acerca de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "Clave API de usuario de AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Añadir una nueva propiedad"
 
@@ -151,7 +155,7 @@ msgid "Add to Playlist"
 msgstr "Añadir a la lista de reproducción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Propiedades adicionales"
 
@@ -160,10 +164,10 @@ msgstr "Propiedades adicionales"
 msgid "Advanced Search Info"
 msgstr "Información de búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "álbum"
 
@@ -185,21 +189,21 @@ msgstr "Portada"
 msgid "Album Artist"
 msgstr "Artista del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "artistadelálbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Todos los archivos compatibles"
 
@@ -207,58 +211,58 @@ msgstr "Todos los archivos compatibles"
 msgid "An application restart is required to change the theme."
 msgstr "Para cambiar el tema es necesario reiniciar la aplicación."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Se ha proporcionado un RecordingId no válido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "¿Aplicar cambios?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artista"
 
@@ -278,70 +282,70 @@ msgstr "Buscar automáticamente actualizaciones"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Trasera"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Pulsaciones por minuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "ppm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Calculando..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Cancelar"
@@ -364,27 +368,27 @@ msgstr "Borrar todas las letras"
 msgid "Close Library"
 msgstr "Cerrar la biblioteca"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "comentario"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Comentario"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "compositor"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Compositor"
 
@@ -393,38 +397,38 @@ msgstr "Compositor"
 msgid "Configure"
 msgstr "Configurar"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Colaboradores en GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Convertido {0} nombre de archivo a etiqueta con éxito"
 msgstr[1] "Convertidos {0} nombres de archivo a etiquetas con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Convertida {0} etiqueta a nombre de archivo con éxito"
 msgstr[1] "Convertidas {0} etiquetas a nombres de archivo con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr "Convertir los nombres de los archivo en etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr "Convertir las etiquetas en nombres de archivo..."
 
@@ -432,8 +436,8 @@ msgstr "Convertir las etiquetas en nombres de archivo..."
 msgid "Copied debug info to clipboard."
 msgstr "Información de depuración copiada en el portapapeles."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copiar firma al portapapeles"
 
@@ -457,8 +461,8 @@ msgstr "Crear una lista de reproducción"
 msgid "Credits"
 msgstr "Créditos"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "personalizado"
 
@@ -470,23 +474,23 @@ msgid "Custom"
 msgstr "Personalizado"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Propiedades personalizadas"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Las propiedades personalizadas solo pueden editarse para los archivos "
 "individuales."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -498,21 +502,21 @@ msgstr "Eliminar la etiqueta"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Eliminar la etiqueta (Mayús+Supr)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Borrando las etiquetas..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "descripción"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Descripción"
 
@@ -543,23 +547,28 @@ msgstr ""
 "Traductores:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Descartar"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Descartar"
 
@@ -571,9 +580,24 @@ msgstr "Descartar los cambios no aplicados"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Descartar los cambios no aplicados (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Descartando las etiquetas..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "pistatotal"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -599,25 +623,25 @@ msgstr "Descargar metadatos de MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Descargar los metadatos de MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Letras descargadas para {0} archivos correctamente"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Descargados correctamente los metadatos de los {0} archivos"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Descargando las letras..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Descargando metadatos de MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr "Haz clic aquí para abrir la biblioteca"
 
@@ -688,6 +712,16 @@ msgstr "Introduce aquí tu opción"
 msgid "Enter description here"
 msgstr "Introduce aquí la descripción"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Introduce aquí el nombre del archivo"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Introduce aquí la totalidad de la pista"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr "Introduce aquí el nombre del archivo"
@@ -708,7 +742,7 @@ msgstr "Introduce aquí el código del idioma"
 msgid "Enter offset here"
 msgstr "Introduce aquí el offset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr "Introduce aquí el editor"
 
@@ -728,12 +762,12 @@ msgstr "Introduce aquí la totalidad de la pista"
 msgid "Enter year here"
 msgstr "Introduce aquí el año"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -748,19 +782,19 @@ msgstr "Salir"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Exportar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exportar contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
@@ -771,11 +805,11 @@ msgstr "Exportar portada del álbum"
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Exportada correctamente contraportada del álbum al archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
@@ -784,19 +818,19 @@ msgstr "Exportada correctamente la portada del álbum al archivo"
 msgid "Exported successfully to: {0}"
 msgstr "Exportado con éxito a: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr "Búsqueda fallida en MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Búsquedas fallidas en MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Error al exportar contraportada del álbum a un archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Error al exportar portada del álbum a un archivo"
 
@@ -812,9 +846,9 @@ msgstr "Archivo"
 msgid "File Name"
 msgstr "Nombre del archivo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Nombre de archivo a etiquetar"
@@ -829,28 +863,28 @@ msgstr "Nombre de un archivo a una etiqueta (Ctrl+F)"
 msgid "File Path"
 msgstr "Ruta del archivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Propiedades del archivo"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "nombredearchivo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Firma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "La firma se ha copiado al portapapeles."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr "Modo de carpeta"
 
@@ -859,29 +893,29 @@ msgstr "Modo de carpeta"
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Cadena de formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Frontal"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "género"
 
@@ -902,19 +936,19 @@ msgstr "Obtener clave API nueva"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "Repo de GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -922,7 +956,7 @@ msgid "Help"
 msgstr "Ayuda"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr "Ocultar el panel de Extras"
 
@@ -937,31 +971,31 @@ msgstr "Importar desde LRC"
 msgid "Include Only Selected Files"
 msgstr "Incluir solo los archivos seleccionados"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Información"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Insertar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insertar la contraportada del álbum"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insertar la portada del álbum"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Insertando portadas…"
 
@@ -979,19 +1013,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Código de idioma"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr "La biblioteca se ha modificado en el disco."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Cargado {0} archivo de música."
 msgstr[1] "Cargados {0} archivos de música."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
@@ -999,7 +1033,7 @@ msgstr "Cargando los archivos de música de la biblioteca..."
 msgid "Lryics"
 msgstr "Letras"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "letras"
 
@@ -1025,7 +1059,7 @@ msgstr "Gestionar letras"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gestionar las letras (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
@@ -1043,13 +1077,13 @@ msgstr "Archivo de música"
 msgid "Music Library"
 msgstr "Biblioteca musical"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "Id de grabación MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
@@ -1058,24 +1092,24 @@ msgstr "Propiedad personalizada nueva"
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr "Nueva actualización disponible."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 
@@ -1083,20 +1117,20 @@ msgstr "No se ha encontrado ninguna entrada AcoustId para la firma del archivo"
 msgid "No file selected"
 msgstr "Ningún archivo seleccionado"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "No hay archivos seleccionados para la eliminación."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "No se ha descargado ninguna letra"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "No se han descargado metadatos"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "No hay archivos de música seleccionados."
 
@@ -1105,11 +1139,11 @@ msgstr "No hay archivos de música seleccionados."
 msgid "No Music Files Found"
 msgstr "No se han encontrado archivos de música"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "No hay archivos de música en la biblioteca."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "No se ha proporcionado ningún MusicBrainz RecordingId para la entrada "
@@ -1120,7 +1154,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "No hay archivos de música seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr "No hay una clave api para el usuario configurada."
 
@@ -1145,11 +1179,11 @@ msgstr "Apagar"
 msgid "Offset (in milliseconds)"
 msgstr "Desfase (en milisegundos)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "Vale"
 
@@ -1165,8 +1199,8 @@ msgstr "Vale"
 msgid "On"
 msgstr "Encender"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1174,8 +1208,8 @@ msgstr ""
 "Sólo se puede enviar un archivo a AcoustID cada vez. Seleccione sólo un "
 "archivo e inténtelo de nuevo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Abrir"
 
@@ -1185,7 +1219,7 @@ msgid "Open a library with music to get started"
 msgstr "Abra una biblioteca con música para empezar"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1195,11 +1229,11 @@ msgstr "Abra una biblioteca con música para empezar"
 msgid "Open Folder"
 msgstr "Abrir carpeta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Abrir un archivo de música"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1233,10 +1267,10 @@ msgstr "Ruta"
 msgid "Path (Empty)"
 msgstr "Ruta (Vacía)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1246,23 +1280,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Archivo de la lista de reproducción creado correctamente."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr "Modo de la lista de reproducción"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr "La ruta de la lista de reproducción no puede estar vacía."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Seleccione una cadena de formato."
 
@@ -1275,39 +1309,39 @@ msgstr "Conservar fecha de modificación"
 msgid "PREVIEW"
 msgstr "VISTA PREVIA"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Nombre de la propiedad"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "editor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Editor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Editor"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "editor"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr "Recargar"
 
@@ -1319,20 +1353,20 @@ msgstr "Recargar la biblioteca"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Eliminar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Eliminar propiedad personalizada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "¿Eliminar los archivos?"
 
@@ -1346,7 +1380,7 @@ msgstr "Eliminar de la lista de reproducción"
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr "Quitando las carátulas del álbum..."
 
@@ -1372,8 +1406,8 @@ msgstr "Guardar etiqueta"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Guardar la etiqueta (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Guardando etiquetas…"
 
@@ -1392,27 +1426,27 @@ msgstr "Seleccione algunos archivos"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr "Mostrar el panel de Extras"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1426,43 +1460,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordenar archivos por"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Enviar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Enviar a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metadatos enviados a AcoustId con éxito"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Enviando datos a AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Cambiar a la contraportada"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Cambiar a la portada"
 
@@ -1475,9 +1509,9 @@ msgstr "Sincronizado"
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Etiqueta a nombre de archivo"
@@ -1486,9 +1520,8 @@ msgstr "Etiqueta a nombre de archivo"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Etiqueta un nombre de un archivo (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Etiqueta tu música"
 
@@ -1497,9 +1530,8 @@ msgstr "Etiqueta tu música"
 msgid "Tag Your Music"
 msgstr "Etiquetar Tu Música"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1508,8 +1540,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1522,7 +1554,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Este archivo no tiene una huella digital válida"
 
@@ -1545,10 +1577,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "título"
 
@@ -1560,15 +1592,15 @@ msgstr "título"
 msgid "Title"
 msgstr "Título"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Demasiados archivos seleccionados"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "pista"
 
@@ -1580,14 +1612,14 @@ msgstr "pista"
 msgid "Track"
 msgstr "Pista"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "pistatotal"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
@@ -1606,17 +1638,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Escribe ! para la búsqueda avanzada"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "No se puede añadir un archivo a la lista de reproducción. Es posible que el "
 "archivo ya exista en la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "No se puede crear la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
@@ -1630,29 +1662,29 @@ msgstr "No se puede exportar al LRC."
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "No se ha podido cargar el archivo de imagen"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "No se pueden eliminar algunos archivos de la lista de reproducción."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "No se ha podido guardar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "No se ha podido guardar {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "No se puede enviar a AcoustId. Compruebe la clave API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1661,7 +1693,7 @@ msgstr "Desconocido"
 msgid "Unsynchronized"
 msgstr "Desincronizado"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr "Actualización"
 
@@ -1675,8 +1707,8 @@ msgstr "Usa las letras del LRC"
 msgid "Use Relative Paths"
 msgstr "Usar rutas relativas"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr "¿Utilizar rutas relativas?"
 
@@ -1710,8 +1742,8 @@ msgstr ""
 "¿Deseas reiniciar {0} para aplicar el nuevo tema?\n"
 "Cualquier trabajo no guardado se perderá."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1721,10 +1753,10 @@ msgstr ""
 "ruta relativa?\n"
 "En caso contrario, se utilizará la ruta completa."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "año"
 
@@ -1736,10 +1768,10 @@ msgstr "año"
 msgid "Year"
 msgstr "Año"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Sí"
@@ -1872,15 +1904,24 @@ msgstr "Seleccionar todos los archivos"
 msgid "Track Total"
 msgstr "Pista total"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Pista total"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Conmutar panel de etiquetas"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Acciones de etiqueta"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
 
@@ -1888,51 +1929,45 @@ msgstr "Aplicar cambios a la etiqueta (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Etiqueta; Música; Editor; Biblioteca; Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Compatible con muchos tipos de archivos de música (mp3, ogg, flac, wma, "
-"wav, etc.)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Compatible con muchos tipos de archivos de música (mp3, ogg, flac, wma, "
+#~ "wav, etc.)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Edite etiquetas y portadas de álbumes de varios archivos, incluso en "
-"subcarpetas, todo a la vez"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Edite etiquetas y portadas de álbumes de varios archivos, incluso en "
+#~ "subcarpetas, todo a la vez"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Editar las letras sincronizadas y no sincronizadas para un archivo (con "
-"soporte de importación y exportación LRC)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Editar las letras sincronizadas y no sincronizadas para un archivo (con "
+#~ "soporte de importación y exportación LRC)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-"— Convierte fácilmente nombres de archivo en etiquetas y etiquetas en "
-"nombres de archivo"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr ""
+#~ "— Convierte fácilmente nombres de archivo en etiquetas y etiquetas en "
+#~ "nombres de archivo"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Buscar información de archivos en MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Buscar información de archivos en MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr ""
-"— Buscar información sobre las letras de las canciones con Music163 y Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr ""
+#~ "— Buscar información sobre las letras de las canciones con Music163 y "
+#~ "Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Abrir, gestionar y crear listas de reproducción en muchos formatos (m3u, "
-"pls, xspf, etc.)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Abrir, gestionar y crear listas de reproducción en muchos formatos "
+#~ "(m3u, pls, xspf, etc.)"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Abre una biblioteca con música para empezar."

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -61,26 +61,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -128,7 +128,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "AcoustId:n käyttäjän API-avain"
 
@@ -166,9 +166,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "albumi"
 
@@ -191,9 +191,9 @@ msgid "Album Artist"
 msgstr "Albumin esittäjä"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgstr "Valitse kaikki tiedostot"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -263,9 +263,9 @@ msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "esittäjä"
 
@@ -301,21 +301,21 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -378,9 +378,9 @@ msgid "Close Library"
 msgstr "Sulje kirjasto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "kommentti"
 
@@ -390,9 +390,9 @@ msgid "Comment"
 msgstr "Kommentti"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -419,26 +419,26 @@ msgstr "Avustajat GitHubissa ❤️"
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Muunnettiin {0} tiedostonimi tunnisteeksi"
 msgstr[1] "Muunnettiin {0} tiedostonimeä tunnisteiksi"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Muunnettiin {0} tunniste tiedostonimeksi"
 msgstr[1] "Muunnettiin {0} tunnistetta tiedostonimiksi"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Muunna tiedostonimi tunnisteeksi"
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Muunna tunniste tiedostonimeksi"
@@ -474,7 +474,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr "Poista tagit"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Tallennetaan tageja..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "kuvaus"
 
@@ -583,21 +583,21 @@ msgstr "Hylkää toteuttamattomat muutokset"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Hylkää toteuttamattomat muutokset"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Hylätään tagit..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "kappale"
@@ -628,21 +628,21 @@ msgstr "Lataa MusicBrainz-metatiedot"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Lataa MusicBrainz-metatiedot"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} tiedostolle ladattiin sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Ladataan sanoituksia..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
@@ -658,19 +658,19 @@ msgid "Edit"
 msgstr "Muokkaa"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -762,12 +762,12 @@ msgstr "kappale"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -806,11 +806,11 @@ msgstr "Vie albumin etukuvitus"
 msgid "Export to LRC"
 msgstr "Vie"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -827,11 +827,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgid "File Properties"
 msgstr "Tiedoston ominaisuudet"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "tiedostonimi"
 
@@ -918,9 +918,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -933,7 +933,7 @@ msgid "Genre"
 msgstr "Tyylilaji"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Hanki uusi API-avain"
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1031,19 +1031,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kielikoodi"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1052,7 +1052,7 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -1120,7 +1120,7 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1152,15 +1152,15 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "No files selected for removal."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Sanoituksia ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Metatietoja ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1170,12 +1170,12 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "No Music Files Found"
 msgstr "Musiikkitiedostoja ei löytynyt"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "No music files in library."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1273,17 +1273,17 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Korvaa sanoitukset verkkopalvelusta"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1346,9 +1346,9 @@ msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -1364,9 +1364,9 @@ msgid "Publishing Date"
 msgstr "Julkaisija"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "julkaisija"
@@ -1413,7 +1413,7 @@ msgstr "Poista soittolistalta"
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Poista albumin takakannen kuvitus"
@@ -1442,8 +1442,8 @@ msgstr "Tallenna tagi"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
@@ -1507,11 +1507,11 @@ msgstr "Lähetä"
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Lähetetään tietoja AcoustId:hen..."
 
@@ -1589,7 +1589,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Teema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Tällä tiedostolla ei ole kelvollista sormenjälkeä"
 
@@ -1611,9 +1611,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Aikaleima (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "nimi"
 
@@ -1631,9 +1631,9 @@ msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "kappale"
 
@@ -1646,9 +1646,9 @@ msgid "Track"
 msgstr "Kappale"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -1673,16 +1673,16 @@ msgstr "Tyyppi"
 msgid "Type ! for advanced search"
 msgstr "Etsi tiedostonimeä (kirjoita ! avataksesi edistyneen haun)..."
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Kuvatiedoston lataaminen ei onnistu"
@@ -1698,30 +1698,30 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr "Käyttöliittymä"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Verkkopalvelut"
@@ -1789,9 +1789,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "vuosi"
 
@@ -1847,6 +1847,14 @@ msgstr "Muista viimeksi avattu kansio"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Sisällytä alikansiot"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0}/{1} valittu"
@@ -37,63 +37,67 @@ msgstr "{0}/{1} valittu"
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<säilytä>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -121,18 +125,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId:n käyttäjän API-avain"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 #, fuzzy
 msgid "Add New Property"
 msgstr "Uusi mukautettu ominaisuus"
@@ -144,7 +148,7 @@ msgid "Add to Playlist"
 msgstr "Lisää soittolistaan"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Lisäominaisuudet"
 
@@ -153,10 +157,10 @@ msgstr "Lisäominaisuudet"
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "albumi"
 
@@ -178,22 +182,22 @@ msgstr "Albumin kuvitus"
 msgid "Album Artist"
 msgstr "Albumin esittäjä"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 #, fuzzy
 msgid "All files"
 msgstr "Valitse kaikki tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Valitse kaikki tiedostot"
@@ -202,58 +206,58 @@ msgstr "Valitse kaikki tiedostot"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "esittäjä"
 
@@ -273,70 +277,70 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Takaisin"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Lasketaan..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Peru"
@@ -359,27 +363,27 @@ msgstr "Tyhjennä kaikki sanoitukset"
 msgid "Close Library"
 msgstr "Sulje kirjasto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "kommentti"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "säveltäjä"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Säveltäjä"
 
@@ -388,39 +392,39 @@ msgstr "Säveltäjä"
 msgid "Configure"
 msgstr "Määritä"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Muunnettiin {0} tiedostonimi tunnisteeksi"
 msgstr[1] "Muunnettiin {0} tiedostonimeä tunnisteiksi"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Muunnettiin {0} tunniste tiedostonimeksi"
 msgstr[1] "Muunnettiin {0} tunnistetta tiedostonimiksi"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Muunna tiedostonimi tunnisteeksi"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Muunna tunniste tiedostonimeksi"
@@ -430,8 +434,8 @@ msgstr "Muunna tunniste tiedostonimeksi"
 msgid "Copied debug info to clipboard."
 msgstr "Kopioi sormenjälki leikepöydälle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopioi sormenjälki leikepöydälle"
 
@@ -455,8 +459,8 @@ msgstr "Luo soittolista"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr ""
 
@@ -468,21 +472,21 @@ msgid "Custom"
 msgstr "Mukautettu"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -495,22 +499,22 @@ msgstr "Poista tagit"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Tallennetaan tageja..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "kuvaus"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -530,23 +534,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Hylkää"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Hylkää"
 
@@ -560,9 +569,24 @@ msgstr "Hylkää toteuttamattomat muutokset"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Hylkää toteuttamattomat muutokset"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Hylätään tagit..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "kappale"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -590,25 +614,25 @@ msgstr "Lataa MusicBrainz-metatiedot"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Lataa MusicBrainz-metatiedot"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} tiedostolle ladattiin sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Ladataan sanoituksia..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -672,6 +696,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "kuvaus"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "julkaisija"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "kappale"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -692,7 +726,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "julkaisija"
@@ -714,12 +748,12 @@ msgstr "kappale"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -734,19 +768,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Vie"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Vie albumin takakuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
@@ -758,11 +792,11 @@ msgstr "Vie albumin etukuvitus"
 msgid "Export to LRC"
 msgstr "Vie"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -771,19 +805,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Viety onnistuneesti: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -800,9 +834,9 @@ msgstr "Tiedostonimi"
 msgid "File Name"
 msgstr "Tiedostonimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Tiedostonimi tunnisteeksi"
@@ -818,28 +852,28 @@ msgstr "Tiedostonimi tunnisteeksi"
 msgid "File Path"
 msgstr "Tiedostopolku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Tiedoston ominaisuudet"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "tiedostonimi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Sormenjälki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -848,29 +882,29 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Etu"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -891,19 +925,19 @@ msgstr "Hanki uusi API-avain"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -911,7 +945,7 @@ msgid "Help"
 msgstr "Ohje"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -927,31 +961,31 @@ msgstr "Tuo LRC:stä"
 msgid "Include Only Selected Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Syötä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr ""
 
@@ -969,19 +1003,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kielikoodi"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -990,7 +1024,7 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -1018,7 +1052,7 @@ msgstr "Hallitse sanoituksia"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Hallitse sanoituksia"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
@@ -1037,13 +1071,13 @@ msgstr "Musiikkitiedosto"
 msgid "Music Library"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
@@ -1052,24 +1086,24 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1078,21 +1112,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Sanoituksia ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Metatietoja ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1102,12 +1136,12 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "No Music Files Found"
 msgstr "Musiikkitiedostoja ei löytynyt"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "No music files in library."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1116,7 +1150,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1141,11 +1175,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Siirtymä (millisekunneissa)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1162,15 +1196,15 @@ msgstr "OK"
 msgid "On"
 msgstr "Avaa"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Avaa"
 
@@ -1180,7 +1214,7 @@ msgid "Open a library with music to get started"
 msgstr "Aloita avaamalla musiikkia sisältävä kirjasto"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1190,12 +1224,12 @@ msgstr "Aloita avaamalla musiikkia sisältävä kirjasto"
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 #, fuzzy
 msgid "Open Music File"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1230,10 +1264,10 @@ msgstr "Tiedostopolku"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1243,23 +1277,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr ""
 
@@ -1272,39 +1306,39 @@ msgstr "Säilytä muokkauksen aikaleima"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Julkaisija"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "Lataa kansio uudelleen"
@@ -1317,20 +1351,20 @@ msgstr "Lataa kirjasto uudelleen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Poista"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Poista sanoitus"
@@ -1345,7 +1379,7 @@ msgstr "Poista soittolistalta"
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Poista albumin takakannen kuvitus"
@@ -1374,8 +1408,8 @@ msgstr "Tallenna tagi"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
@@ -1394,27 +1428,27 @@ msgstr "Valitse joitain tiedostoja"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1426,43 +1460,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Järjestä tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Lähetetään tietoja AcoustId:hen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Vaihda takakanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Vaihda etukanteen"
 
@@ -1475,9 +1509,9 @@ msgstr "Synkronoitu"
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr ""
@@ -1487,9 +1521,8 @@ msgstr ""
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Muunna tunniste tiedostonimeksi"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Lisää tagit musiikkiin"
 
@@ -1498,9 +1531,8 @@ msgstr "Lisää tagit musiikkiin"
 msgid "Tag Your Music"
 msgstr "Lisää tagit musiikkiin"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
@@ -1509,8 +1541,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1521,7 +1553,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Teema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Tällä tiedostolla ei ole kelvollista sormenjälkeä"
 
@@ -1542,10 +1574,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "nimi"
 
@@ -1557,15 +1589,15 @@ msgstr "nimi"
 msgid "Title"
 msgstr "Nimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "kappale"
 
@@ -1577,15 +1609,15 @@ msgstr "kappale"
 msgid "Track"
 msgstr "Kappale"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
@@ -1605,16 +1637,16 @@ msgstr "Tyyppi"
 msgid "Type ! for advanced search"
 msgstr "Etsi tiedostonimeä (kirjoita ! avataksesi edistyneen haun)..."
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Kuvatiedoston lataaminen ei onnistu"
@@ -1630,30 +1662,30 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1662,7 +1694,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr "Synkronoimaton"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1676,8 +1708,8 @@ msgstr "Käytä LRC:n sanoituksia"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1707,18 +1739,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "vuosi"
 
@@ -1730,10 +1762,10 @@ msgstr "vuosi"
 msgid "Year"
 msgstr "Vuosi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1867,15 +1899,24 @@ msgstr "Valitse kaikki tiedostot"
 msgid "Track Total"
 msgstr "Kappaleita yhteensä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Kappaleita yhteensä"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
@@ -1884,44 +1925,28 @@ msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr ""
 "Tag;Music;Editor;Library;Nickvision;tägi;tunniste;muokkain;kirjasto;musiikki;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr "— Tuki useille musiikkitiedostotyypeille (mp3, ogg, flac, wma ja wav)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Tuki useille musiikkitiedostotyypeille (mp3, ogg, flac, wma ja wav)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Muokkaa useiden eri alikansioissa olevien tiedostojen tunnisteita ja "
-"albumikuvituksia kerralla"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Muokkaa useiden eri alikansioissa olevien tiedostojen tunnisteita ja "
+#~ "albumikuvituksia kerralla"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "— Muunna vaivatta tiedostonimet tunnisteiksi ja päinvastoin"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "— Muunna vaivatta tiedostonimet tunnisteiksi ja päinvastoin"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,81 +19,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0}/{1} valittu"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<säilytä>"
 
@@ -101,13 +109,13 @@ msgstr "<säilytä>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -125,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId:n käyttäjän API-avain"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #, fuzzy
 msgid "Add New Property"
 msgstr "Uusi mukautettu ominaisuus"
@@ -147,28 +155,28 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "Add to Playlist"
 msgstr "Lisää soittolistaan"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Lisäominaisuudet"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "albumi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Albumi"
 
@@ -177,27 +185,27 @@ msgstr "Albumi"
 msgid "Album Art"
 msgstr "Albumin kuvitus"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Albumin esittäjä"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 #, fuzzy
 msgid "All files"
 msgstr "Valitse kaikki tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Valitse kaikki tiedostot"
@@ -206,66 +214,66 @@ msgstr "Valitse kaikki tiedostot"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "esittäjä"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Esittäjä"
 
@@ -277,70 +285,72 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Takaisin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Lasketaan..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Peru"
@@ -349,7 +359,7 @@ msgstr "Peru"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -358,32 +368,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr "Tyhjennä kaikki sanoitukset"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Sulje kirjasto"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "kommentti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Kommentti"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "säveltäjä"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Säveltäjä"
 
@@ -392,39 +406,39 @@ msgstr "Säveltäjä"
 msgid "Configure"
 msgstr "Määritä"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Muunnettiin {0} tiedostonimi tunnisteeksi"
 msgstr[1] "Muunnettiin {0} tiedostonimeä tunnisteiksi"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Muunnettiin {0} tunniste tiedostonimeksi"
 msgstr[1] "Muunnettiin {0} tunnistetta tiedostonimiksi"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Muunna tiedostonimi tunnisteeksi"
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Muunna tunniste tiedostonimeksi"
@@ -434,8 +448,8 @@ msgstr "Muunna tunniste tiedostonimeksi"
 msgid "Copied debug info to clipboard."
 msgstr "Kopioi sormenjälki leikepöydälle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopioi sormenjälki leikepöydälle"
 
@@ -459,8 +473,8 @@ msgstr "Luo soittolista"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr ""
 
@@ -471,22 +485,22 @@ msgstr ""
 msgid "Custom"
 msgstr "Mukautettu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -495,26 +509,26 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Poista tagit"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Tallennetaan tageja..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "kuvaus"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -534,28 +548,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Hylkää"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Hylkää"
 
@@ -564,75 +578,75 @@ msgstr "Hylkää"
 msgid "Discard Unapplied Changed"
 msgstr "Hylkää toteuttamattomat muutokset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Hylkää toteuttamattomat muutokset"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Hylätään tagit..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "kappale"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "Kesto"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Lataa sanoitukset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Lataa MusicBrainz-metatiedot"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Lataa MusicBrainz-metatiedot"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} tiedostolle ladattiin sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Ladataan sanoituksia..."
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -662,27 +676,27 @@ msgid ""
 "If disabled, only blank tag properties will be filled."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -691,26 +705,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "kuvaus"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "kappale"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -726,34 +740,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "kappale"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -767,20 +781,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Vie"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Vie albumin takakuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
@@ -792,11 +806,11 @@ msgstr "Vie albumin etukuvitus"
 msgid "Export to LRC"
 msgstr "Vie"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -805,19 +819,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Viety onnistuneesti: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -827,21 +841,21 @@ msgid "File"
 msgstr "Tiedostonimi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Tiedostonimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Tiedostonimi tunnisteeksi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Tiedostonimi tunnisteeksi"
@@ -852,28 +866,28 @@ msgstr "Tiedostonimi tunnisteeksi"
 msgid "File Path"
 msgstr "Tiedostopolku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Tiedoston ominaisuudet"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "tiedostonimi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Sormenjälki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -882,37 +896,39 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Etu"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "tyylilaji"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Tyylilaji"
 
@@ -925,27 +941,33 @@ msgstr "Hanki uusi API-avain"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Vaalea"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ohje"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -961,31 +983,37 @@ msgstr "Tuo LRC:stä"
 msgid "Include Only Selected Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Syötä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1003,19 +1031,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kielikoodi"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1024,41 +1052,47 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Sanoitukset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Keskeisimmät ominaisuudet"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Hallitse sanoituksia"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 #, fuzzy
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Hallitse sanoituksia"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Tyyppi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1071,13 +1105,13 @@ msgstr "Musiikkitiedosto"
 msgid "Music Library"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
@@ -1086,24 +1120,24 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1112,45 +1146,45 @@ msgstr ""
 msgid "No file selected"
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Sanoituksia ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Metatietoja ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Musiikkitiedostoja ei löytynyt"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 #, fuzzy
 msgid "No music files in library."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1175,11 +1209,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Siirtymä (millisekunneissa)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1196,45 +1230,45 @@ msgstr "OK"
 msgid "On"
 msgstr "Avaa"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Avaa"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Aloita avaamalla musiikkia sisältävä kirjasto"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 #, fuzzy
 msgid "Open Music File"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1264,10 +1298,10 @@ msgstr "Tiedostopolku"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1277,23 +1311,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr ""
 
@@ -1306,39 +1340,39 @@ msgstr "Säilytä muokkauksen aikaleima"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Julkaisija"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "Lataa kansio uudelleen"
@@ -1350,21 +1384,21 @@ msgid "Reload Library"
 msgstr "Lataa kirjasto uudelleen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Poista"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Poista sanoitus"
@@ -1379,12 +1413,12 @@ msgstr "Poista soittolistalta"
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Poista albumin takakannen kuvitus"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1398,18 +1432,18 @@ msgid "Save Playlist"
 msgstr "Luo soittolista"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Tallenna tagi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
@@ -1418,8 +1452,8 @@ msgstr "Tallennetaan tageja..."
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Valitse joitain tiedostoja"
 
@@ -1428,27 +1462,27 @@ msgstr "Valitse joitain tiedostoja"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1460,43 +1494,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Järjestä tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Lähetetään tietoja AcoustId:hen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Vaihda takakanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Vaihda etukanteen"
 
@@ -1509,40 +1543,42 @@ msgstr "Synkronoitu"
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Muunna tunniste tiedostonimeksi"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Lisää tagit musiikkiin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Lisää tagit musiikkiin"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1553,7 +1589,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Teema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Tällä tiedostolla ei ole kelvollista sormenjälkeä"
 
@@ -1574,55 +1610,55 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Aikaleima (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "nimi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Nimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "kappale"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Kappale"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Kokeile eri kirjastoa"
 
@@ -1631,22 +1667,22 @@ msgstr "Kokeile eri kirjastoa"
 msgid "Type"
 msgstr "Tyyppi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr "Etsi tiedostonimeä (kirjoita ! avataksesi edistyneen haun)..."
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Kuvatiedoston lataaminen ei onnistu"
@@ -1662,30 +1698,30 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1694,7 +1730,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr "Synkronoimaton"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1708,8 +1744,8 @@ msgstr "Käytä LRC:n sanoituksia"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1718,10 +1754,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "Käyttöliittymä"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Verkkopalvelut"
 
@@ -1732,6 +1768,11 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1739,33 +1780,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "vuosi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Vuosi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1840,7 +1881,7 @@ msgid "Remove Front Album Art"
 msgstr "Poista albumin etukannen kuvitus"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Vaihda albumin kuvitus"
 
@@ -1871,52 +1912,52 @@ msgstr "Lopeta"
 msgid "About Tagger"
 msgstr "Tietoja - Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Kirjastovalikko"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Kirjasto"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Päävalikko"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Avaa kansio (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Avaa soittolista (Ctrl+Shift+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Valitse kaikki tiedostot"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Kappaleita yhteensä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Kappaleita yhteensä"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
@@ -1925,28 +1966,44 @@ msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr ""
 "Tag;Music;Editor;Library;Nickvision;tägi;tunniste;muokkain;kirjasto;musiikki;"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "— Tuki useille musiikkitiedostotyypeille (mp3, ogg, flac, wma ja wav)"
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr "— Tuki useille musiikkitiedostotyypeille (mp3, ogg, flac, wma ja wav)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "— Muokkaa useiden eri alikansioissa olevien tiedostojen tunnisteita ja "
-#~ "albumikuvituksia kerralla"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"— Muokkaa useiden eri alikansioissa olevien tiedostojen tunnisteita ja "
+"albumikuvituksia kerralla"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr "— Muunna vaivatta tiedostonimet tunnisteiksi ja päinvastoin"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr "— Muunna vaivatta tiedostonimet tunnisteiksi ja päinvastoin"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "— Etsi tiedostojen tietoja MusicBrainzista"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-09-14 13:06+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -133,7 +133,7 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId:n käyttäjän API-avain"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -166,9 +166,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "albumi"
 
@@ -191,9 +191,9 @@ msgid "Album Artist"
 msgstr "Albumin esittäjä"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgstr ""
 msgid "All files"
 msgstr "Valitse kaikki tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Valitse kaikki tiedostot"
@@ -214,18 +214,18 @@ msgstr "Valitse kaikki tiedostot"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -242,14 +242,14 @@ msgstr ""
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -263,9 +263,9 @@ msgid "Apply Changes?"
 msgstr "Toteutetaanko muutokset?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "esittäjä"
 
@@ -286,8 +286,8 @@ msgid "B"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -301,40 +301,40 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Lasketaan..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -378,9 +378,9 @@ msgid "Close Library"
 msgstr "Sulje kirjasto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "kommentti"
 
@@ -390,9 +390,9 @@ msgid "Comment"
 msgstr "Kommentti"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -410,8 +410,8 @@ msgstr "Määritä"
 msgid "Contributors on GitHub ❤️"
 msgstr "Avustajat GitHubissa ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -419,26 +419,26 @@ msgstr "Avustajat GitHubissa ❤️"
 msgid "Convert"
 msgstr "Muunna"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Muunnettiin {0} tiedostonimi tunnisteeksi"
 msgstr[1] "Muunnettiin {0} tiedostonimeä tunnisteiksi"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Muunnettiin {0} tunniste tiedostonimeksi"
 msgstr[1] "Muunnettiin {0} tunnistetta tiedostonimiksi"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Muunna tiedostonimi tunnisteeksi"
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Muunna tunniste tiedostonimeksi"
@@ -474,7 +474,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr ""
 
@@ -513,15 +513,15 @@ msgstr "Poista tagit"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Tallennetaan tageja..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "kuvaus"
 
@@ -553,14 +553,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Hylkää"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -583,21 +583,21 @@ msgstr "Hylkää toteuttamattomat muutokset"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Hylkää toteuttamattomat muutokset"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Hylätään tagit..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "kappale"
@@ -628,21 +628,21 @@ msgstr "Lataa MusicBrainz-metatiedot"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Lataa MusicBrainz-metatiedot"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} tiedostolle ladattiin sanoitukset"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Ladattiin metatiedot {0} tiedostolle"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Ladataan sanoituksia..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Ladataan MusicBrainz-metatietoja..."
 
@@ -762,12 +762,12 @@ msgstr "kappale"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -789,12 +789,12 @@ msgstr ""
 msgid "Export"
 msgstr "Vie"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Vie albumin takakuvitus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
@@ -806,11 +806,11 @@ msgstr "Vie albumin etukuvitus"
 msgid "Export to LRC"
 msgstr "Vie"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -823,15 +823,15 @@ msgstr "Viety onnistuneesti: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -848,7 +848,7 @@ msgstr "Tiedostonimi"
 msgid "File Name"
 msgstr "Tiedostonimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -872,7 +872,7 @@ msgid "File Properties"
 msgstr "Tiedoston ominaisuudet"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "tiedostonimi"
 
@@ -881,12 +881,12 @@ msgstr "tiedostonimi"
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Sormenjälki kopioitiin leikepöydälle."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -896,16 +896,16 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -918,9 +918,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -941,7 +941,7 @@ msgstr "Hanki uusi API-avain"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
@@ -952,9 +952,9 @@ msgstr "GitHub-tietovarasto"
 msgid "Height"
 msgstr "Vaalea"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -983,7 +983,7 @@ msgstr "Tuo LRC:stä"
 msgid "Include Only Selected Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1003,17 +1003,17 @@ msgstr ""
 msgid "Insert"
 msgstr "Syötä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1031,19 +1031,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Kielikoodi"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Ladattiin {0} musiikkitiedosto."
 msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1052,7 +1052,7 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -1067,6 +1067,10 @@ msgstr "Sanoitukset"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Keskeisimmät ominaisuudet"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1105,12 +1109,12 @@ msgstr "Musiikkitiedosto"
 msgid "Music Library"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
@@ -1120,7 +1124,7 @@ msgstr "Uusi mukautettu ominaisuus"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1129,15 +1133,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1146,21 +1150,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Sanoituksia ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Metatietoja ei ladattu"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
@@ -1170,12 +1174,12 @@ msgstr "Ladataan musiikkitiedostoja kansiosta..."
 msgid "No Music Files Found"
 msgstr "Musiikkitiedostoja ei löytynyt"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 #, fuzzy
 msgid "No music files in library."
 msgstr "Ladataan musiikkitiedostoja kansiosta..."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1184,7 +1188,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Ei valittuja musiikkitiedostoja"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1209,7 +1213,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Siirtymä (millisekunneissa)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1230,14 +1234,14 @@ msgstr "OK"
 msgid "On"
 msgstr "Avaa"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Avaa"
@@ -1248,7 +1252,7 @@ msgid "Open a library with music to get started"
 msgstr "Aloita avaamalla musiikkia sisältävä kirjasto"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1258,12 +1262,12 @@ msgstr "Aloita avaamalla musiikkia sisältävä kirjasto"
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 #, fuzzy
 msgid "Open Music File"
 msgstr "Musiikkitiedosto"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1298,8 +1302,8 @@ msgstr "Tiedostopolku"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1311,21 +1315,21 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1340,15 +1344,15 @@ msgstr "Säilytä muokkauksen aikaleima"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Ominaisuuden nimi"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -1364,14 +1368,14 @@ msgid "Publishing Date"
 msgstr "Julkaisija"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "julkaisija"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1392,12 +1396,12 @@ msgstr "Lataa kirjasto uudelleen"
 msgid "Remove"
 msgstr "Poista"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Poista mukautettu ominaisuus"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
@@ -1413,7 +1417,7 @@ msgstr "Poista soittolistalta"
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Poista albumin takakannen kuvitus"
@@ -1442,8 +1446,8 @@ msgstr "Tallenna tagi"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Toteuta muutokset tunnisteeseen (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Tallennetaan tageja..."
 
@@ -1466,14 +1470,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1494,12 +1498,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Järjestä tiedostot"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1507,15 +1511,15 @@ msgstr "Lähetä"
 msgid "Submit to AcoustId"
 msgstr "Lähetä AcoustId:hen"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metatiedot lähetettiin AcoustId:hen onnistuneesti"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Lähetetään tietoja AcoustId:hen..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1526,7 +1530,7 @@ msgstr "Lähetetään tietoja AcoustId:hen..."
 msgid "Switch to Back Cover"
 msgstr "Vaihda takakanteen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1543,7 +1547,7 @@ msgstr "Synkronoitu"
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1577,7 +1581,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1589,7 +1593,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Teema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Tällä tiedostolla ei ole kelvollista sormenjälkeä"
 
@@ -1611,9 +1615,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Aikaleima (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "nimi"
 
@@ -1625,15 +1629,15 @@ msgstr "nimi"
 msgid "Title"
 msgstr "Nimi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Liian monta tiedostoa valittu"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "kappale"
 
@@ -1646,9 +1650,9 @@ msgid "Track"
 msgstr "Kappale"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -1673,16 +1677,16 @@ msgstr "Tyyppi"
 msgid "Type ! for advanced search"
 msgstr "Etsi tiedostonimeä (kirjoita ! avataksesi edistyneen haun)..."
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Kuvatiedoston lataaminen ei onnistu"
@@ -1698,30 +1702,30 @@ msgstr "Ei voi tallentaa {0}."
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Ei voi tallentaa {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Ei voi tallentaa {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1744,7 +1748,7 @@ msgstr "Käytä LRC:n sanoituksia"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1780,7 +1784,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1789,9 +1793,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "vuosi"
 
@@ -1803,8 +1807,8 @@ msgstr "vuosi"
 msgid "Year"
 msgstr "Vuosi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -61,26 +61,24 @@ msgstr "%titre%- %artiste%"
 msgid "%track%- %title%"
 msgstr "%piste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "associées à l’empreinte à la place."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "Clé utilisateur d’API AcoustId"
 
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Artiste de l'album"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "artiste de l’album"
 
@@ -219,7 +219,7 @@ msgstr "Tous les fichiers pris en charge"
 msgid "An application restart is required to change the theme."
 msgstr "Un redémarrage de l’application est nécessaire pour changer le thème."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artiste"
 
@@ -306,21 +306,21 @@ msgid "Beats Per Minute"
 msgstr "Battements par minute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Fermer la bibliothèque"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "commentaire"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Commentaire"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "compositeur"
 
@@ -424,26 +424,26 @@ msgstr "Contributeurs sur GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Conversion des fichiers en étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Convertir la balise en nom de fichier"
@@ -479,7 +479,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "personnalisé"
 
@@ -519,14 +519,14 @@ msgstr "Supprimer l'étiquette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Suppression des étiquettes..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "description"
 
@@ -588,21 +588,21 @@ msgstr "Abandonner les changements"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Abandonner les changements"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Abandon des balises…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "pistestotal"
@@ -633,21 +633,21 @@ msgstr "Télécharger les métadonnées depuis MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Paroles téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Téléchargement des paroles…"
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
@@ -663,14 +663,14 @@ msgid "Edit"
 msgstr "Modifier"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Activer pour remplacer la couverture actuelle de l’album par celle récupérée "
 "depuis MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -680,7 +680,7 @@ msgstr ""
 "seront remplies."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -777,12 +777,12 @@ msgstr "pistestotal"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -820,12 +820,12 @@ msgstr "Exporter la face de la pochette d’album"
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
@@ -844,11 +844,11 @@ msgstr "Vérifications échouées sur MusicBrainz"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
@@ -890,7 +890,7 @@ msgid "File Properties"
 msgstr "Propriétés du fichier"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "nom de fichier"
 
@@ -936,9 +936,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "genre"
 
@@ -951,7 +951,7 @@ msgid "Genre"
 msgstr "Genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Obtenir une nouvelle clé d'API"
 
@@ -1030,7 +1030,7 @@ msgstr "Insérer le dos de la pochette d’album"
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Ajout de la pochette d'album..."
 
@@ -1048,19 +1048,19 @@ msgstr "kio"
 msgid "Language Code"
 msgstr "Code de langage"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 
@@ -1068,7 +1068,7 @@ msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "paroles"
 
@@ -1134,7 +1134,7 @@ msgstr "Nouvelle propriété personnalisée"
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
@@ -1165,15 +1165,15 @@ msgstr "Aucun fichier de musique sélectionné."
 msgid "No files selected for removal."
 msgstr "Aucun fichier sélectionné pour la suppression."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Aucune parole n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Aucun fichier de musique sélectionné."
 
@@ -1182,11 +1182,11 @@ msgstr "Aucun fichier de musique sélectionné."
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "Aucun fichier de musique dans la bibliothèque."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1286,17 +1286,17 @@ msgid "Open Playlist"
 msgstr "Ouvrir la liste de lecture"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Écraser la couverture d’album avec MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Remplacer les paroles depuis le service web"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Écraser la balise avec MusicBrainz"
 
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Fichier de liste de lecture créé avec succès."
 
@@ -1335,7 +1335,7 @@ msgstr "Fichier de liste de lecture créé avec succès."
 msgid "Playlist Mode"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Le nom de la liste de lecture ne peut être laissé vide."
@@ -1362,9 +1362,9 @@ msgid "Property Name"
 msgstr "Nom de la propriété"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -1380,9 +1380,9 @@ msgid "Publishing Date"
 msgstr "Maison de disques"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "maison de disques"
@@ -1428,7 +1428,7 @@ msgstr "Supprimer de la liste de lecture"
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Ajout de la pochette d'album..."
@@ -1457,8 +1457,8 @@ msgstr "Enregistrer la balise"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
@@ -1524,11 +1524,11 @@ msgstr "Envoyer"
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thème"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Ce fichier n’a pas d’empreinte valide"
 
@@ -1633,9 +1633,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "titre"
 
@@ -1653,9 +1653,9 @@ msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "piste"
 
@@ -1668,9 +1668,9 @@ msgid "Track"
 msgstr "Morceau"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -1695,17 +1695,17 @@ msgid "Type ! for advanced search"
 msgstr ""
 "Rechercher un nom de fichier (tapez ! pour activer la recherche avancée)…"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Impossible d’ajouter le fichier à la liste de lecture. Le fichier existe "
 "peut-être déjà dedans."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Impossible de créer la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Impossible de charger l’image"
@@ -1720,29 +1720,29 @@ msgstr "Impossible d’exporter vers LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Impossible de supprimer certains fichiers de la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1777,7 +1777,7 @@ msgstr "Interface"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Services Web"
@@ -1812,9 +1812,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "année"
 
@@ -1869,6 +1869,14 @@ msgstr "Mémoriser la dernière bibliothèque ouverte"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Inclure les sous-dossiers"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%titre%- %artiste%"
 msgid "%track%- %title%"
 msgstr "%piste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%piste%- %titre%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "À propos de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "Clé utilisateur d’API AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Artiste de l'album"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "artiste de l’album"
 
@@ -210,8 +210,8 @@ msgstr "artiste de l’album"
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Tous les fichiers pris en charge"
 
@@ -219,18 +219,18 @@ msgstr "Tous les fichiers pris en charge"
 msgid "An application restart is required to change the theme."
 msgstr "Un redémarrage de l’application est nécessaire pour changer le thème."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -247,14 +247,14 @@ msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -268,9 +268,9 @@ msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artiste"
 
@@ -291,8 +291,8 @@ msgid "B"
 msgstr "o"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -306,40 +306,40 @@ msgid "Beats Per Minute"
 msgstr "Battements par minute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Calcul…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -383,9 +383,9 @@ msgid "Close Library"
 msgstr "Fermer la bibliothèque"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "commentaire"
 
@@ -395,9 +395,9 @@ msgid "Comment"
 msgstr "Commentaire"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "compositeur"
 
@@ -415,8 +415,8 @@ msgstr "Configurer"
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -424,26 +424,26 @@ msgstr "Contributeurs sur GitHub ❤️"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Conversion des fichiers en étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Convertir la balise en nom de fichier"
@@ -479,7 +479,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "personnalisé"
 
@@ -519,14 +519,14 @@ msgstr "Supprimer l'étiquette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Suppression des étiquettes..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "description"
 
@@ -558,14 +558,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Abandonner"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -588,21 +588,21 @@ msgstr "Abandonner les changements"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Abandonner les changements"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Abandon des balises…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "pistestotal"
@@ -633,21 +633,21 @@ msgstr "Télécharger les métadonnées depuis MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Paroles téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Téléchargement des paroles…"
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
@@ -777,12 +777,12 @@ msgstr "pistestotal"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -804,12 +804,12 @@ msgstr ""
 msgid "Export"
 msgstr "Exporter"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exporter le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
@@ -820,12 +820,12 @@ msgstr "Exporter la face de la pochette d’album"
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
@@ -840,15 +840,15 @@ msgstr "Exporté avec succès vers : {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
@@ -866,7 +866,7 @@ msgstr "Nom du fichier"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -890,7 +890,7 @@ msgid "File Properties"
 msgstr "Propriétés du fichier"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "nom de fichier"
 
@@ -899,12 +899,12 @@ msgstr "nom de fichier"
 msgid "Fingerprint"
 msgstr "Empreinte"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Empreinte copiée vers le presse-papiers."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -914,16 +914,16 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Chaîne de format"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -936,9 +936,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "genre"
 
@@ -959,7 +959,7 @@ msgstr "Obtenir une nouvelle clé d'API"
 msgid "GiB"
 msgstr "Gio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
@@ -970,9 +970,9 @@ msgstr "Dépôt GitHub"
 msgid "Height"
 msgstr "Clair"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -1000,7 +1000,7 @@ msgstr "Importer depuis LRC"
 msgid "Include Only Selected Files"
 msgstr "Inclure uniquement les fichiers sélectionnés"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1020,17 +1020,17 @@ msgstr "Informations"
 msgid "Insert"
 msgstr "Insérer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insérer le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Ajout de la pochette d'album..."
 
@@ -1048,19 +1048,19 @@ msgstr "kio"
 msgid "Language Code"
 msgstr "Code de langage"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 
@@ -1068,7 +1068,7 @@ msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "paroles"
 
@@ -1082,6 +1082,10 @@ msgstr "Paroles"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Propriétés principales"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1119,12 +1123,12 @@ msgstr "Musique"
 msgid "Music Library"
 msgstr "Bibliothèque musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
@@ -1134,7 +1138,7 @@ msgstr "Nouvelle propriété personnalisée"
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1143,15 +1147,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
@@ -1160,20 +1164,20 @@ msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 msgid "No file selected"
 msgstr "Aucun fichier de musique sélectionné."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Aucun fichier sélectionné pour la suppression."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Aucune parole n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Aucun fichier de musique sélectionné."
 
@@ -1182,11 +1186,11 @@ msgstr "Aucun fichier de musique sélectionné."
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "Aucun fichier de musique dans la bibliothèque."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
@@ -1196,7 +1200,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1221,7 +1225,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Décalage (en millisecondes)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1242,7 +1246,7 @@ msgstr "OK"
 msgid "On"
 msgstr "Ouvrir"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1251,7 +1255,7 @@ msgstr ""
 "Seul un fichier peut être envoyé à AcoustId à la fois. Sélectionnez un seul "
 "fichier et essayez à nouveau."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Ouvrir"
@@ -1262,7 +1266,7 @@ msgid "Open a library with music to get started"
 msgstr "Ouvrez une bibliothèque contenant des musiques pour commencer"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1272,11 +1276,11 @@ msgstr "Ouvrez une bibliothèque contenant des musiques pour commencer"
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Ouvrir le fichier de musique"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1312,8 +1316,8 @@ msgstr "Chemin d’accès du fichier"
 msgid "Path (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1325,23 +1329,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Fichier de liste de lecture créé avec succès."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Le nom de la liste de lecture ne peut être laissé vide."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1356,15 +1360,15 @@ msgstr "Conserver l’horodatage de modification"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -1380,14 +1384,14 @@ msgid "Publishing Date"
 msgstr "Maison de disques"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1408,12 +1412,12 @@ msgstr "Recharger la bibliothèque"
 msgid "Remove"
 msgstr "Supprimer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Supprimer la propriété personnalisée"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Supprimer les fichiers ?"
@@ -1428,7 +1432,7 @@ msgstr "Supprimer de la liste de lecture"
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Ajout de la pochette d'album..."
@@ -1457,8 +1461,8 @@ msgstr "Enregistrer la balise"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
@@ -1481,14 +1485,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1511,12 +1515,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Trier les fichiers par"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Envoyer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1524,15 +1528,15 @@ msgstr "Envoyer"
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1543,7 +1547,7 @@ msgstr "Envoi des données à AcoustId…"
 msgid "Switch to Back Cover"
 msgstr "Dos de la couverture"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1561,7 +1565,7 @@ msgstr "Synchronisées"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1595,7 +1599,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1609,7 +1613,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thème"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Ce fichier n’a pas d’empreinte valide"
 
@@ -1633,9 +1637,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "titre"
 
@@ -1647,15 +1651,15 @@ msgstr "titre"
 msgid "Title"
 msgstr "Titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "piste"
 
@@ -1668,9 +1672,9 @@ msgid "Track"
 msgstr "Morceau"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -1695,17 +1699,17 @@ msgid "Type ! for advanced search"
 msgstr ""
 "Rechercher un nom de fichier (tapez ! pour activer la recherche avancée)…"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Impossible d’ajouter le fichier à la liste de lecture. Le fichier existe "
 "peut-être déjà dedans."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Impossible de créer la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Impossible de charger l’image"
@@ -1720,29 +1724,29 @@ msgstr "Impossible d’exporter vers LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Impossible de supprimer certains fichiers de la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1765,7 +1769,7 @@ msgstr "Utiliser les paroles LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1803,7 +1807,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1812,9 +1816,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "année"
 
@@ -1826,8 +1830,8 @@ msgstr "année"
 msgid "Year"
 msgstr "Année"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,81 +19,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} sur {1} sélectionné(s)"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artiste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%titre%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%titre%- %artiste%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%piste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<conserver>"
 
@@ -101,13 +109,13 @@ msgstr "<conserver>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "À propos de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -133,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "Clé utilisateur d’API AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Ajouter une nouvelle propriété"
 
@@ -154,28 +162,28 @@ msgstr "Ajouter une nouvelle propriété"
 msgid "Add to Playlist"
 msgstr "Ajouter à la liste de lecture"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Propriétés additionnelles"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -184,26 +192,26 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Couverture de l’album"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Artiste de l'album"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "artiste de l’album"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Tous les fichiers pris en charge"
 
@@ -211,66 +219,66 @@ msgstr "Tous les fichiers pris en charge"
 msgid "An application restart is required to change the theme."
 msgstr "Un redémarrage de l’application est nécessaire pour changer le thème."
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artiste"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Artiste"
 
@@ -282,70 +290,72 @@ msgstr ""
 msgid "B"
 msgstr "o"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Dos"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Battements par minute"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Calcul…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annuler"
@@ -354,7 +364,7 @@ msgstr "Annuler"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -363,32 +373,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr "Effacer toutes les paroles"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Fermer la bibliothèque"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "commentaire"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "compositeur"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Compositeur"
 
@@ -397,39 +411,39 @@ msgstr "Compositeur"
 msgid "Configure"
 msgstr "Configurer"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Conversion des fichiers en étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Convertir la balise en nom de fichier"
@@ -439,8 +453,8 @@ msgstr "Convertir la balise en nom de fichier"
 msgid "Copied debug info to clipboard."
 msgstr "Copier l’empreinte vers le presse-papiers"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copier l’empreinte vers le presse-papiers"
 
@@ -464,8 +478,8 @@ msgstr "Créer une liste de lecture"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "personnalisé"
 
@@ -476,24 +490,24 @@ msgstr "personnalisé"
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Propriétés personnalisées"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Les propriétés personnalisées ne peuvent être éditées que pour des fichiers "
 "individuels."
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -501,25 +515,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Supprimer l'étiquette"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Suppression des étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "description"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Description"
 
@@ -539,28 +553,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Abandonner"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Abandonner"
 
@@ -569,75 +583,75 @@ msgstr "Abandonner"
 msgid "Discard Unapplied Changed"
 msgstr "Abandonner les changements"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Abandonner les changements"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Abandon des balises…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "pistestotal"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "Durée"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Télécharger les paroles"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Paroles téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Téléchargement des paroles…"
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -675,29 +689,29 @@ msgstr ""
 "données récupérées depuis MusicBrainz. Si cette option est désactivée, "
 "seules les propriétés des balises laissées vides seront remplies."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 #, fuzzy
 msgid "Enter album artist here"
 msgstr "artiste de l’album"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 #, fuzzy
 msgid "Enter beats per minute here"
 msgstr "battementsparminute"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -706,26 +720,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "description"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "pistestotal"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -741,34 +755,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "pistestotal"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -782,20 +796,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Exporter"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exporter le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
@@ -806,12 +820,12 @@ msgstr "Exporter la face de la pochette d’album"
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
@@ -821,20 +835,20 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Exporté avec succès vers : {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 #, fuzzy
 msgid "Failed MusicBrainz Lookup"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
@@ -845,21 +859,21 @@ msgid "File"
 msgstr "Nom du fichier"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Nom de fichier vers balise"
@@ -870,28 +884,28 @@ msgstr "Nom de fichier vers balise"
 msgid "File Path"
 msgstr "Chemin d’accès du fichier"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Propriétés du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "nom de fichier"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Empreinte"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Empreinte copiée vers le presse-papiers."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -900,37 +914,39 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Chaîne de format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Face"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Genre"
 
@@ -943,27 +959,33 @@ msgstr "Obtenir une nouvelle clé d'API"
 msgid "GiB"
 msgstr "Gio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Clair"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aide"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -978,31 +1000,37 @@ msgstr "Importer depuis LRC"
 msgid "Include Only Selected Files"
 msgstr "Inclure uniquement les fichiers sélectionnés"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Informations"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Insérer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insérer le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Ajout de la pochette d'album..."
 
@@ -1020,19 +1048,19 @@ msgstr "kio"
 msgid "Language Code"
 msgstr "Code de langage"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 
@@ -1040,40 +1068,46 @@ msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "paroles"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Paroles"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Propriétés principales"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Gérer les paroles"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 #, fuzzy
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gérer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "Mio"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Type"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1085,13 +1119,13 @@ msgstr "Musique"
 msgid "Music Library"
 msgstr "Bibliothèque musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
 
@@ -1100,24 +1134,24 @@ msgstr "Nouvelle propriété personnalisée"
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
@@ -1126,43 +1160,43 @@ msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 msgid "No file selected"
 msgstr "Aucun fichier de musique sélectionné."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Aucun fichier sélectionné pour la suppression."
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Aucune parole n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Aucun fichier de musique sélectionné."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "Aucun fichier de musique dans la bibliothèque."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1187,11 +1221,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Décalage (en millisecondes)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1208,8 +1242,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Ouvrir"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1217,37 +1251,37 @@ msgstr ""
 "Seul un fichier peut être envoyé à AcoustId à la fois. Sélectionnez un seul "
 "fichier et essayez à nouveau."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Ouvrez une bibliothèque contenant des musiques pour commencer"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Ouvrir le fichier de musique"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Ouvrir la liste de lecture"
 
@@ -1278,10 +1312,10 @@ msgstr "Chemin d’accès du fichier"
 msgid "Path (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1291,25 +1325,25 @@ msgstr ""
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Fichier de liste de lecture créé avec succès."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Le nom de la liste de lecture ne peut être laissé vide."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Sélectionnez un format."
 
@@ -1322,39 +1356,39 @@ msgstr "Conserver l’horodatage de modification"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Maison de disques"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "Recharger le dossier"
@@ -1366,21 +1400,21 @@ msgid "Reload Library"
 msgstr "Recharger la bibliothèque"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Supprimer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Supprimer la propriété personnalisée"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Supprimer les fichiers ?"
 
@@ -1394,12 +1428,12 @@ msgstr "Supprimer de la liste de lecture"
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Ajout de la pochette d'album..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1413,18 +1447,18 @@ msgid "Save Playlist"
 msgstr "Créer une liste de lecture"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Enregistrer la balise"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
@@ -1433,8 +1467,8 @@ msgstr "Enregistrement des balises…"
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Sélectionnez des fichiers"
 
@@ -1443,27 +1477,27 @@ msgstr "Sélectionnez des fichiers"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1477,43 +1511,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Trier les fichiers par"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Envoyer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Dos de la couverture"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Face de la couverture"
 
@@ -1527,40 +1561,42 @@ msgstr "Synchronisées"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Balise vers nom de fichier"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Balise vers nom de fichier"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associez des balises à vos musiques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Étiquetez vos musiques"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1573,7 +1609,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thème"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Ce fichier n’a pas d’empreinte valide"
 
@@ -1596,54 +1632,54 @@ msgstr "Tio"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "titre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "piste"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Morceau"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "pistestotal"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Essayez une autre bibliothèque"
 
@@ -1652,24 +1688,24 @@ msgstr "Essayez une autre bibliothèque"
 msgid "Type"
 msgstr "Type"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr ""
 "Rechercher un nom de fichier (tapez ! pour activer la recherche avancée)…"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Impossible d’ajouter le fichier à la liste de lecture. Le fichier existe "
 "peut-être déjà dedans."
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Impossible de créer la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Impossible de charger l’image"
@@ -1684,29 +1720,29 @@ msgstr "Impossible d’exporter vers LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Impossible de supprimer certains fichiers de la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1715,7 +1751,7 @@ msgstr "Inconnu"
 msgid "Unsynchronized"
 msgstr "Non synchronisées"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1729,8 +1765,8 @@ msgstr "Utiliser les paroles LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1739,10 +1775,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "Interface"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Services Web"
 
@@ -1755,6 +1791,11 @@ msgstr ""
 "Que souhaitez-vous que Tagger fasse avec les paroles trouvées dans le "
 "fichier LRC, en conflit avec les paroles existantes pour le même horodatage ?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1762,33 +1803,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "année"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Année"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Oui"
@@ -1862,7 +1903,7 @@ msgid "Remove Front Album Art"
 msgstr "Retirer la face de la pochette d’album"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Échanger la couverture de l’album"
 
@@ -1893,52 +1934,52 @@ msgstr "Quitter"
 msgid "About Tagger"
 msgstr "À propos de Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Menu de la bibliothèque"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Menu principal"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Ouvrir un dossier (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Ouvrir une liste de lecture (Ctrl+Maj+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Sélectionner tous les fichiers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Total des pistes"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Total des pistes"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Basculer le volet des balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Actions relatives aux balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
@@ -1946,46 +1987,52 @@ msgstr "Appliquer les changements à la balise (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Tag;Musique;Éditeur;Bibliothèque;Balise;Étiquette; Nickvision;"
 
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "— Prise en charge de nombreux types de fichiers de musiques (mp3, ogg, "
-#~ "flac, wma, wav et plus)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+"— Prise en charge de nombreux types de fichiers de musiques (mp3, ogg, flac, "
+"wma, wav et plus)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "— Modifiez les balises et la couverture d’album de plusieurs fichiers à "
-#~ "la fois, même dans des sous-répertoires"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"— Modifiez les balises et la couverture d’album de plusieurs fichiers à la "
+"fois, même dans des sous-répertoires"
 
-#~ msgid ""
-#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-#~ "and export support)"
-#~ msgstr ""
-#~ "— Modifiez les paroles synchronisées ou non d’un fichier (avec prise en "
-#~ "charge de l’importation et exportation LRC)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+"— Modifiez les paroles synchronisées ou non d’un fichier (avec prise en "
+"charge de l’importation et exportation LRC)"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr ""
-#~ "— Convertissez aisément des noms de fichiers en balises et des balises en "
-#~ "noms de fichiers"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr ""
+"— Convertissez aisément des noms de fichiers en balises et des balises en "
+"noms de fichiers"
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr ""
-#~ "— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr ""
+"— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
 
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr ""
-#~ "— Recherchez des informations sur les paroles à l’aide de Music163 et "
-#~ "Letras"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr ""
+"— Recherchez des informations sur les paroles à l’aide de Music163 et Letras"
 
-#~ msgid ""
-#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-#~ "more)"
-#~ msgstr ""
-#~ "— Ouvrez, gérez et créez des listes de lecture dans de nombreux formats "
-#~ "(m3u, pls, xspf, et plus)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
+"— Ouvrez, gérez et créez des listes de lecture dans de nombreux formats "
+"(m3u, pls, xspf, et plus)"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} sur {1} sélectionné(s)"
@@ -37,63 +37,67 @@ msgstr "{0} sur {1} sélectionné(s)"
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artiste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%titre%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%titre%- %artiste%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%piste%- %titre%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<conserver>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "À propos de {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "Clé utilisateur d’API AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Ajouter"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Ajouter une nouvelle propriété"
 
@@ -151,7 +155,7 @@ msgid "Add to Playlist"
 msgstr "Ajouter à la liste de lecture"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Propriétés additionnelles"
 
@@ -160,10 +164,10 @@ msgstr "Propriétés additionnelles"
 msgid "Advanced Search Info"
 msgstr "Informations sur la recherche avancée"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -185,21 +189,21 @@ msgstr "Couverture de l’album"
 msgid "Album Artist"
 msgstr "Artiste de l'album"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "artiste de l’album"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Tous les fichiers pris en charge"
 
@@ -207,58 +211,58 @@ msgstr "Tous les fichiers pris en charge"
 msgid "An application restart is required to change the theme."
 msgstr "Un redémarrage de l’application est nécessaire pour changer le thème."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Un RecordingId invalide a été fourni à MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Appliquer les changements ?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artiste"
 
@@ -278,70 +282,70 @@ msgstr ""
 msgid "B"
 msgstr "o"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Dos"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Battements par minute"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Calcul…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annuler"
@@ -364,27 +368,27 @@ msgstr "Effacer toutes les paroles"
 msgid "Close Library"
 msgstr "Fermer la bibliothèque"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "commentaire"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Commentaire"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "compositeur"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Compositeur"
 
@@ -393,39 +397,39 @@ msgstr "Compositeur"
 msgid "Configure"
 msgstr "Configurer"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nom de fichier converti en balise avec succès"
 msgstr[1] "{0} noms de fichiers convertis en balises avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} balise convertie en nom de fichier avec succès"
 msgstr[1] "{0} balises converties en noms de fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Conversion des fichiers en étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Convertir la balise en nom de fichier"
@@ -435,8 +439,8 @@ msgstr "Convertir la balise en nom de fichier"
 msgid "Copied debug info to clipboard."
 msgstr "Copier l’empreinte vers le presse-papiers"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copier l’empreinte vers le presse-papiers"
 
@@ -460,8 +464,8 @@ msgstr "Créer une liste de lecture"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "personnalisé"
 
@@ -473,23 +477,23 @@ msgid "Custom"
 msgstr "Personnalisé"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Propriétés personnalisées"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Les propriétés personnalisées ne peuvent être éditées que pour des fichiers "
 "individuels."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -501,21 +505,21 @@ msgstr "Supprimer l'étiquette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Suppression des étiquettes..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "description"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Description"
 
@@ -535,23 +539,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Abandonner"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Abandonner"
 
@@ -565,9 +574,24 @@ msgstr "Abandonner les changements"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Abandonner les changements"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Abandon des balises…"
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "pistestotal"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -595,25 +619,25 @@ msgstr "Télécharger les métadonnées depuis MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Télécharger les métadonnées depuis MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Paroles téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Métadonnées téléchargées pour {0} fichiers avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Téléchargement des paroles…"
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Téléchargement des métadonnées depuis MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -687,6 +711,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "description"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "maison de disques"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "pistestotal"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -707,7 +741,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "maison de disques"
@@ -729,12 +763,12 @@ msgstr "pistestotal"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -749,19 +783,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Exporter"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Exporter le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
@@ -772,12 +806,12 @@ msgstr "Exporter la face de la pochette d’album"
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr ""
 "Le dos de la pochette d’album a été exporté vers le fichier avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
@@ -787,20 +821,20 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr "Exporté avec succès vers : {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 #, fuzzy
 msgid "Failed MusicBrainz Lookup"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Vérifications échouées sur MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Échec de l’exportation du dos de la pochette d’album vers le fichier"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Échec de l’exportation de la face de la pochette d’album vers le fichier"
@@ -818,9 +852,9 @@ msgstr "Nom du fichier"
 msgid "File Name"
 msgstr "Nom du fichier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Nom de fichier vers balise"
@@ -836,28 +870,28 @@ msgstr "Nom de fichier vers balise"
 msgid "File Path"
 msgstr "Chemin d’accès du fichier"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Propriétés du fichier"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "nom de fichier"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Empreinte"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Empreinte copiée vers le presse-papiers."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -866,29 +900,29 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Chaîne de format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Face"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "genre"
 
@@ -909,19 +943,19 @@ msgstr "Obtenir une nouvelle clé d'API"
 msgid "GiB"
 msgstr "Gio"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -929,7 +963,7 @@ msgid "Help"
 msgstr "Aide"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -944,31 +978,31 @@ msgstr "Importer depuis LRC"
 msgid "Include Only Selected Files"
 msgstr "Inclure uniquement les fichiers sélectionnés"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Informations"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Insérer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Insérer le dos de la pochette d’album"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Insérer la face de la pochette d’album"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Ajout de la pochette d'album..."
 
@@ -986,19 +1020,19 @@ msgstr "kio"
 msgid "Language Code"
 msgstr "Code de langage"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} musique chargée."
 msgstr[1] "{0} musiques chargées."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 
@@ -1006,7 +1040,7 @@ msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "paroles"
 
@@ -1033,7 +1067,7 @@ msgstr "Gérer les paroles"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gérer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
@@ -1051,13 +1085,13 @@ msgstr "Musique"
 msgid "Music Library"
 msgstr "Bibliothèque musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "Identifiant MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
 
@@ -1066,24 +1100,24 @@ msgstr "Nouvelle propriété personnalisée"
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Non"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 
@@ -1092,20 +1126,20 @@ msgstr "Pas d’entrée AcoustId trouvée pour l’empreinte du fichier"
 msgid "No file selected"
 msgstr "Aucun fichier de musique sélectionné."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Aucun fichier sélectionné pour la suppression."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Aucune parole n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Aucune métadonnée n’a été téléchargée"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Aucun fichier de musique sélectionné."
 
@@ -1114,11 +1148,11 @@ msgstr "Aucun fichier de musique sélectionné."
 msgid "No Music Files Found"
 msgstr "Aucune musique trouvée"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "Aucun fichier de musique dans la bibliothèque."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Aucun RecordingId pour MusicBrainz n’a été fourni pour l’entrée AcoustId"
@@ -1128,7 +1162,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Aucun fichier de musique sélectionné"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1153,11 +1187,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Décalage (en millisecondes)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1174,8 +1208,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Ouvrir"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1183,8 +1217,8 @@ msgstr ""
 "Seul un fichier peut être envoyé à AcoustId à la fois. Sélectionnez un seul "
 "fichier et essayez à nouveau."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -1194,7 +1228,7 @@ msgid "Open a library with music to get started"
 msgstr "Ouvrez une bibliothèque contenant des musiques pour commencer"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1204,11 +1238,11 @@ msgstr "Ouvrez une bibliothèque contenant des musiques pour commencer"
 msgid "Open Folder"
 msgstr "Ouvrir un dossier"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Ouvrir le fichier de musique"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1244,10 +1278,10 @@ msgstr "Chemin d’accès du fichier"
 msgid "Path (Empty)"
 msgstr "Nom (vide)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1257,25 +1291,25 @@ msgstr ""
 msgid "Playlist"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Fichier de liste de lecture créé avec succès."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Liste de lecture"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Le nom de la liste de lecture ne peut être laissé vide."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Sélectionnez un format."
 
@@ -1288,39 +1322,39 @@ msgstr "Conserver l’horodatage de modification"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Nom de la propriété"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Maison de disques"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Maison de disques"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "maison de disques"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "Recharger le dossier"
@@ -1333,20 +1367,20 @@ msgstr "Recharger la bibliothèque"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Supprimer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Supprimer la propriété personnalisée"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Supprimer les fichiers ?"
 
@@ -1360,7 +1394,7 @@ msgstr "Supprimer de la liste de lecture"
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Ajout de la pochette d'album..."
@@ -1389,8 +1423,8 @@ msgstr "Enregistrer la balise"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Enregistrement des balises…"
 
@@ -1409,27 +1443,27 @@ msgstr "Sélectionnez des fichiers"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1443,43 +1477,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Trier les fichiers par"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Envoyer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Envoyer à AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Métadonnées envoyées à AcoustId avec succès"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Envoi des données à AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Dos de la couverture"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Face de la couverture"
 
@@ -1493,9 +1527,9 @@ msgstr "Synchronisées"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Balise vers nom de fichier"
@@ -1505,9 +1539,8 @@ msgstr "Balise vers nom de fichier"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Balise vers nom de fichier"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associez des balises à vos musiques"
 
@@ -1516,9 +1549,8 @@ msgstr "Associez des balises à vos musiques"
 msgid "Tag Your Music"
 msgstr "Étiquetez vos musiques"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1527,8 +1559,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1541,7 +1573,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thème"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Ce fichier n’a pas d’empreinte valide"
 
@@ -1564,10 +1596,10 @@ msgstr "Tio"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "titre"
 
@@ -1579,15 +1611,15 @@ msgstr "titre"
 msgid "Title"
 msgstr "Titre"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Trop de fichiers sélectionnés"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "piste"
 
@@ -1599,14 +1631,14 @@ msgstr "piste"
 msgid "Track"
 msgstr "Morceau"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "pistestotal"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
@@ -1627,17 +1659,17 @@ msgid "Type ! for advanced search"
 msgstr ""
 "Rechercher un nom de fichier (tapez ! pour activer la recherche avancée)…"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Impossible d’ajouter le fichier à la liste de lecture. Le fichier existe "
 "peut-être déjà dedans."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Impossible de créer la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Impossible de charger l’image"
@@ -1652,29 +1684,29 @@ msgstr "Impossible d’exporter vers LRC."
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Impossible de charger l’image"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Impossible de supprimer certains fichiers de la liste de lecture."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Impossible d’enregistrer {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Impossible d’enregistrer {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Impossible d’envoyer les métadonnées à AcoustId. Vérifiez la clé API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1683,7 +1715,7 @@ msgstr "Inconnu"
 msgid "Unsynchronized"
 msgstr "Non synchronisées"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1697,8 +1729,8 @@ msgstr "Utiliser les paroles LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1730,18 +1762,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "année"
 
@@ -1753,10 +1785,10 @@ msgstr "année"
 msgid "Year"
 msgstr "Année"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Oui"
@@ -1889,15 +1921,24 @@ msgstr "Sélectionner tous les fichiers"
 msgid "Track Total"
 msgstr "Total des pistes"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Total des pistes"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Basculer le volet des balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Actions relatives aux balises"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Appliquer les changements à la balise (Ctrl+S)"
 
@@ -1905,52 +1946,46 @@ msgstr "Appliquer les changements à la balise (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Tag;Musique;Éditeur;Bibliothèque;Balise;Étiquette; Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Prise en charge de nombreux types de fichiers de musiques (mp3, ogg, flac, "
-"wma, wav et plus)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Prise en charge de nombreux types de fichiers de musiques (mp3, ogg, "
+#~ "flac, wma, wav et plus)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Modifiez les balises et la couverture d’album de plusieurs fichiers à la "
-"fois, même dans des sous-répertoires"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Modifiez les balises et la couverture d’album de plusieurs fichiers à "
+#~ "la fois, même dans des sous-répertoires"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Modifiez les paroles synchronisées ou non d’un fichier (avec prise en "
-"charge de l’importation et exportation LRC)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Modifiez les paroles synchronisées ou non d’un fichier (avec prise en "
+#~ "charge de l’importation et exportation LRC)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-"— Convertissez aisément des noms de fichiers en balises et des balises en "
-"noms de fichiers"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr ""
+#~ "— Convertissez aisément des noms de fichiers en balises et des balises en "
+#~ "noms de fichiers"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr ""
-"— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr ""
+#~ "— Recherchez des informations sur les fichiers, à l’aide de MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr ""
-"— Recherchez des informations sur les paroles à l’aide de Music163 et Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr ""
+#~ "— Recherchez des informations sur les paroles à l’aide de Music163 et "
+#~ "Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Ouvrez, gérez et créez des listes de lecture dans de nombreux formats "
-"(m3u, pls, xspf, et plus)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Ouvrez, gérez et créez des listes de lecture dans de nombreux formats "
+#~ "(m3u, pls, xspf, et plus)"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,15 +20,15 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
@@ -38,63 +38,67 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%אמן% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%כותרת% - %אמן%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%רצועה% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<לשמור>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 מבי״ב"
 
@@ -103,8 +107,8 @@ msgstr "0 מבי״ב"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -128,18 +132,18 @@ msgid "AcoustId User API Key"
 msgstr "מפתח משתמש API ל־AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 #, fuzzy
 msgid "Add New Property"
 msgstr "מאפיין מותאם חדש"
@@ -151,7 +155,7 @@ msgid "Add to Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "מאפיינים נוספים"
 
@@ -160,10 +164,10 @@ msgstr "מאפיינים נוספים"
 msgid "Advanced Search Info"
 msgstr "חיפוש מידע מתקדם"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "אלבום"
 
@@ -185,22 +189,22 @@ msgstr "עטיפת אלבום"
 msgid "Album Artist"
 msgstr "אמן האלבום"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "אמן האלבום"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 #, fuzzy
 msgid "All files"
 msgstr "יש לבחור קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 #, fuzzy
 msgid "All Supported Files"
 msgstr "יש לבחור קבצים"
@@ -209,58 +213,58 @@ msgstr "יש לבחור קבצים"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "אמן"
 
@@ -280,70 +284,70 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "אחורי"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "פעימות לדקה"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "ביטול"
@@ -366,27 +370,27 @@ msgstr "ניקוי כל מילות השיר"
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "הערכה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "הערה"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "מלחין"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "מלחין"
 
@@ -395,20 +399,20 @@ msgstr "מלחין"
 msgid "Configure"
 msgstr "הגדרה"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub ‏❤️ {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -417,7 +421,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -426,12 +430,12 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "המרת שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "המרת תג לשם קובץ"
@@ -441,8 +445,8 @@ msgstr "המרת תג לשם קובץ"
 msgid "Copied debug info to clipboard."
 msgstr "העתקת טביעת אצבע ללוח הגזירים"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "העתקת טביעת אצבע ללוח הגזירים"
 
@@ -466,8 +470,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -479,21 +483,21 @@ msgid "Custom"
 msgstr "מותאם אישית"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "מאפיינים מותאמים"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -506,22 +510,22 @@ msgstr "מחיקת תגיות"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "תיאור"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "תיאור"
 
@@ -541,23 +545,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "השלכה"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "השלכה"
 
@@ -571,10 +580,25 @@ msgstr "השלכת שינויים שלא הוחלו"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "השלכת שינויים שלא הוחלו"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "שומר תגיות…"
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "מספר רצועות כולל"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -603,26 +627,26 @@ msgstr "הורדת נתוני מידע מ־MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -693,6 +717,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "תיאור"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "מוציא לאור"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "מספר רצועות כולל"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -713,7 +747,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "מוציא לאור"
@@ -735,12 +769,12 @@ msgstr "מספר רצועות כולל"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -755,19 +789,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "ייצוא"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
@@ -778,11 +812,11 @@ msgstr "ייצוא עטיפת אלבום קדמית"
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
@@ -791,19 +825,19 @@ msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 msgid "Exported successfully to: {0}"
 msgstr "הייצוא בוצע בהצלחה אל: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
@@ -820,9 +854,9 @@ msgstr "שם קובץ"
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
@@ -838,28 +872,28 @@ msgstr "שם קובץ לתג"
 msgid "File Path"
 msgstr "נתיב הקובץ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "מאפייני קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "טביעת אצבע"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -869,29 +903,29 @@ msgstr ""
 msgid "Format"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "קדמי"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "סוגה"
 
@@ -912,19 +946,19 @@ msgstr "לקבל מפתחות API חדשים"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -932,7 +966,7 @@ msgid "Help"
 msgstr "עזרה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -948,31 +982,31 @@ msgstr "ייבוא מ־LRC"
 msgid "Include Only Selected Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "מידע"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 #, fuzzy
 msgid "Inserting album art..."
 msgstr "הכנסת עטיפת אלבום אחורית"
@@ -991,11 +1025,11 @@ msgstr "קי״ב"
 msgid "Language Code"
 msgstr "שפת קוד"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1004,8 +1038,8 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1014,7 +1048,7 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "מילות שיר"
 
@@ -1041,7 +1075,7 @@ msgstr "ניהול מילות שיר"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "ניהול מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
@@ -1060,13 +1094,13 @@ msgstr "קובץ מוזיקה"
 msgid "Music Library"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
@@ -1075,24 +1109,24 @@ msgstr "מאפיין מותאם חדש"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1101,21 +1135,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "No music files are selected."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1125,12 +1159,12 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "No Music Files Found"
 msgstr "לא נמצאו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "No music files in library."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1139,7 +1173,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1164,11 +1198,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "אישור"
 
@@ -1185,8 +1219,8 @@ msgstr "אישור"
 msgid "On"
 msgstr "פתיחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1194,8 +1228,8 @@ msgstr ""
 "ניתן לשלוח ל־AcoustID קובץ אחד בלבד בכל פעם. נא לבחור קובץ אחד בלבד ולנסות "
 "שוב."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "פתיחה"
 
@@ -1206,7 +1240,7 @@ msgid "Open a library with music to get started"
 msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1216,12 +1250,12 @@ msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 #, fuzzy
 msgid "Open Music File"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1256,10 +1290,10 @@ msgstr "נתיב הקובץ"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1269,23 +1303,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "יש לבחור תבנית למחרוזת."
 
@@ -1298,39 +1332,39 @@ msgstr "שמירת חותמת זמן השינוי"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "מוציא לאור"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "טעינת תיקייה מחדש"
@@ -1343,20 +1377,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "הסרה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 #, fuzzy
 msgid "Remove Files?"
 msgstr "הסרת מילות שיר"
@@ -1371,7 +1405,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "הסרת עטיפה אחורית לאלבום"
@@ -1399,8 +1433,8 @@ msgstr "שמירת תג"
 msgid "Save Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
@@ -1419,27 +1453,27 @@ msgstr "יש לבחור קבצים"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1451,43 +1485,43 @@ msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של ש�
 msgid "Sort Files By"
 msgstr "מיון פריטים לפי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "החלפה לכיסוי קדמי"
 
@@ -1501,9 +1535,9 @@ msgstr ""
 msgid "Tag"
 msgstr "המתייג"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "תג לשם קובץ"
@@ -1513,9 +1547,8 @@ msgstr "תג לשם קובץ"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "תג לשם קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "תיוג המוזיקה שלך"
 
@@ -1524,9 +1557,8 @@ msgstr "תיוג המוזיקה שלך"
 msgid "Tag Your Music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "המתייג"
 
@@ -1535,8 +1567,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1547,7 +1579,7 @@ msgstr ""
 msgid "Theme"
 msgstr "ערכת עיצוב"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "לקובץ זה אין טביעת אצבע תקפה"
 
@@ -1570,10 +1602,10 @@ msgstr "טבי״ב"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "חותמת זמן (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "כותרת"
 
@@ -1585,15 +1617,15 @@ msgstr "כותרת"
 msgid "Title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "רצועה"
 
@@ -1605,14 +1637,14 @@ msgstr "רצועה"
 msgid "Track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
@@ -1635,16 +1667,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "חיפוש שם קובץ (יש להזין ! לחיפוש מתקדם)…"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "לא ניתן לטעון את קובץ התמונה"
@@ -1659,30 +1691,30 @@ msgstr "לא ניתן לייצא ל־LRC."
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1691,7 +1723,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1705,8 +1737,8 @@ msgstr "שימוש במילות שיר מ־LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1738,18 +1770,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "שנה"
 
@@ -1761,10 +1793,10 @@ msgstr "שנה"
 msgid "Year"
 msgstr "שנה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1901,15 +1933,24 @@ msgstr "יש לבחור קבצים"
 msgid "Track Total"
 msgstr "מספר רצועות כולל"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "מספר רצועות כולל"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "הצגה/הסתרת סרגל התיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "פעולות תיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
@@ -1919,43 +1960,27 @@ msgstr ""
 "תג;תגית;תגיות;מוזיקה;מוסיקה;שירים;עורך;ספרייה;ספריה;אלבום;אלבומים;Nickvision;"
 "תיוג;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr "- תמיכה בסוגי קובצי מוזיקה שונים (‎mp3, ogg, flac, wma ו־wav)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr "- תמיכה בסוגי קובצי מוזיקה שונים (‎mp3, ogg, flac, wma ו־wav)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"- עריכת תגיות ועטיפת אלבום למספר רב של קבצים, גם מתיקיות שונות, הכול בבת אחת"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "- עריכת תגיות ועטיפת אלבום למספר רב של קבצים, גם מתיקיות שונות, הכול בבת "
+#~ "אחת"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "- המרת שמות קבצים לתגיות ותגיות לשמות קבצים בקלות"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "- המרת שמות קבצים לתגיות ותגיות לשמות קבצים בקלות"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -62,26 +62,24 @@ msgstr "%כותרת% - %אמן%"
 msgid "%track%- %title%"
 msgstr "%רצועה% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -97,7 +95,9 @@ msgstr "%רצועה% - %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -135,7 +135,7 @@ msgstr ""
 "אם אין ברשותך, המתייג ישלח את נתוני התגיות שלך יחד עם טביעת האצבע במקום."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "מפתח משתמש API ל־AcoustId"
 
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "חיפוש מידע מתקדם"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "אלבום"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "אמן האלבום"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "אמן האלבום"
 
@@ -221,7 +221,7 @@ msgstr "יש לבחור קבצים"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 
@@ -270,9 +270,9 @@ msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "אמן"
 
@@ -308,21 +308,21 @@ msgid "Beats Per Minute"
 msgstr "פעימות לדקה"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -385,9 +385,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "הערכה"
 
@@ -397,9 +397,9 @@ msgid "Comment"
 msgstr "הערה"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "מלחין"
 
@@ -426,7 +426,7 @@ msgstr "תורמים ב־GitHub ‏❤️ {0}"
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -435,7 +435,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -444,12 +444,12 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "המרת שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "המרת תג לשם קובץ"
@@ -485,7 +485,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -524,15 +524,15 @@ msgstr "מחיקת תגיות"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "תיאור"
 
@@ -594,22 +594,22 @@ msgstr "השלכת שינויים שלא הוחלו"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "השלכת שינויים שלא הוחלו"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "מספר רצועות כולל"
@@ -641,22 +641,22 @@ msgstr "הורדת נתוני מידע מ־MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
@@ -672,12 +672,12 @@ msgid "Edit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr "לאפשר לדרוס עטיפת אלבום קיימת עם עטיפת מ־MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 #, fuzzy
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
@@ -687,7 +687,7 @@ msgstr ""
 "ריקים ימולאו."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -783,12 +783,12 @@ msgstr "מספר רצועות כולל"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -826,11 +826,11 @@ msgstr "ייצוא עטיפת אלבום קדמית"
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
@@ -847,11 +847,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
@@ -892,7 +892,7 @@ msgid "File Properties"
 msgstr "מאפייני קובץ"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "שם קובץ"
 
@@ -939,9 +939,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "סוגה"
 
@@ -954,7 +954,7 @@ msgid "Genre"
 msgstr "סוגה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "לקבל מפתחות API חדשים"
 
@@ -1034,7 +1034,7 @@ msgstr "הכנסת עטיפת אלבום אחורית"
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 #, fuzzy
 msgid "Inserting album art..."
 msgstr "הכנסת עטיפת אלבום אחורית"
@@ -1053,11 +1053,11 @@ msgstr "קי״ב"
 msgid "Language Code"
 msgstr "שפת קוד"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1066,8 +1066,8 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1076,7 +1076,7 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "מילות שיר"
 
@@ -1142,7 +1142,7 @@ msgstr "מאפיין מותאם חדש"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1174,15 +1174,15 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "No files selected for removal."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 #, fuzzy
 msgid "No music files are selected."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1192,12 +1192,12 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "No Music Files Found"
 msgstr "לא נמצאו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "No music files in library."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1298,17 +1298,17 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "דריסת עטיפת אלבום עם MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "דריסת תג עם MusicBrainz"
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1371,9 +1371,9 @@ msgid "Property Name"
 msgstr "שם מאפיין"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -1389,9 +1389,9 @@ msgid "Publishing Date"
 msgstr "מוציא לאור"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "מוציא לאור"
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "הסרת עטיפה אחורית לאלבום"
@@ -1466,8 +1466,8 @@ msgstr "שמירת תג"
 msgid "Save Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
@@ -1531,11 +1531,11 @@ msgstr "שליחה"
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "Theme"
 msgstr "ערכת עיצוב"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "לקובץ זה אין טביעת אצבע תקפה"
 
@@ -1638,9 +1638,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "חותמת זמן (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "כותרת"
 
@@ -1658,9 +1658,9 @@ msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "רצועה"
 
@@ -1673,9 +1673,9 @@ msgid "Track"
 msgstr "רצועה"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -1702,16 +1702,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "חיפוש שם קובץ (יש להזין ! לחיפוש מתקדם)…"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "לא ניתן לטעון את קובץ התמונה"
@@ -1726,30 +1726,30 @@ msgstr "לא ניתן לייצא ל־LRC."
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1784,7 +1784,7 @@ msgstr "ממשק משתמש"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "שרת אינטרנט"
@@ -1819,9 +1819,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "שנה"
 
@@ -1877,6 +1877,14 @@ msgstr "לזכור את התיקייה האחרונה שנפתחה"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "כולל תתי־תיקיות"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 #, fuzzy

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,17 +20,25 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
@@ -38,63 +46,63 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%אמן% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%כותרת% - %אמן%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%רצועה% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<לשמור>"
 
@@ -102,13 +110,13 @@ msgstr "<לשמור>"
 msgid "0 MiB"
 msgstr "0 מבי״ב"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -132,18 +140,18 @@ msgid "AcoustId User API Key"
 msgstr "מפתח משתמש API ל־AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #, fuzzy
 msgid "Add New Property"
 msgstr "מאפיין מותאם חדש"
@@ -154,28 +162,28 @@ msgstr "מאפיין מותאם חדש"
 msgid "Add to Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "מאפיינים נוספים"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "חיפוש מידע מתקדם"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "אלבום"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "אלבום"
 
@@ -184,27 +192,27 @@ msgstr "אלבום"
 msgid "Album Art"
 msgstr "עטיפת אלבום"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "אמן האלבום"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "אמן האלבום"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 #, fuzzy
 msgid "All files"
 msgstr "יש לבחור קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 #, fuzzy
 msgid "All Supported Files"
 msgstr "יש לבחור קבצים"
@@ -213,66 +221,66 @@ msgstr "יש לבחור קבצים"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "אמן"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "אמן"
 
@@ -284,70 +292,72 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "אחורי"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "פעימות לדקה"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "ביטול"
@@ -356,7 +366,7 @@ msgstr "ביטול"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -365,32 +375,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr "ניקוי כל מילות השיר"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "הערכה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "הערה"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "מלחין"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "מלחין"
 
@@ -399,20 +413,20 @@ msgstr "מלחין"
 msgid "Configure"
 msgstr "הגדרה"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub ‏❤️ {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -421,7 +435,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -430,12 +444,12 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "המרת שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "המרת תג לשם קובץ"
@@ -445,8 +459,8 @@ msgstr "המרת תג לשם קובץ"
 msgid "Copied debug info to clipboard."
 msgstr "העתקת טביעת אצבע ללוח הגזירים"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "העתקת טביעת אצבע ללוח הגזירים"
 
@@ -470,8 +484,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -482,22 +496,22 @@ msgstr "מותאם אישית"
 msgid "Custom"
 msgstr "מותאם אישית"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "מאפיינים מותאמים"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -506,26 +520,26 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "מחיקת תגיות"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "תיאור"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "תיאור"
 
@@ -545,28 +559,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "השלכה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "השלכה"
 
@@ -575,78 +589,78 @@ msgstr "השלכה"
 msgid "Discard Unapplied Changed"
 msgstr "השלכת שינויים שלא הוחלו"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "השלכת שינויים שלא הוחלו"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "שומר תגיות…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "מספר רצועות כולל"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "משך זמן"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 #, fuzzy
 msgid "Download Lyrics"
 msgstr "ניהול מילות שיר"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -681,29 +695,29 @@ msgstr ""
 "לאפשר לדרוס תג קיים עם מידע המגיע מ־MusicBrainz. אם מושבת, רק מאפייני תג "
 "ריקים ימולאו."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 #, fuzzy
 msgid "Enter album artist here"
 msgstr "אמן האלבום"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 #, fuzzy
 msgid "Enter beats per minute here"
 msgstr "פעימות בדקה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -712,26 +726,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "תיאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "מספר רצועות כולל"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -747,34 +761,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "מספר רצועות כולל"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -788,20 +802,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "ייצוא"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
@@ -812,11 +826,11 @@ msgstr "ייצוא עטיפת אלבום קדמית"
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
@@ -825,19 +839,19 @@ msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 msgid "Exported successfully to: {0}"
 msgstr "הייצוא בוצע בהצלחה אל: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
@@ -847,21 +861,21 @@ msgid "File"
 msgstr "שם קובץ"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "שם קובץ לתג"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "שם קובץ לתג"
@@ -872,28 +886,28 @@ msgstr "שם קובץ לתג"
 msgid "File Path"
 msgstr "נתיב הקובץ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "מאפייני קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "טביעת אצבע"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -903,37 +917,39 @@ msgstr ""
 msgid "Format"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "קדמי"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "סוגה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "סוגה"
 
@@ -946,27 +962,33 @@ msgstr "לקבל מפתחות API חדשים"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "בהיר"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "עזרה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -982,31 +1004,37 @@ msgstr "ייבוא מ־LRC"
 msgid "Include Only Selected Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "מידע"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 #, fuzzy
 msgid "Inserting album art..."
 msgstr "הכנסת עטיפת אלבום אחורית"
@@ -1025,11 +1053,11 @@ msgstr "קי״ב"
 msgid "Language Code"
 msgstr "שפת קוד"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1038,8 +1066,8 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1048,40 +1076,45 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "מילות שיר"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "מילות שיר"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "מאפיינים ראשיים"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "ניהול מילות שיר"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 #, fuzzy
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "ניהול מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "צ׳אט במטריקס"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "מבי״ב"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+msgid "Mime Type"
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1094,13 +1127,13 @@ msgstr "קובץ מוזיקה"
 msgid "Music Library"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
@@ -1109,24 +1142,24 @@ msgstr "מאפיין מותאם חדש"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1135,45 +1168,45 @@ msgstr ""
 msgid "No file selected"
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 #, fuzzy
 msgid "No music files are selected."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "לא נמצאו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 #, fuzzy
 msgid "No music files in library."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1198,11 +1231,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "אישור"
 
@@ -1219,8 +1252,8 @@ msgstr "אישור"
 msgid "On"
 msgstr "פתיחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1228,39 +1261,39 @@ msgstr ""
 "ניתן לשלוח ל־AcoustID קובץ אחד בלבד בכל פעם. נא לבחור קובץ אחד בלבד ולנסות "
 "שוב."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "פתיחה"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 #, fuzzy
 msgid "Open a library with music to get started"
 msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 #, fuzzy
 msgid "Open Music File"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1290,10 +1323,10 @@ msgstr "נתיב הקובץ"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1303,23 +1336,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "יש לבחור תבנית למחרוזת."
 
@@ -1332,39 +1365,39 @@ msgstr "שמירת חותמת זמן השינוי"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "שם מאפיין"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "מוציא לאור"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "טעינת תיקייה מחדש"
@@ -1376,21 +1409,21 @@ msgid "Reload Library"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "הסרה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
 msgstr "הסרת מילות שיר"
@@ -1405,12 +1438,12 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "הסרת עטיפה אחורית לאלבום"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1423,18 +1456,18 @@ msgid "Save Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "שמירת תג"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
@@ -1443,8 +1476,8 @@ msgstr "שומר תגיות…"
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "יש לבחור קבצים"
 
@@ -1453,27 +1486,27 @@ msgstr "יש לבחור קבצים"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1485,43 +1518,43 @@ msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של ש�
 msgid "Sort Files By"
 msgstr "מיון פריטים לפי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "החלפה לכיסוי קדמי"
 
@@ -1535,40 +1568,42 @@ msgstr ""
 msgid "Tag"
 msgstr "המתייג"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "תג לשם קובץ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "תג לשם קובץ"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "תיוג המוזיקה שלך"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "המתייג"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1579,7 +1614,7 @@ msgstr ""
 msgid "Theme"
 msgstr "ערכת עיצוב"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "לקובץ זה אין טביעת אצבע תקפה"
 
@@ -1602,56 +1637,56 @@ msgstr "טבי״ב"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "חותמת זמן (hh:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "כותרת"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "רצועה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "רצועה"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr ""
 "יוסף אור בוצ׳קו <yoseforb@gmail.com>\n"
 "מיזם תרגום GNOME לעברית https://l10n.gnome.org/teams/he/"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 #, fuzzy
 msgid "Try a different library"
 msgstr "יש לנסות תיקייה אחרת"
@@ -1661,22 +1696,22 @@ msgstr "יש לנסות תיקייה אחרת"
 msgid "Type"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr "חיפוש שם קובץ (יש להזין ! לחיפוש מתקדם)…"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "לא ניתן לטעון את קובץ התמונה"
@@ -1691,30 +1726,30 @@ msgstr "לא ניתן לייצא ל־LRC."
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1723,7 +1758,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1737,8 +1772,8 @@ msgstr "שימוש במילות שיר מ־LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1747,10 +1782,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "ממשק משתמש"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "שרת אינטרנט"
 
@@ -1763,6 +1798,11 @@ msgstr ""
 "מה ברצונך שהמתייג יעשה עם מילות שיר שנמצאו בקובץ LRC שמתנגשות עם מילות שיר "
 "קיימות עם אותה חותמת זמן?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1770,33 +1810,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "שנה"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "שנה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1872,7 +1912,7 @@ msgid "Remove Front Album Art"
 msgstr "הסרת עטיפה קדמית לאלבום"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "החלפת עטיפת אלבום"
 
@@ -1903,54 +1943,54 @@ msgstr "יציאה"
 msgid "About Tagger"
 msgstr "על אודות המתייג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "תפריט ראשי"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 #, fuzzy
 msgid "Open Folder (Ctrl+O)"
 msgstr "פתיחת תיקיית מוזיקה (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 #, fuzzy
 msgid "Select All Files"
 msgstr "יש לבחור קבצים"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "מספר רצועות כולל"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "מספר רצועות כולל"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "הצגה/הסתרת סרגל התיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "פעולות תיוג"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
@@ -1960,27 +2000,43 @@ msgstr ""
 "תג;תגית;תגיות;מוזיקה;מוסיקה;שירים;עורך;ספרייה;ספריה;אלבום;אלבומים;Nickvision;"
 "תיוג;"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr "- תמיכה בסוגי קובצי מוזיקה שונים (‎mp3, ogg, flac, wma ו־wav)"
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr "- תמיכה בסוגי קובצי מוזיקה שונים (‎mp3, ogg, flac, wma ו־wav)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "- עריכת תגיות ועטיפת אלבום למספר רב של קבצים, גם מתיקיות שונות, הכול בבת "
-#~ "אחת"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"- עריכת תגיות ועטיפת אלבום למספר רב של קבצים, גם מתיקיות שונות, הכול בבת אחת"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr "- המרת שמות קבצים לתגיות ותגיות לשמות קבצים בקלות"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr "- המרת שמות קבצים לתגיות ותגיות לשמות קבצים בקלות"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "- קבלת מידע על קבצים באמצעות MusicBrainz"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -25,8 +25,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -62,34 +62,24 @@ msgstr "%כותרת% - %אמן%"
 msgid "%track%- %title%"
 msgstr "%רצועה% - %כותרת%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -97,9 +87,19 @@ msgstr "%רצועה% - %כותרת%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -115,7 +115,7 @@ msgstr "0 מבי״ב"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -140,7 +140,7 @@ msgid "AcoustId User API Key"
 msgstr "מפתח משתמש API ל־AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "חיפוש מידע מתקדם"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "אלבום"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "אמן האלבום"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "אמן האלבום"
 
@@ -211,8 +211,8 @@ msgstr "אמן האלבום"
 msgid "All files"
 msgstr "יש לבחור קבצים"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 #, fuzzy
 msgid "All Supported Files"
 msgstr "יש לבחור קבצים"
@@ -221,18 +221,18 @@ msgstr "יש לבחור קבצים"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -249,14 +249,14 @@ msgstr "מזהה ההקלטה שסופק ל־MusicBrainz אינו תקף"
 msgid "Apply"
 msgstr "החלה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -270,9 +270,9 @@ msgid "Apply Changes?"
 msgstr "להחיל שינויים?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "אמן"
 
@@ -293,8 +293,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -308,40 +308,40 @@ msgid "Beats Per Minute"
 msgstr "פעימות לדקה"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -385,9 +385,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "הערכה"
 
@@ -397,9 +397,9 @@ msgid "Comment"
 msgstr "הערה"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "מלחין"
 
@@ -417,8 +417,8 @@ msgstr "הגדרה"
 msgid "Contributors on GitHub ❤️"
 msgstr "תורמים ב־GitHub ‏❤️ {0}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -426,7 +426,7 @@ msgstr "תורמים ב־GitHub ‏❤️ {0}"
 msgid "Convert"
 msgstr "המרה"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -435,7 +435,7 @@ msgstr[1] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[2] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 msgstr[3] "‏{0} שמות קבצים הומרו בהצלחה לתגיות"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -444,12 +444,12 @@ msgstr[1] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[2] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 msgstr[3] "‏{0} תגיות הומרו בהצלחה לשמות קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "המרת שם קובץ לתג"
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "המרת תג לשם קובץ"
@@ -485,7 +485,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "מותאם אישית"
 
@@ -524,15 +524,15 @@ msgstr "מחיקת תגיות"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "תיאור"
 
@@ -564,14 +564,14 @@ msgstr ""
 msgid "Disc"
 msgstr "השלכה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -594,22 +594,22 @@ msgstr "השלכת שינויים שלא הוחלו"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "השלכת שינויים שלא הוחלו"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "מספר רצועות כולל"
@@ -641,22 +641,22 @@ msgstr "הורדת נתוני מידע מ־MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "הורדת נתוני מידע מ־MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "הורדו בהצלחה נתוני מידע על {0} קבצים"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "מוריד נתוני מידע מ־MusicBrainz…"
 
@@ -783,12 +783,12 @@ msgstr "מספר רצועות כולל"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -810,12 +810,12 @@ msgstr ""
 msgid "Export"
 msgstr "ייצוא"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "ייצוא עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
@@ -826,11 +826,11 @@ msgstr "ייצוא עטיפת אלבום קדמית"
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "עטיפת אלבום אחורית יוצאה בהצלחה"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
@@ -843,15 +843,15 @@ msgstr "הייצוא בוצע בהצלחה אל: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "ייצוא עטיפת אלבום אחורית לקובץ נכשל"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "ייצוא עטיפת אלבום קדמית לקובץ נכשל"
 
@@ -868,7 +868,7 @@ msgstr "שם קובץ"
 msgid "File Name"
 msgstr "שם קובץ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -892,7 +892,7 @@ msgid "File Properties"
 msgstr "מאפייני קובץ"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "שם קובץ"
 
@@ -901,12 +901,12 @@ msgstr "שם קובץ"
 msgid "Fingerprint"
 msgstr "טביעת אצבע"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "טביעת האצבע הועתקה ללוח הגזירים."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -917,16 +917,16 @@ msgstr ""
 msgid "Format"
 msgstr "תבנית מחרוזת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "תבנית מחרוזת"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -939,9 +939,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "סוגה"
 
@@ -962,7 +962,7 @@ msgstr "לקבל מפתחות API חדשים"
 msgid "GiB"
 msgstr "גיב״ב"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "מאגר GitHub"
@@ -973,9 +973,9 @@ msgstr "מאגר GitHub"
 msgid "Height"
 msgstr "בהיר"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -1004,7 +1004,7 @@ msgstr "ייבוא מ־LRC"
 msgid "Include Only Selected Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1024,17 +1024,17 @@ msgstr "מידע"
 msgid "Insert"
 msgstr "הוספה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "הכנסת עטיפת אלבום אחורית"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "הכנסת עטיפת אלבום קדמית"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 #, fuzzy
 msgid "Inserting album art..."
 msgstr "הכנסת עטיפת אלבום אחורית"
@@ -1053,11 +1053,11 @@ msgstr "קי״ב"
 msgid "Language Code"
 msgstr "שפת קוד"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1066,8 +1066,8 @@ msgstr[1] "נטענו {0} קובצי מוזיקה."
 msgstr[2] "נטענו {0} קובצי מוזיקה."
 msgstr[3] "נטענו {0} קובצי מוזיקה."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1076,7 +1076,7 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "מילות שיר"
 
@@ -1090,6 +1090,10 @@ msgstr "מילות שיר"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "מאפיינים ראשיים"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1127,12 +1131,12 @@ msgstr "קובץ מוזיקה"
 msgid "Music Library"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "מזהה ההקלטות MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
@@ -1142,7 +1146,7 @@ msgstr "מאפיין מותאם חדש"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1151,15 +1155,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1168,21 +1172,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 #, fuzzy
 msgid "No music files are selected."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
@@ -1192,12 +1196,12 @@ msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 msgid "No Music Files Found"
 msgstr "לא נמצאו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 #, fuzzy
 msgid "No music files in library."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1206,7 +1210,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "לא נבחרו קובצי מוזיקה"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1231,7 +1235,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1252,7 +1256,7 @@ msgstr "אישור"
 msgid "On"
 msgstr "פתיחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1261,7 +1265,7 @@ msgstr ""
 "ניתן לשלוח ל־AcoustID קובץ אחד בלבד בכל פעם. נא לבחור קובץ אחד בלבד ולנסות "
 "שוב."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "פתיחה"
@@ -1273,7 +1277,7 @@ msgid "Open a library with music to get started"
 msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1283,12 +1287,12 @@ msgstr "יש לפתוח תיקייה עם מוזיקה להתחלת התיוג"
 msgid "Open Folder"
 msgstr "פתיחת תיקייה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 #, fuzzy
 msgid "Open Music File"
 msgstr "קובץ מוזיקה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1323,8 +1327,8 @@ msgstr "נתיב הקובץ"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1336,21 +1340,21 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1365,15 +1369,15 @@ msgstr "שמירת חותמת זמן השינוי"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "שם מאפיין"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -1389,14 +1393,14 @@ msgid "Publishing Date"
 msgstr "מוציא לאור"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "מוציא לאור"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1417,12 +1421,12 @@ msgstr ""
 msgid "Remove"
 msgstr "הסרה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "הסרת מאפיין מותאם"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
@@ -1438,7 +1442,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "הסרת עטיפה אחורית לאלבום"
@@ -1466,8 +1470,8 @@ msgstr "שמירת תג"
 msgid "Save Tag (Ctrl+S)"
 msgstr "החלת שינויים לתג (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "שומר תגיות…"
 
@@ -1490,14 +1494,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1518,12 +1522,12 @@ msgstr "כמה קובצי מוזיקה עוד ממתינים להחלה של ש�
 msgid "Sort Files By"
 msgstr "מיון פריטים לפי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "שליחה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1531,15 +1535,15 @@ msgstr "שליחה"
 msgid "Submit to AcoustId"
 msgstr "שליחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "נתוני המידע נשלחו בהצלחה ל־AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "שולח נתוני מידע ל־AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1550,7 +1554,7 @@ msgstr "שולח נתוני מידע ל־AcoustId…"
 msgid "Switch to Back Cover"
 msgstr "החלפה לכיסוי אחורי"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1568,7 +1572,7 @@ msgstr ""
 msgid "Tag"
 msgstr "המתייג"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1602,7 +1606,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1614,7 +1618,7 @@ msgstr ""
 msgid "Theme"
 msgstr "ערכת עיצוב"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "לקובץ זה אין טביעת אצבע תקפה"
 
@@ -1638,9 +1642,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "חותמת זמן (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "כותרת"
 
@@ -1652,15 +1656,15 @@ msgstr "כותרת"
 msgid "Title"
 msgstr "כותרת"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "נבחרו יותר מדי קבצים"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "רצועה"
 
@@ -1673,9 +1677,9 @@ msgid "Track"
 msgstr "רצועה"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -1702,16 +1706,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "חיפוש שם קובץ (יש להזין ! לחיפוש מתקדם)…"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "לא ניתן לטעון את קובץ התמונה"
@@ -1726,30 +1730,30 @@ msgstr "לא ניתן לייצא ל־LRC."
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "לא ניתן לשמור את {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "לא ניתן לשמור את {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "לא ניתן לשלוח ל־AcoustID. נא לבדוק את מפתח ה־API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1772,7 +1776,7 @@ msgstr "שימוש במילות שיר מ־LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1810,7 +1814,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1819,9 +1823,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "שנה"
 
@@ -1833,8 +1837,8 @@ msgstr "שנה"
 msgid "Year"
 msgstr "שנה"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
@@ -38,63 +38,67 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%izvođač%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%naslov%- %izvođač%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<zadrži>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -103,8 +107,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Informacije"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "API ključ AcoustId korisnika"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 #, fuzzy
 msgid "Add New Property"
 msgstr "Novo prilagođeno svojstvo"
@@ -152,7 +156,7 @@ msgid "Add to Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Dodatna svojstva"
 
@@ -161,10 +165,10 @@ msgstr "Dodatna svojstva"
 msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -186,22 +190,22 @@ msgstr "Slika albuma"
 msgid "Album Artist"
 msgstr "Izvođač albuma"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "izvođač albuma"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 #, fuzzy
 msgid "All files"
 msgstr "Odaberi neke datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Odaberi neke datoteke"
@@ -210,58 +214,58 @@ msgstr "Odaberi neke datoteke"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "izvođač"
 
@@ -281,70 +285,70 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Natrag"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "BPM"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Odustani"
@@ -367,27 +371,27 @@ msgstr ""
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "komentar"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Komentar"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "skladatelj"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Skladatelj"
 
@@ -396,23 +400,23 @@ msgstr "Skladatelj"
 msgid "Configure"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Doprinositelji na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -420,7 +424,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -428,12 +432,12 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Pretvaranje imena datoteka u oznake …"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Pretvori oznaku u ime datoteke"
@@ -443,8 +447,8 @@ msgstr "Pretvori oznaku u ime datoteke"
 msgid "Copied debug info to clipboard."
 msgstr "Kopiraj digitalni otisak u međuspremnik"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopiraj digitalni otisak u međuspremnik"
 
@@ -468,8 +472,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -481,21 +485,21 @@ msgid "Custom"
 msgstr "Prilagođeno"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Prilagođena svojstva"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
@@ -508,21 +512,21 @@ msgstr "Izbriši oznaku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Brisanje oznaka …"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "opis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Opis"
 
@@ -542,23 +546,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Odbaci"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Odbaci"
 
@@ -572,10 +581,25 @@ msgstr "Odbaci neprimjenjene promjene"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Odbaci neprimjenjene promjene"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Spremanje oznaka …"
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "broj pjesama"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -603,26 +627,26 @@ msgstr "Preuzmi MusicBrainz metapodatke"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -695,6 +719,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "opis"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "izdavač"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "broj pjesama"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -715,7 +749,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "izdavač"
@@ -737,12 +771,12 @@ msgstr "broj pjesama"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -757,19 +791,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Izvezi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Izvezi stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
@@ -781,11 +815,11 @@ msgstr "Izvezi prednju sliku albuma"
 msgid "Export to LRC"
 msgstr "Izvezi"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
@@ -794,19 +828,19 @@ msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
@@ -823,9 +857,9 @@ msgstr "Ime datoteke"
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
@@ -842,28 +876,28 @@ msgstr "Ime datoteke u oznaku"
 msgid "File Path"
 msgstr "Staza do datoteke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Svojstva datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "ime datoteke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Digitalni otisak"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Digitalni otisak je kopiran u međuspremnik."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -873,29 +907,29 @@ msgstr ""
 msgid "Format"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Prednja strana"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "žanr"
 
@@ -916,19 +950,19 @@ msgstr "Nabavi novi API ključ"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -936,7 +970,7 @@ msgid "Help"
 msgstr "Pomoć"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -952,31 +986,31 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Umetni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Umetni stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Umetanje slike albuma …"
 
@@ -994,11 +1028,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1006,8 +1040,8 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1016,7 +1050,7 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr ""
 
@@ -1042,7 +1076,7 @@ msgstr ""
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
@@ -1061,13 +1095,13 @@ msgstr "Glazbena datoteka"
 msgid "Music Library"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "ID oznaka MusicBrainz snimke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
@@ -1076,24 +1110,24 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1102,21 +1136,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1126,12 +1160,12 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "No music files in library."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1140,7 +1174,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1165,11 +1199,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "U redu"
 
@@ -1186,8 +1220,8 @@ msgstr "U redu"
 msgid "On"
 msgstr "Otvori"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1195,8 +1229,8 @@ msgstr ""
 "AcoustID-u se može poslati samo jedna datoteka. Odaberi samo jednu datoteku "
 "i pokušaj ponovo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Otvori"
 
@@ -1207,7 +1241,7 @@ msgid "Open a library with music to get started"
 msgstr "Započni otvaranjem mape s glazbom"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1217,12 +1251,12 @@ msgstr "Započni otvaranjem mape s glazbom"
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 #, fuzzy
 msgid "Open Music File"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1257,10 +1291,10 @@ msgstr "Staza do datoteke"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1270,24 +1304,24 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "Oznake su uspješno spremljene."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Odaberi jedan format izraza."
 
@@ -1300,39 +1334,39 @@ msgstr "Sačuvaj vremensku oznaku modifikacije"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Izdavač"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "Ponovo učitaj mapu"
@@ -1345,20 +1379,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Ukloni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Ukloni"
@@ -1374,7 +1408,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Ukloni"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Umetanje slike albuma …"
@@ -1402,8 +1436,8 @@ msgstr "Spremi oznaku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
@@ -1422,27 +1456,27 @@ msgstr "Odaberi neke datoteke"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1456,43 +1490,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Redoslijed datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Pošalji"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Prikaži stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Prikaži prednju sliku albuma"
 
@@ -1506,9 +1540,9 @@ msgstr ""
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Oznaka u ime datoteke"
@@ -1518,9 +1552,8 @@ msgstr "Oznaka u ime datoteke"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Oznaka u ime datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označite svoju glazbu"
 
@@ -1529,9 +1562,8 @@ msgstr "Označite svoju glazbu"
 msgid "Tag Your Music"
 msgstr "Označi svoju glazbu"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1540,8 +1572,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1552,7 +1584,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1574,10 +1606,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "naslov"
 
@@ -1589,15 +1621,15 @@ msgstr "naslov"
 msgid "Title"
 msgstr "Naslov"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "pjesma"
 
@@ -1609,14 +1641,14 @@ msgstr "pjesma"
 msgid "Track"
 msgstr "Pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "broj pjesama"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
@@ -1637,16 +1669,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Neuspjelo učitavanje slikovne datoteke"
@@ -1663,30 +1695,30 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1695,7 +1727,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1709,8 +1741,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1740,18 +1772,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "godina"
 
@@ -1763,10 +1795,10 @@ msgstr "godina"
 msgid "Year"
 msgstr "Godina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1903,15 +1935,24 @@ msgstr "Odaberi neke datoteke"
 msgid "Track Total"
 msgstr "Broj pjesama"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Broj pjesama"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Uklj./Isklj. ploču oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Radnje oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
@@ -1919,44 +1960,27 @@ msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Oznaka;Glazba;Uređivač;Biblioteka;Fonoteka;Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"– Podrška za razne vrste glazbenih datoteka (mp3, ogg, flac, wma i wav)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "– Podrška za razne vrste glazbenih datoteka (mp3, ogg, flac, wma i wav)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"– Uredi oznake i omote albuma datoteka, čak i u podmapama, sve odjednom"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "– Uredi oznake i omote albuma datoteka, čak i u podmapama, sve odjednom"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "– Pretvori imena datoteka u oznake i oznake u imena datoteka"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "– Pretvori imena datoteka u oznake i oznake u imena datoteka"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,17 +20,25 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
@@ -38,63 +46,63 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%izvođač%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%naslov%- %izvođač%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<zadrži>"
 
@@ -102,13 +110,13 @@ msgstr "<zadrži>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, fuzzy, csharp-format
 msgid "About {0}"
 msgstr "Informacije"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -133,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "API ključ AcoustId korisnika"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #, fuzzy
 msgid "Add New Property"
 msgstr "Novo prilagođeno svojstvo"
@@ -155,28 +163,28 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "Add to Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Dodatna svojstva"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -185,27 +193,27 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Slika albuma"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Izvođač albuma"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "izvođač albuma"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 #, fuzzy
 msgid "All files"
 msgstr "Odaberi neke datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Odaberi neke datoteke"
@@ -214,66 +222,66 @@ msgstr "Odaberi neke datoteke"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "izvođač"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Izvođač"
 
@@ -285,70 +293,72 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Natrag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "BPM"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Odustani"
@@ -357,7 +367,7 @@ msgstr "Odustani"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -366,32 +376,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "komentar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Komentar"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "skladatelj"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Skladatelj"
 
@@ -400,23 +414,23 @@ msgstr "Skladatelj"
 msgid "Configure"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 "Nicholas Logozzo {0}\n"
 "Doprinositelji na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -424,7 +438,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -432,12 +446,12 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Pretvaranje imena datoteka u oznake …"
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Pretvori oznaku u ime datoteke"
@@ -447,8 +461,8 @@ msgstr "Pretvori oznaku u ime datoteke"
 msgid "Copied debug info to clipboard."
 msgstr "Kopiraj digitalni otisak u međuspremnik"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Kopiraj digitalni otisak u međuspremnik"
 
@@ -472,8 +486,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -484,22 +498,22 @@ msgstr "prilagođeno"
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Prilagođena svojstva"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 #, fuzzy
 msgid "David Lapshin"
 msgstr "David Lapshin {0}"
@@ -508,25 +522,25 @@ msgstr "David Lapshin {0}"
 msgid "Delete Tag"
 msgstr "Izbriši oznaku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Brisanje oznaka …"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "opis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Opis"
 
@@ -546,28 +560,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Odbaci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Odbaci"
 
@@ -576,77 +590,77 @@ msgstr "Odbaci"
 msgid "Discard Unapplied Changed"
 msgstr "Odbaci neprimjenjene promjene"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Odbaci neprimjenjene promjene"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Spremanje oznaka …"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "broj pjesama"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "Trajanje"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -683,29 +697,29 @@ msgstr ""
 "Aktiviraj prepisivanje postojećih metapodataka oznaka s MusicBrainz "
 "podacima. Ako je deaktivirano, popunit će se samo prazna svojstva oznake."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 #, fuzzy
 msgid "Enter album artist here"
 msgstr "izvođač albuma"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 #, fuzzy
 msgid "Enter beats per minute here"
 msgstr "broje otkucaja u minuti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -714,26 +728,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "opis"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "broj pjesama"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -749,34 +763,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "broj pjesama"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -790,20 +804,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Izvezi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Izvezi stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
@@ -815,11 +829,11 @@ msgstr "Izvezi prednju sliku albuma"
 msgid "Export to LRC"
 msgstr "Izvezi"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
@@ -828,19 +842,19 @@ msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
@@ -850,21 +864,21 @@ msgid "File"
 msgstr "Ime datoteke"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Ime datoteke u oznaku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Ime datoteke u oznaku"
@@ -876,28 +890,28 @@ msgstr "Ime datoteke u oznaku"
 msgid "File Path"
 msgstr "Staza do datoteke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Svojstva datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "ime datoteke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Digitalni otisak"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Digitalni otisak je kopiran u međuspremnik."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -907,37 +921,39 @@ msgstr ""
 msgid "Format"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Prednja strana"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "žanr"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Žanr"
 
@@ -950,27 +966,33 @@ msgstr "Nabavi novi API ključ"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Svijetla"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -986,31 +1008,37 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Umetni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Umetni stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Umetanje slike albuma …"
 
@@ -1028,11 +1056,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1040,8 +1068,8 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1050,39 +1078,44 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Glavna svojstva"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+msgid "Mime Type"
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1095,13 +1128,13 @@ msgstr "Glazbena datoteka"
 msgid "Music Library"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID oznaka MusicBrainz snimke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
@@ -1110,24 +1143,24 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1136,45 +1169,45 @@ msgstr ""
 msgid "No file selected"
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 #, fuzzy
 msgid "No music files in library."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1199,11 +1232,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "U redu"
 
@@ -1220,8 +1253,8 @@ msgstr "U redu"
 msgid "On"
 msgstr "Otvori"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1229,39 +1262,39 @@ msgstr ""
 "AcoustID-u se može poslati samo jedna datoteka. Odaberi samo jednu datoteku "
 "i pokušaj ponovo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otvori"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 #, fuzzy
 msgid "Open a library with music to get started"
 msgstr "Započni otvaranjem mape s glazbom"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 #, fuzzy
 msgid "Open Music File"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1291,10 +1324,10 @@ msgstr "Staza do datoteke"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1304,24 +1337,24 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "Oznake su uspješno spremljene."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Odaberi jedan format izraza."
 
@@ -1334,39 +1367,39 @@ msgstr "Sačuvaj vremensku oznaku modifikacije"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Ime svojstva"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Izdavač"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Izdavač"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "Ponovo učitaj mapu"
@@ -1378,21 +1411,21 @@ msgid "Reload Library"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Ukloni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Ukloni"
@@ -1408,12 +1441,12 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Ukloni"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Umetanje slike albuma …"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1426,18 +1459,18 @@ msgid "Save Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Spremi oznaku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
@@ -1446,8 +1479,8 @@ msgstr "Spremanje oznaka …"
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Odaberi neke datoteke"
 
@@ -1456,27 +1489,27 @@ msgstr "Odaberi neke datoteke"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1490,43 +1523,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Redoslijed datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Pošalji"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Prikaži stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Prikaži prednju sliku albuma"
 
@@ -1540,40 +1573,42 @@ msgstr ""
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Oznaka u ime datoteke"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Oznaka u ime datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Označite svoju glazbu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Označi svoju glazbu"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1584,7 +1619,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1606,54 +1641,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "naslov"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Naslov"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "pjesma"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Pjesma"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "broj pjesama"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 #, fuzzy
 msgid "Try a different library"
 msgstr "Pokušaj koristiti jednu drugu mapu"
@@ -1663,22 +1698,22 @@ msgstr "Pokušaj koristiti jednu drugu mapu"
 msgid "Type"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Neuspjelo učitavanje slikovne datoteke"
@@ -1695,30 +1730,30 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1727,7 +1762,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1741,8 +1776,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1751,10 +1786,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "Korisničko sučelje"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web usluge"
 
@@ -1765,6 +1800,11 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1772,33 +1812,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "godina"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Godina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1874,7 +1914,7 @@ msgid "Remove Front Album Art"
 msgstr "Ukloni prednju sliku albuma"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Zamijeni sliku albuma"
 
@@ -1905,54 +1945,54 @@ msgstr "Zatvori aplikaciju"
 msgid "About Tagger"
 msgstr "O aplikaciji Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Glavni izbornik"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 #, fuzzy
 msgid "Open Folder (Ctrl+O)"
 msgstr "Otvori mapu glazbe (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 #, fuzzy
 msgid "Select All Files"
 msgstr "Odaberi neke datoteke"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Broj pjesama"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Broj pjesama"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Uklj./Isklj. ploču oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Radnje oznaka"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
@@ -1960,27 +2000,44 @@ msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Oznaka;Glazba;Uređivač;Biblioteka;Fonoteka;Nickvision;"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
 #, fuzzy
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "– Podrška za razne vrste glazbenih datoteka (mp3, ogg, flac, wma i wav)"
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+"– Podrška za razne vrste glazbenih datoteka (mp3, ogg, flac, wma i wav)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "– Uredi oznake i omote albuma datoteka, čak i u podmapama, sve odjednom"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"– Uredi oznake i omote albuma datoteka, čak i u podmapama, sve odjednom"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr "– Pretvori imena datoteka u oznake i oznake u imena datoteka"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr "– Pretvori imena datoteka u oznake i oznake u imena datoteka"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
 #, fuzzy
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "– Pronađi informacije o datoteci koristeći MusicBrainz"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -62,26 +62,24 @@ msgstr "%naslov%- %izvođač%"
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -97,7 +95,9 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "koje su povezane s digitalnim otiskom."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "API ključ AcoustId korisnika"
 
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Izvođač albuma"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "izvođač albuma"
 
@@ -222,7 +222,7 @@ msgstr "Odaberi neke datoteke"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -271,9 +271,9 @@ msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "izvođač"
 
@@ -309,21 +309,21 @@ msgid "Beats Per Minute"
 msgstr "BPM"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -386,9 +386,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "komentar"
 
@@ -398,9 +398,9 @@ msgid "Comment"
 msgstr "Komentar"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "skladatelj"
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -438,7 +438,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -446,12 +446,12 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Pretvaranje imena datoteka u oznake …"
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Pretvori oznaku u ime datoteke"
@@ -487,7 +487,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -526,14 +526,14 @@ msgstr "Izbriši oznaku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Brisanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "opis"
 
@@ -595,22 +595,22 @@ msgstr "Odbaci neprimjenjene promjene"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Odbaci neprimjenjene promjene"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Spremanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "broj pjesama"
@@ -641,22 +641,22 @@ msgstr "Preuzmi MusicBrainz metapodatke"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
@@ -672,14 +672,14 @@ msgid "Edit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Aktiviraj prepisivanje postojeće slike albuma s pronađenom slikom na "
 "MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 #, fuzzy
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
@@ -689,7 +689,7 @@ msgstr ""
 "podacima. Ako je deaktivirano, popunit će se samo prazna svojstva oznake."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -785,12 +785,12 @@ msgstr "broj pjesama"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -829,11 +829,11 @@ msgstr "Izvezi prednju sliku albuma"
 msgid "Export to LRC"
 msgstr "Izvezi"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
@@ -850,11 +850,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
@@ -896,7 +896,7 @@ msgid "File Properties"
 msgstr "Svojstva datoteke"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "ime datoteke"
 
@@ -943,9 +943,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "žanr"
 
@@ -958,7 +958,7 @@ msgid "Genre"
 msgstr "Žanr"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Nabavi novi API ključ"
 
@@ -1038,7 +1038,7 @@ msgstr "Umetni stražnju sliku albuma"
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Umetanje slike albuma …"
 
@@ -1056,11 +1056,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1068,8 +1068,8 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1078,7 +1078,7 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1175,15 +1175,15 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "No files selected for removal."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1193,12 +1193,12 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "No music files in library."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1299,17 +1299,17 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Prepiši sliku albuma s MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Prepiši oznaku s MusicBrainz"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "Oznake su uspješno spremljene."
@@ -1347,7 +1347,7 @@ msgstr "Oznake su uspješno spremljene."
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1373,9 +1373,9 @@ msgid "Property Name"
 msgstr "Ime svojstva"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "izdavač"
 
@@ -1391,9 +1391,9 @@ msgid "Publishing Date"
 msgstr "Izdavač"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "izdavač"
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Ukloni"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Umetanje slike albuma …"
@@ -1469,8 +1469,8 @@ msgstr "Spremi oznaku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
@@ -1536,11 +1536,11 @@ msgstr "Pošalji"
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1642,9 +1642,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "naslov"
 
@@ -1662,9 +1662,9 @@ msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "pjesma"
 
@@ -1677,9 +1677,9 @@ msgid "Track"
 msgstr "Pjesma"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -1704,16 +1704,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Neuspjelo učitavanje slikovne datoteke"
@@ -1730,30 +1730,30 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1788,7 +1788,7 @@ msgstr "Korisničko sučelje"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web usluge"
@@ -1821,9 +1821,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "godina"
 
@@ -1879,6 +1879,14 @@ msgstr "Zapamti zadnju otvorenu mapu"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Uključi podmape"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 #, fuzzy

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -25,8 +25,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -62,34 +62,24 @@ msgstr "%naslov%- %izvođač%"
 msgid "%track%- %title%"
 msgstr "%pjesma%- %naslov%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -97,9 +87,19 @@ msgstr "%pjesma%- %naslov%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -115,7 +115,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Informacije"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "API ključ AcoustId korisnika"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Informacije napredne pretrage"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Izvođač albuma"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "izvođač albuma"
 
@@ -212,8 +212,8 @@ msgstr "izvođač albuma"
 msgid "All files"
 msgstr "Odaberi neke datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Odaberi neke datoteke"
@@ -222,18 +222,18 @@ msgstr "Odaberi neke datoteke"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -250,14 +250,14 @@ msgstr ""
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -271,9 +271,9 @@ msgid "Apply Changes?"
 msgstr "Primijeniti promjene?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "izvođač"
 
@@ -294,8 +294,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -309,40 +309,40 @@ msgid "Beats Per Minute"
 msgstr "BPM"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -386,9 +386,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "komentar"
 
@@ -398,9 +398,9 @@ msgid "Comment"
 msgstr "Komentar"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "skladatelj"
 
@@ -421,8 +421,8 @@ msgstr ""
 "Nicholas Logozzo {0}\n"
 "Doprinositelji na GitHubu ❤️ {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -438,7 +438,7 @@ msgstr[0] "{0} ime datoteke uspješno pretvoreno u oznaku"
 msgstr[1] "{0} imena datoteka uspješno pretvorena u oznaku"
 msgstr[2] "{0} imena datoteka uspješno pretvorena u oznaku"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -446,12 +446,12 @@ msgstr[0] "{0} oznaka uspješno pretvorena u ime datoteke"
 msgstr[1] "{0} oznake uspješno pretvorene u imena datoteka"
 msgstr[2] "{0} oznaka uspješno pretvorena u imena datoteka"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Pretvaranje imena datoteka u oznake …"
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Pretvori oznaku u ime datoteke"
@@ -487,7 +487,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "prilagođeno"
 
@@ -526,14 +526,14 @@ msgstr "Izbriši oznaku"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Brisanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "opis"
 
@@ -565,14 +565,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Odbaci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -595,22 +595,22 @@ msgstr "Odbaci neprimjenjene promjene"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Odbaci neprimjenjene promjene"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Spremanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "broj pjesama"
@@ -641,22 +641,22 @@ msgstr "Preuzmi MusicBrainz metapodatke"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Preuzmi MusicBrainz metapodatke"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Uspješno preuzeti metapodaci za {0} datoteke(a)"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Preuzmi MusicBrainz metapodatke …"
 
@@ -785,12 +785,12 @@ msgstr "broj pjesama"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -812,12 +812,12 @@ msgstr ""
 msgid "Export"
 msgstr "Izvezi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Izvezi stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
@@ -829,11 +829,11 @@ msgstr "Izvezi prednju sliku albuma"
 msgid "Export to LRC"
 msgstr "Izvezi"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Stražnja slika albuma je uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
@@ -846,15 +846,15 @@ msgstr ""
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Stražnja slika albuma nije uspješno izvezena u datoteku"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Prednja slika albuma nije uspješno izvezena u datoteku"
 
@@ -871,7 +871,7 @@ msgstr "Ime datoteke"
 msgid "File Name"
 msgstr "Ime datoteke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -896,7 +896,7 @@ msgid "File Properties"
 msgstr "Svojstva datoteke"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "ime datoteke"
 
@@ -905,12 +905,12 @@ msgstr "ime datoteke"
 msgid "Fingerprint"
 msgstr "Digitalni otisak"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Digitalni otisak je kopiran u međuspremnik."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -921,16 +921,16 @@ msgstr ""
 msgid "Format"
 msgstr "Format izraza"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Format izraza"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -943,9 +943,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "žanr"
 
@@ -966,7 +966,7 @@ msgstr "Nabavi novi API ključ"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
@@ -977,9 +977,9 @@ msgstr "GitHub repozitorij"
 msgid "Height"
 msgstr "Svijetla"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1028,17 +1028,17 @@ msgstr ""
 msgid "Insert"
 msgstr "Umetni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Umetni stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Umetni prednju sliku albuma"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Umetanje slike albuma …"
 
@@ -1056,11 +1056,11 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1068,8 +1068,8 @@ msgstr[0] "Učitana je {0} glazbena datoteka."
 msgstr[1] "Učitane su {0} glazbene datoteke."
 msgstr[2] "Učitano je {0} glazbenih datoteka."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1078,7 +1078,7 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr ""
 
@@ -1092,6 +1092,10 @@ msgstr ""
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Glavna svojstva"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1128,12 +1132,12 @@ msgstr "Glazbena datoteka"
 msgid "Music Library"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID oznaka MusicBrainz snimke"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
@@ -1143,7 +1147,7 @@ msgstr "Novo prilagođeno svojstvo"
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1152,15 +1156,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1169,21 +1173,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
@@ -1193,12 +1197,12 @@ msgstr "Učitavanje glazbenih datoteka iz mape …"
 msgid "No Music Files Found"
 msgstr "Nijedna glazbena datoteka nije pronađena"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 #, fuzzy
 msgid "No music files in library."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1207,7 +1211,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nijedna glazbena datoteka nije odabrana"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1232,7 +1236,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1253,7 +1257,7 @@ msgstr "U redu"
 msgid "On"
 msgstr "Otvori"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1262,7 +1266,7 @@ msgstr ""
 "AcoustID-u se može poslati samo jedna datoteka. Odaberi samo jednu datoteku "
 "i pokušaj ponovo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otvori"
@@ -1274,7 +1278,7 @@ msgid "Open a library with music to get started"
 msgstr "Započni otvaranjem mape s glazbom"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1284,12 +1288,12 @@ msgstr "Započni otvaranjem mape s glazbom"
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 #, fuzzy
 msgid "Open Music File"
 msgstr "Glazbena datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1324,8 +1328,8 @@ msgstr "Staza do datoteke"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1337,22 +1341,22 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "Oznake su uspješno spremljene."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1367,15 +1371,15 @@ msgstr "Sačuvaj vremensku oznaku modifikacije"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Ime svojstva"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "izdavač"
 
@@ -1391,14 +1395,14 @@ msgid "Publishing Date"
 msgstr "Izdavač"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "izdavač"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1419,12 +1423,12 @@ msgstr ""
 msgid "Remove"
 msgstr "Ukloni"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Ukloni prilagođeno svojstvo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
@@ -1441,7 +1445,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Ukloni"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Umetanje slike albuma …"
@@ -1469,8 +1473,8 @@ msgstr "Spremi oznaku"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Primijeni promjene na oznaku (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Spremanje oznaka …"
 
@@ -1493,14 +1497,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1523,12 +1527,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Redoslijed datoteka"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Pošalji"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1536,15 +1540,15 @@ msgstr "Pošalji"
 msgid "Submit to AcoustId"
 msgstr "Pošalji AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Metapodaci su uspješno poslani AcoustId-u"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Slanje metapodatka AcoustId-u …"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1555,7 +1559,7 @@ msgstr "Slanje metapodatka AcoustId-u …"
 msgid "Switch to Back Cover"
 msgstr "Prikaži stražnju sliku albuma"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1573,7 +1577,7 @@ msgstr ""
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1607,7 +1611,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1619,7 +1623,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1642,9 +1646,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "naslov"
 
@@ -1656,15 +1660,15 @@ msgstr "naslov"
 msgid "Title"
 msgstr "Naslov"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Odabrano je previše datoteka"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "pjesma"
 
@@ -1677,9 +1681,9 @@ msgid "Track"
 msgstr "Pjesma"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -1704,16 +1708,16 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Traži ime datoteke (utipkaj ! za aktiviranje napredne pretrage) …"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 #, fuzzy
 msgid "Unable to create playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Neuspjelo učitavanje slikovne datoteke"
@@ -1730,30 +1734,30 @@ msgstr "Neuspjelo spremanje datoteke {0}."
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 #, fuzzy
 msgid "Unable to remove some files from playlist."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Neuspjelo spremanje datoteke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Neuspjelo spremanje datoteke {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Neuspjelo slanje AcoustId-u. Provjeri API ključ"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1776,7 +1780,7 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1812,7 +1816,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1821,9 +1825,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "godina"
 
@@ -1835,8 +1839,8 @@ msgstr "godina"
 msgid "Year"
 msgstr "Godina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -61,26 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "metadati associati all'impronta di questo brano."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "Chiave delle API di AcoustId dell'utente"
 
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Artista dell'album"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "artistaalbum"
 
@@ -222,7 +222,7 @@ msgstr "Tutti i file"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un RecordingId non valido a MusicBrainz"
 
@@ -271,9 +271,9 @@ msgid "Apply Changes?"
 msgstr "Applicare le modifiche?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artista"
 
@@ -309,21 +309,21 @@ msgid "Beats Per Minute"
 msgstr "Battiti al minuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -386,9 +386,9 @@ msgid "Close Library"
 msgstr "Chiudi la libreria"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "commento"
 
@@ -398,9 +398,9 @@ msgid "Comment"
 msgstr "Commento"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "compositore"
 
@@ -427,26 +427,26 @@ msgstr "I collaboratori su GitHub ❤️"
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file convertito con successo"
 msgstr[1] "{0} nomi di file convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta convertita in nome di file con successo"
 msgstr[1] "{0} etichette convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Converti il nome del file in etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Converti l'etichetta nel nome del file"
@@ -482,7 +482,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -523,15 +523,15 @@ msgstr "Elimina le etichette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "descrizione"
 
@@ -593,21 +593,21 @@ msgstr "Annulla le modifiche non applicate"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Annulla le modifiche non applicate"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Cancellazione delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "traccetotali"
@@ -638,21 +638,21 @@ msgstr "Scarica i metadati da MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Testi per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadati per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Scaricamento dei testi in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Scaricamento dei metadati da MusicBrainz in corso…"
 
@@ -668,14 +668,14 @@ msgid "Edit"
 msgstr "Modifica"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Abilita la sovrascrittura delle copertine esistenti con quelle trovate su "
 "MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -684,7 +684,7 @@ msgstr ""
 "disabilitato verranno riempiti solamente i campi vuoti."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -780,12 +780,12 @@ msgstr "traccetotali"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -823,11 +823,11 @@ msgstr "Esporta copertina (fronte)"
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
@@ -845,12 +845,12 @@ msgstr "Controllo su MusicBrainz non riuscito"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina anteriore"
@@ -892,7 +892,7 @@ msgid "File Properties"
 msgstr "Proprietà del file"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "nomefile"
 
@@ -938,9 +938,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "genere"
 
@@ -953,7 +953,7 @@ msgid "Genre"
 msgstr "Genere"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Ottieni una nuova chiave per le API"
 
@@ -1032,7 +1032,7 @@ msgstr "Inserisci copertina posteriore"
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Inserimento della copertina..."
 
@@ -1050,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Codice della lingua"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Caricato {0} brano."
 msgstr[1] "Caricati {0} brani."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Caricamento dei brani dalla libreria…"
 
@@ -1070,7 +1070,7 @@ msgstr "Caricamento dei brani dalla libreria…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "testo"
 
@@ -1136,7 +1136,7 @@ msgstr "Nuova proprietà personalizzata"
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1153,7 +1153,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 
@@ -1167,15 +1167,15 @@ msgstr "Nessun brano selezionato."
 msgid "No files selected for removal."
 msgstr "Nessun file selezionato per la rimozione."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Nessun testo scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Nessun brano selezionato."
 
@@ -1184,11 +1184,11 @@ msgstr "Nessun brano selezionato."
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "Nessun brano nella libreria."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1288,17 +1288,17 @@ msgid "Open Playlist"
 msgstr "Apri playlist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Sovrascrivi la copertina con MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Sovrascrivi testo con servizio in rete"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Sovrascrivi i tag con With MusicBrainz"
 
@@ -1327,7 +1327,7 @@ msgstr ""
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "File della playlist creato con successo."
 
@@ -1337,7 +1337,7 @@ msgstr "File della playlist creato con successo."
 msgid "Playlist Mode"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Il nome della playlist non può essere vuoto."
@@ -1364,9 +1364,9 @@ msgid "Property Name"
 msgstr "Nome della proprietà"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "etichetta"
 
@@ -1382,9 +1382,9 @@ msgid "Publishing Date"
 msgstr "Etichetta"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "etichetta"
@@ -1430,7 +1430,7 @@ msgstr "Rimuovi dalla playlist"
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Inserimento della copertina..."
@@ -1459,8 +1459,8 @@ msgstr "Salva le etichette"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
@@ -1525,11 +1525,11 @@ msgstr "Invia"
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso…"
 
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Questo file non ha un'impronta valida"
 
@@ -1633,9 +1633,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "titolo"
 
@@ -1653,9 +1653,9 @@ msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "traccia"
 
@@ -1668,9 +1668,9 @@ msgid "Track"
 msgstr "Numero della traccia"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -1696,17 +1696,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Cerca un brano (inserire ! per attivare la ricerca avanzata)…"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Aggiunta del file alla playlist non riuscita. Il file potrebbe essere già "
 "contenuto in essa."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Creazione della playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Caricamento del file immagine non riuscito"
@@ -1721,30 +1721,30 @@ msgstr "Esportazione in LRC non riuscita."
 msgid "Unable to import from LRC."
 msgstr "Importazione da LRC non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Caricamento del file immagine non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Rimozione di alcuni file dalla playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Salvataggio di {0} non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Salvataggio di {0} non riuscito."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 "Invio dei dati ad AcoustId non riuscito. Controllare la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1779,7 +1779,7 @@ msgstr "Interfaccia utente"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Servizi in rete"
@@ -1814,9 +1814,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "anno"
 
@@ -1871,6 +1871,14 @@ msgstr "Memorizza l'ultima libreria aperta"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Includi le sottocartelle"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "Chiave delle API di AcoustId dell'utente"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Artista dell'album"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "artistaalbum"
 
@@ -212,8 +212,8 @@ msgstr "artistaalbum"
 msgid "All files"
 msgstr "Seleziona tutti i file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Tutti i file"
@@ -222,18 +222,18 @@ msgstr "Tutti i file"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un RecordingId non valido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -250,14 +250,14 @@ msgstr "È stato fornito un RecordingId non valido a MusicBrainz"
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -271,9 +271,9 @@ msgid "Apply Changes?"
 msgstr "Applicare le modifiche?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artista"
 
@@ -294,8 +294,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -309,40 +309,40 @@ msgid "Beats Per Minute"
 msgstr "Battiti al minuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Elaborazione in corso…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -386,9 +386,9 @@ msgid "Close Library"
 msgstr "Chiudi la libreria"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "commento"
 
@@ -398,9 +398,9 @@ msgid "Comment"
 msgstr "Commento"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "compositore"
 
@@ -418,8 +418,8 @@ msgstr "Configura"
 msgid "Contributors on GitHub ❤️"
 msgstr "I collaboratori su GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -427,26 +427,26 @@ msgstr "I collaboratori su GitHub ❤️"
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file convertito con successo"
 msgstr[1] "{0} nomi di file convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta convertita in nome di file con successo"
 msgstr[1] "{0} etichette convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Converti il nome del file in etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Converti l'etichetta nel nome del file"
@@ -482,7 +482,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -523,15 +523,15 @@ msgstr "Elimina le etichette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "descrizione"
 
@@ -563,14 +563,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Scarta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -593,21 +593,21 @@ msgstr "Annulla le modifiche non applicate"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Annulla le modifiche non applicate"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Cancellazione delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "traccetotali"
@@ -638,21 +638,21 @@ msgstr "Scarica i metadati da MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Testi per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadati per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Scaricamento dei testi in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Scaricamento dei metadati da MusicBrainz in corso…"
 
@@ -780,12 +780,12 @@ msgstr "traccetotali"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -807,12 +807,12 @@ msgstr ""
 msgid "Export"
 msgstr "Esporta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Esporta copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
@@ -823,11 +823,11 @@ msgstr "Esporta copertina (fronte)"
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
@@ -841,16 +841,16 @@ msgstr "Esportazione completata con successo su: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina anteriore"
@@ -868,7 +868,7 @@ msgstr "Nome del file"
 msgid "File Name"
 msgstr "Nome del file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -892,7 +892,7 @@ msgid "File Properties"
 msgstr "Proprietà del file"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "nomefile"
 
@@ -901,12 +901,12 @@ msgstr "nomefile"
 msgid "Fingerprint"
 msgstr "Impronta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Impronta copiata negli appunti."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -916,16 +916,16 @@ msgstr ""
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formatta stringa"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -938,9 +938,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "genere"
 
@@ -961,7 +961,7 @@ msgstr "Ottieni una nuova chiave per le API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
@@ -972,9 +972,9 @@ msgstr "Repository GitHub"
 msgid "Height"
 msgstr "Chiaro"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -1002,7 +1002,7 @@ msgstr "Importa da LRC"
 msgid "Include Only Selected Files"
 msgstr "Includi solo i file selezionati"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1022,17 +1022,17 @@ msgstr "Info"
 msgid "Insert"
 msgstr "Inserisci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Inserisci copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Inserimento della copertina..."
 
@@ -1050,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Codice della lingua"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Caricato {0} brano."
 msgstr[1] "Caricati {0} brani."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Caricamento dei brani dalla libreria…"
 
@@ -1070,7 +1070,7 @@ msgstr "Caricamento dei brani dalla libreria…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "testo"
 
@@ -1084,6 +1084,10 @@ msgstr "Testo"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Proprietà principali"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1121,12 +1125,12 @@ msgstr "Brano"
 msgid "Music Library"
 msgstr "Libreria musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
@@ -1136,7 +1140,7 @@ msgstr "Nuova proprietà personalizzata"
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1145,15 +1149,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 
@@ -1162,20 +1166,20 @@ msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 msgid "No file selected"
 msgstr "Nessun brano selezionato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Nessun file selezionato per la rimozione."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Nessun testo scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Nessun brano selezionato."
 
@@ -1184,11 +1188,11 @@ msgstr "Nessun brano selezionato."
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "Nessun brano nella libreria."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
@@ -1198,7 +1202,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1223,7 +1227,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Offset (in millisecondi)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1244,7 +1248,7 @@ msgstr "OK"
 msgid "On"
 msgstr "Apri"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1253,7 +1257,7 @@ msgstr ""
 "È possibile inviare solamente un brano per volta ad AcoustId. Selezionare un "
 "solo brano ed inviare nuovamente i dati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Apri"
@@ -1264,7 +1268,7 @@ msgid "Open a library with music to get started"
 msgstr "Aprire una libreria musicale per iniziare"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1274,11 +1278,11 @@ msgstr "Aprire una libreria musicale per iniziare"
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Apri brano"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1314,8 +1318,8 @@ msgstr "Percorso del file"
 msgid "Path (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1327,23 +1331,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "File della playlist creato con successo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Il nome della playlist non può essere vuoto."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1358,15 +1362,15 @@ msgstr "Mantieni l'istante temporale di modifica"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "etichetta"
 
@@ -1382,14 +1386,14 @@ msgid "Publishing Date"
 msgstr "Etichetta"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1410,12 +1414,12 @@ msgstr "Ricarica la libreria"
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Rimuovere i file?"
@@ -1430,7 +1434,7 @@ msgstr "Rimuovi dalla playlist"
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Inserimento della copertina..."
@@ -1459,8 +1463,8 @@ msgstr "Salva le etichette"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
@@ -1483,14 +1487,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1512,12 +1516,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordina file per"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Invia"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1525,15 +1529,15 @@ msgstr "Invia"
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1544,7 +1548,7 @@ msgstr "Invio dei dati ad AcoustId in corso…"
 msgid "Switch to Back Cover"
 msgstr "Passa alla copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1562,7 +1566,7 @@ msgstr "Sincronizzato"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1596,7 +1600,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1610,7 +1614,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Questo file non ha un'impronta valida"
 
@@ -1633,9 +1637,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "titolo"
 
@@ -1647,15 +1651,15 @@ msgstr "titolo"
 msgid "Title"
 msgstr "Titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "traccia"
 
@@ -1668,9 +1672,9 @@ msgid "Track"
 msgstr "Numero della traccia"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -1696,17 +1700,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Cerca un brano (inserire ! per attivare la ricerca avanzata)…"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Aggiunta del file alla playlist non riuscita. Il file potrebbe essere già "
 "contenuto in essa."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Creazione della playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Caricamento del file immagine non riuscito"
@@ -1721,30 +1725,30 @@ msgstr "Esportazione in LRC non riuscita."
 msgid "Unable to import from LRC."
 msgstr "Importazione da LRC non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Caricamento del file immagine non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Rimozione di alcuni file dalla playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Salvataggio di {0} non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Salvataggio di {0} non riuscito."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 "Invio dei dati ad AcoustId non riuscito. Controllare la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1767,7 +1771,7 @@ msgstr "Usa il testo da LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1805,7 +1809,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1814,9 +1818,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "anno"
 
@@ -1828,8 +1832,8 @@ msgstr "anno"
 msgid "Year"
 msgstr "Anno"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} di {1} selezionati"
@@ -37,63 +37,67 @@ msgstr "{0} di {1} selezionati"
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<tieni>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "Chiave delle API di AcoustId dell'utente"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 #, fuzzy
 msgid "Add New Property"
 msgstr "Nuova proprietà personalizzata"
@@ -152,7 +156,7 @@ msgid "Add to Playlist"
 msgstr "Aggiungi alla playlist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Proprietà aggiuntive"
 
@@ -161,10 +165,10 @@ msgstr "Proprietà aggiuntive"
 msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -186,22 +190,22 @@ msgstr "Copertina"
 msgid "Album Artist"
 msgstr "Artista dell'album"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "artistaalbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 #, fuzzy
 msgid "All files"
 msgstr "Seleziona tutti i file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Tutti i file"
@@ -210,58 +214,58 @@ msgstr "Tutti i file"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un RecordingId non valido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artista"
 
@@ -281,70 +285,70 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Indietro"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Battiti al minuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Elaborazione in corso…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annulla"
@@ -367,27 +371,27 @@ msgstr "Cancella tutto il testo"
 msgid "Close Library"
 msgstr "Chiudi la libreria"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "commento"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Commento"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "compositore"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Compositore"
 
@@ -396,39 +400,39 @@ msgstr "Compositore"
 msgid "Configure"
 msgstr "Configura"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "I collaboratori su GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file convertito con successo"
 msgstr[1] "{0} nomi di file convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta convertita in nome di file con successo"
 msgstr[1] "{0} etichette convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Converti il nome del file in etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Converti l'etichetta nel nome del file"
@@ -438,8 +442,8 @@ msgstr "Converti l'etichetta nel nome del file"
 msgid "Copied debug info to clipboard."
 msgstr "Copia l'impronta negli appunti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copia l'impronta negli appunti"
 
@@ -463,8 +467,8 @@ msgstr "Crea playlist"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -476,23 +480,23 @@ msgid "Custom"
 msgstr "Personalizzato"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Proprietà personalizzate"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Le proprietà personalizzate possono essere modificate solo un file alla "
 "volta."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -505,22 +509,22 @@ msgstr "Elimina le etichette"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "descrizione"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Descrizione"
 
@@ -540,23 +544,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Scarta"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Scarta"
 
@@ -570,9 +579,24 @@ msgstr "Annulla le modifiche non applicate"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Annulla le modifiche non applicate"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Cancellazione delle etichette in corso…"
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "traccetotali"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -600,25 +624,25 @@ msgstr "Scarica i metadati da MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Testi per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadati per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Scaricamento dei testi in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Scaricamento dei metadati da MusicBrainz in corso…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -690,6 +714,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "descrizione"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "etichetta"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "traccetotali"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -710,7 +744,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "etichetta"
@@ -732,12 +766,12 @@ msgstr "traccetotali"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -752,19 +786,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Esporta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Esporta copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
@@ -775,11 +809,11 @@ msgstr "Esporta copertina (fronte)"
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
@@ -788,21 +822,21 @@ msgstr "La copertina anteriore è stata esportata correttamente"
 msgid "Exported successfully to: {0}"
 msgstr "Esportazione completata con successo su: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 #, fuzzy
 msgid "Failed MusicBrainz Lookup"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina anteriore"
@@ -820,9 +854,9 @@ msgstr "Nome del file"
 msgid "File Name"
 msgstr "Nome del file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Da nome del file ad etichetta"
@@ -838,28 +872,28 @@ msgstr "Da nome del file ad etichetta"
 msgid "File Path"
 msgstr "Percorso del file"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Proprietà del file"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "nomefile"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Impronta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Impronta copiata negli appunti."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -868,29 +902,29 @@ msgstr ""
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Formatta stringa"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Fronte"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "genere"
 
@@ -911,19 +945,19 @@ msgstr "Ottieni una nuova chiave per le API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -931,7 +965,7 @@ msgid "Help"
 msgstr "Aiuto"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -946,31 +980,31 @@ msgstr "Importa da LRC"
 msgid "Include Only Selected Files"
 msgstr "Includi solo i file selezionati"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Inserisci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Inserisci copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Inserimento della copertina..."
 
@@ -988,19 +1022,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Codice della lingua"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Caricato {0} brano."
 msgstr[1] "Caricati {0} brani."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Caricamento dei brani dalla libreria…"
 
@@ -1008,7 +1042,7 @@ msgstr "Caricamento dei brani dalla libreria…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "testo"
 
@@ -1035,7 +1069,7 @@ msgstr "Gestisci testo"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gestisci testo"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
@@ -1053,13 +1087,13 @@ msgstr "Brano"
 msgid "Music Library"
 msgstr "Libreria musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
@@ -1068,24 +1102,24 @@ msgstr "Nuova proprietà personalizzata"
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 
@@ -1094,20 +1128,20 @@ msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 msgid "No file selected"
 msgstr "Nessun brano selezionato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Nessun file selezionato per la rimozione."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Nessun testo scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Nessun brano selezionato."
 
@@ -1116,11 +1150,11 @@ msgstr "Nessun brano selezionato."
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "Nessun brano nella libreria."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
@@ -1130,7 +1164,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1155,11 +1189,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Offset (in millisecondi)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1176,8 +1210,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Apri"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1185,8 +1219,8 @@ msgstr ""
 "È possibile inviare solamente un brano per volta ad AcoustId. Selezionare un "
 "solo brano ed inviare nuovamente i dati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Apri"
 
@@ -1196,7 +1230,7 @@ msgid "Open a library with music to get started"
 msgstr "Aprire una libreria musicale per iniziare"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1206,11 +1240,11 @@ msgstr "Aprire una libreria musicale per iniziare"
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Apri brano"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1246,10 +1280,10 @@ msgstr "Percorso del file"
 msgid "Path (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1259,25 +1293,25 @@ msgstr ""
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "File della playlist creato con successo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Il nome della playlist non può essere vuoto."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Seleziona un formato."
 
@@ -1290,39 +1324,39 @@ msgstr "Mantieni l'istante temporale di modifica"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "Ricarica la cartella"
@@ -1335,20 +1369,20 @@ msgstr "Ricarica la libreria"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Rimuovere i file?"
 
@@ -1362,7 +1396,7 @@ msgstr "Rimuovi dalla playlist"
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Inserimento della copertina..."
@@ -1391,8 +1425,8 @@ msgstr "Salva le etichette"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
@@ -1411,27 +1445,27 @@ msgstr "Selezionare alcuni file"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1444,43 +1478,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordina file per"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Invia"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Passa alla copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Passa alla copertina anteriore"
 
@@ -1494,9 +1528,9 @@ msgstr "Sincronizzato"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Da etichetta a nome di file"
@@ -1506,9 +1540,8 @@ msgstr "Da etichetta a nome di file"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Da etichetta a nome di file"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associa un'etichetta ai tuoi brani"
 
@@ -1517,9 +1550,8 @@ msgstr "Associa un'etichetta ai tuoi brani"
 msgid "Tag Your Music"
 msgstr "Etichetta la tua musica"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1528,8 +1560,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1542,7 +1574,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Questo file non ha un'impronta valida"
 
@@ -1564,10 +1596,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "titolo"
 
@@ -1579,15 +1611,15 @@ msgstr "titolo"
 msgid "Title"
 msgstr "Titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "traccia"
 
@@ -1599,14 +1631,14 @@ msgstr "traccia"
 msgid "Track"
 msgstr "Numero della traccia"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "traccetotali"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr ""
 "Federico Marchetti\n"
@@ -1628,17 +1660,17 @@ msgstr "Tipo"
 msgid "Type ! for advanced search"
 msgstr "Cerca un brano (inserire ! per attivare la ricerca avanzata)…"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Aggiunta del file alla playlist non riuscita. Il file potrebbe essere già "
 "contenuto in essa."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Creazione della playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Caricamento del file immagine non riuscito"
@@ -1653,30 +1685,30 @@ msgstr "Esportazione in LRC non riuscita."
 msgid "Unable to import from LRC."
 msgstr "Importazione da LRC non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Caricamento del file immagine non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Rimozione di alcuni file dalla playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Salvataggio di {0} non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Salvataggio di {0} non riuscito."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 "Invio dei dati ad AcoustId non riuscito. Controllare la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1685,7 +1717,7 @@ msgstr "Sconosciuto"
 msgid "Unsynchronized"
 msgstr "Non sincronizzato"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1699,8 +1731,8 @@ msgstr "Usa il testo da LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1732,18 +1764,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "anno"
 
@@ -1755,10 +1787,10 @@ msgstr "anno"
 msgid "Year"
 msgstr "Anno"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Sì"
@@ -1891,15 +1923,24 @@ msgstr "Seleziona tutti i file"
 msgid "Track Total"
 msgstr "Totale delle tracce"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Totale delle tracce"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Mostra/Nascondi il pannello delle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Azioni sulle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
@@ -1908,47 +1949,41 @@ msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr ""
 "Tag;Music;Editor;Library;Musica;Etichetta;Etichette;Libreria;Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Supporta vari tipi di file musicali (mp3, ogg, flac, wma, wav ed altri)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Supporta vari tipi di file musicali (mp3, ogg, flac, wma, wav ed altri)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Modifica etichette e copertine di più brani allo stesso tempo, anche tra "
-"sottocartelle"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Modifica etichette e copertine di più brani allo stesso tempo, anche "
+#~ "tra sottocartelle"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Modifica il testo sincronizzato o non sincronizzato di un file (con "
-"supporto per l'esportazione e l'importazione di LRC)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Modifica il testo sincronizzato o non sincronizzato di un file (con "
+#~ "supporto per l'esportazione e l'importazione di LRC)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-"— Converte nomi di file in etichette e etichette in nomi file con semplicità"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr ""
+#~ "— Converte nomi di file in etichette e etichette in nomi file con "
+#~ "semplicità"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Controlla le informazioni dei brani con MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Controlla le informazioni dei brani con MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Controlla le informazioni sui testi con Music163 e Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Controlla le informazioni sui testi con Music163 e Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Apre, gestisce e crea playlist in vari formati (m3u, pls, xspf, e altri)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Apre, gestisce e crea playlist in vari formati (m3u, pls, xspf, e altri)"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,81 +19,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} di {1} selezionati"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<tieni>"
 
@@ -101,13 +109,13 @@ msgstr "<tieni>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -133,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "Chiave delle API di AcoustId dell'utente"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #, fuzzy
 msgid "Add New Property"
 msgstr "Nuova proprietà personalizzata"
@@ -155,28 +163,28 @@ msgstr "Nuova proprietà personalizzata"
 msgid "Add to Playlist"
 msgstr "Aggiungi alla playlist"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Proprietà aggiuntive"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Informazioni sulla ricerca avanzata"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -185,27 +193,27 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Copertina"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Artista dell'album"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "artistaalbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 #, fuzzy
 msgid "All files"
 msgstr "Seleziona tutti i file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Tutti i file"
@@ -214,66 +222,66 @@ msgstr "Tutti i file"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "È stato fornito un RecordingId non valido a MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Applicare le modifiche?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artista"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Artista"
 
@@ -285,70 +293,72 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Indietro"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Battiti al minuto"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Elaborazione in corso…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annulla"
@@ -357,7 +367,7 @@ msgstr "Annulla"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -366,32 +376,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr "Cancella tutto il testo"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Chiudi la libreria"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "commento"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Commento"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "compositore"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Compositore"
 
@@ -400,39 +414,39 @@ msgstr "Compositore"
 msgid "Configure"
 msgstr "Configura"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "I collaboratori su GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Converti"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} nome di file convertito con successo"
 msgstr[1] "{0} nomi di file convertiti con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etichetta convertita in nome di file con successo"
 msgstr[1] "{0} etichette convertite in nomi di file con successo"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Converti il nome del file in etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Converti l'etichetta nel nome del file"
@@ -442,8 +456,8 @@ msgstr "Converti l'etichetta nel nome del file"
 msgid "Copied debug info to clipboard."
 msgstr "Copia l'impronta negli appunti"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Copia l'impronta negli appunti"
 
@@ -467,8 +481,8 @@ msgstr "Crea playlist"
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "personalizzato/a"
 
@@ -479,24 +493,24 @@ msgstr "personalizzato/a"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Proprietà personalizzate"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Le proprietà personalizzate possono essere modificate solo un file alla "
 "volta."
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -505,26 +519,26 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Elimina le etichette"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 #, fuzzy
 msgid "Deleting tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "descrizione"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Descrizione"
 
@@ -544,28 +558,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Scarta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Scarta"
 
@@ -574,75 +588,75 @@ msgstr "Scarta"
 msgid "Discard Unapplied Changed"
 msgstr "Annulla le modifiche non applicate"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Annulla le modifiche non applicate"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Cancellazione delle etichette in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "traccetotali"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "Durata"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Scarica testo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Scarica i metadati da MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Testi per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Metadati per {0} scaricati con successo"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Scaricamento dei testi in corso…"
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Scaricamento dei metadati da MusicBrainz in corso…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -678,29 +692,29 @@ msgstr ""
 "Abilita la sovrascrittura dei metadati esistenti con quelli trovati su "
 "MusicBrainz. Se disabilitato verranno riempiti solamente i campi vuoti."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 #, fuzzy
 msgid "Enter album artist here"
 msgstr "artistaalbum"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 #, fuzzy
 msgid "Enter beats per minute here"
 msgstr "battitialminuto"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -709,26 +723,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "descrizione"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "traccetotali"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -744,34 +758,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "traccetotali"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -785,20 +799,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Esporta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Esporta copertina"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
@@ -809,11 +823,11 @@ msgstr "Esporta copertina (fronte)"
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "La copertina posteriore è stata esportata correttamente"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
@@ -822,21 +836,21 @@ msgstr "La copertina anteriore è stata esportata correttamente"
 msgid "Exported successfully to: {0}"
 msgstr "Esportazione completata con successo su: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 #, fuzzy
 msgid "Failed MusicBrainz Lookup"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Controllo su MusicBrainz non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina posteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 "Si è verificato un errore durante l'esportazione della copertina anteriore"
@@ -847,21 +861,21 @@ msgid "File"
 msgstr "Nome del file"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Nome del file"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Da nome del file ad etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Da nome del file ad etichetta"
@@ -872,28 +886,28 @@ msgstr "Da nome del file ad etichetta"
 msgid "File Path"
 msgstr "Percorso del file"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Proprietà del file"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "nomefile"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Impronta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Impronta copiata negli appunti."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -902,37 +916,39 @@ msgstr ""
 msgid "Format"
 msgstr "Formato"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Formatta stringa"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Fronte"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "genere"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Genere"
 
@@ -945,27 +961,33 @@ msgstr "Ottieni una nuova chiave per le API"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Chiaro"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -980,31 +1002,37 @@ msgstr "Importa da LRC"
 msgid "Include Only Selected Files"
 msgstr "Includi solo i file selezionati"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Inserisci"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Inserisci copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Inserisci copertina anteriore"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Inserimento della copertina..."
 
@@ -1022,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Codice della lingua"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Caricato {0} brano."
 msgstr[1] "Caricati {0} brani."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Caricamento dei brani dalla libreria…"
 
@@ -1042,40 +1070,46 @@ msgstr "Caricamento dei brani dalla libreria…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "testo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Testo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Proprietà principali"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Gestisci testo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 #, fuzzy
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Gestisci testo"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Tipo"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1087,13 +1121,13 @@ msgstr "Brano"
 msgid "Music Library"
 msgstr "Libreria musicale"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
@@ -1102,24 +1136,24 @@ msgstr "Nuova proprietà personalizzata"
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "No"
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 
@@ -1128,43 +1162,43 @@ msgstr "Non è stato trovata alcuna voce AcoustId per l'impronta del file"
 msgid "No file selected"
 msgstr "Nessun brano selezionato."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Nessun file selezionato per la rimozione."
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Nessun testo scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Nessun metadato scaricato"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Nessun brano selezionato."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Nessun brano trovato"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "Nessun brano nella libreria."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 "Non è stato fornito alcun RecordingId di MusicBrainz per l'elemento AcoustID"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Nessun brano selezionato"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1189,11 +1223,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr "Offset (in millisecondi)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1210,8 +1244,8 @@ msgstr "OK"
 msgid "On"
 msgstr "Apri"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1219,37 +1253,37 @@ msgstr ""
 "È possibile inviare solamente un brano per volta ad AcoustId. Selezionare un "
 "solo brano ed inviare nuovamente i dati."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Apri"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Aprire una libreria musicale per iniziare"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Apri cartella"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Apri brano"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Apri playlist"
 
@@ -1280,10 +1314,10 @@ msgstr "Percorso del file"
 msgid "Path (Empty)"
 msgstr "Nome (vuoto)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1293,25 +1327,25 @@ msgstr ""
 msgid "Playlist"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "File della playlist creato con successo."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 #, fuzzy
 msgid "Playlist Mode"
 msgstr "Playlist"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 #, fuzzy
 msgid "Playlist path can not be empty."
 msgstr "Il nome della playlist non può essere vuoto."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Seleziona un formato."
 
@@ -1324,39 +1358,39 @@ msgstr "Mantieni l'istante temporale di modifica"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Nome della proprietà"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Etichetta"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Etichetta"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "etichetta"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "Ricarica la cartella"
@@ -1368,21 +1402,21 @@ msgid "Reload Library"
 msgstr "Ricarica la libreria"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Rimuovi proprietà personalizzata"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Rimuovere i file?"
 
@@ -1396,12 +1430,12 @@ msgstr "Rimuovi dalla playlist"
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Inserimento della copertina..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1415,18 +1449,18 @@ msgid "Save Playlist"
 msgstr "Crea playlist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Salva le etichette"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Salvataggio delle etichette in corso…"
 
@@ -1435,8 +1469,8 @@ msgstr "Salvataggio delle etichette in corso…"
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Selezionare alcuni file"
 
@@ -1445,27 +1479,27 @@ msgstr "Selezionare alcuni file"
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1478,43 +1512,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Ordina file per"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Invia"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Invia ad AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "I metadati sono stati inviati con successo a AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Invio dei dati ad AcoustId in corso…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Passa alla copertina posteriore"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Passa alla copertina anteriore"
 
@@ -1528,40 +1562,42 @@ msgstr "Sincronizzato"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Da etichetta a nome di file"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Da etichetta a nome di file"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Associa un'etichetta ai tuoi brani"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Etichetta la tua musica"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1574,7 +1610,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Questo file non ha un'impronta valida"
 
@@ -1596,56 +1632,56 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "titolo"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Titolo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Sono stati selezionati troppi file"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "traccia"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Numero della traccia"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "traccetotali"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr ""
 "Federico Marchetti\n"
 "Davide Ferracin <davide.ferracin@protonmail.com>"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Provare con un'altra libreria"
 
@@ -1654,23 +1690,23 @@ msgstr "Provare con un'altra libreria"
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr "Cerca un brano (inserire ! per attivare la ricerca avanzata)…"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Aggiunta del file alla playlist non riuscita. Il file potrebbe essere già "
 "contenuto in essa."
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Creazione della playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 #, fuzzy
 msgid "Unable to download and install update."
 msgstr "Caricamento del file immagine non riuscito"
@@ -1685,30 +1721,30 @@ msgstr "Esportazione in LRC non riuscita."
 msgid "Unable to import from LRC."
 msgstr "Importazione da LRC non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Caricamento del file immagine non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Rimozione di alcuni file dalla playlist non riuscita."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Salvataggio di {0} non riuscito"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Salvataggio di {0} non riuscito."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 "Invio dei dati ad AcoustId non riuscito. Controllare la chiave dell'API"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1717,7 +1753,7 @@ msgstr "Sconosciuto"
 msgid "Unsynchronized"
 msgstr "Non sincronizzato"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1731,8 +1767,8 @@ msgstr "Usa il testo da LRC"
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1741,10 +1777,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "Interfaccia utente"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Servizi in rete"
 
@@ -1757,6 +1793,11 @@ msgstr ""
 "Cosa deve fare Tagger con il testo trovato nel file LRC, che va in conflitto "
 "con il testo già esistente per lo stesso istante temporale?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1764,33 +1805,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "anno"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Anno"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Sì"
@@ -1864,7 +1905,7 @@ msgid "Remove Front Album Art"
 msgstr "Rimuovi la copertina anteriore"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Cambia la copertina"
 
@@ -1895,52 +1936,52 @@ msgstr "Esci"
 msgid "About Tagger"
 msgstr "Informazioni su Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Menù della libreria"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Libreria"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Menù principale"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Apri cartella (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Apri playlist (Ctrl+Maiusc+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Seleziona tutti i file"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Totale delle tracce"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Totale delle tracce"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Mostra/Nascondi il pannello delle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Azioni sulle etichette"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Applica le modifiche alle etichette (Ctrl+S)"
 
@@ -1949,41 +1990,47 @@ msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr ""
 "Tag;Music;Editor;Library;Musica;Etichetta;Etichette;Libreria;Nickvision;"
 
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "— Supporta vari tipi di file musicali (mp3, ogg, flac, wma, wav ed altri)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+"— Supporta vari tipi di file musicali (mp3, ogg, flac, wma, wav ed altri)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "— Modifica etichette e copertine di più brani allo stesso tempo, anche "
-#~ "tra sottocartelle"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"— Modifica etichette e copertine di più brani allo stesso tempo, anche tra "
+"sottocartelle"
 
-#~ msgid ""
-#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-#~ "and export support)"
-#~ msgstr ""
-#~ "— Modifica il testo sincronizzato o non sincronizzato di un file (con "
-#~ "supporto per l'esportazione e l'importazione di LRC)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+"— Modifica il testo sincronizzato o non sincronizzato di un file (con "
+"supporto per l'esportazione e l'importazione di LRC)"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr ""
-#~ "— Converte nomi di file in etichette e etichette in nomi file con "
-#~ "semplicità"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr ""
+"— Converte nomi di file in etichette e etichette in nomi file con semplicità"
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "— Controlla le informazioni dei brani con MusicBrainz"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "— Controlla le informazioni dei brani con MusicBrainz"
 
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "— Controlla le informazioni sui testi con Music163 e Letras"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "— Controlla le informazioni sui testi con Music163 e Letras"
 
-#~ msgid ""
-#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-#~ "more)"
-#~ msgstr ""
-#~ "— Apre, gestisce e crea playlist in vari formati (m3u, pls, xspf, e altri)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
+"— Apre, gestisce e crea playlist in vari formati (m3u, pls, xspf, e altri)"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -60,26 +60,24 @@ msgstr "%title% - %artist%"
 msgid "%track%- %title%"
 msgstr "%track% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -95,7 +93,9 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -136,7 +136,7 @@ msgstr ""
 "controlesom versturen."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "AcoustId-api-sleutel"
 
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Albumartiest"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "albumartiest"
 
@@ -221,7 +221,7 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -270,9 +270,9 @@ msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artiest"
 
@@ -308,21 +308,21 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -385,9 +385,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "opmerking"
 
@@ -397,9 +397,9 @@ msgid "Comment"
 msgstr "Opmerking"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "componist"
 
@@ -426,26 +426,26 @@ msgstr ""
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Bezig met omzetten van bestandsnamen in tags…"
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Tag omzetten in bestandsnaam"
@@ -481,7 +481,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "aangepast"
 
@@ -519,14 +519,14 @@ msgstr "Tag verwijderen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Bezig met verwijderen van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "omschrijving"
 
@@ -588,22 +588,22 @@ msgstr "Wijzigingen verwerpen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Wijzigingen verwerpen"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Bezig met opslaan van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "aantalnummers"
@@ -635,22 +635,22 @@ msgstr "MusicBrainz-metagegevens ophalen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
@@ -666,19 +666,19 @@ msgid "Edit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -772,12 +772,12 @@ msgstr "aantalnummers"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -819,12 +819,12 @@ msgstr "Albumhoes toevoegen"
 msgid "Export to LRC"
 msgstr "Exporteren"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
@@ -842,11 +842,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -888,7 +888,7 @@ msgid "File Properties"
 msgstr "Bestands­eigenschappen"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "bestandsnaam"
 
@@ -935,9 +935,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "genre"
 
@@ -950,7 +950,7 @@ msgid "Genre"
 msgstr "Genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Api-sleutel ophalen"
 
@@ -1032,7 +1032,7 @@ msgstr "Albumhoes toevoegen"
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
@@ -1050,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Taalcode"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1071,7 +1071,7 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1170,15 +1170,15 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "No files selected for removal."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1188,12 +1188,12 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 #, fuzzy
 msgid "No music files in library."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1203,7 +1203,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1298,18 +1298,18 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 #, fuzzy
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Tageigenschappen vervangen door die van MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Tageigenschappen vervangen door die van MusicBrainz"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "De tags zijn opgeslagen."
@@ -1347,7 +1347,7 @@ msgstr "De tags zijn opgeslagen."
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1374,9 +1374,9 @@ msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "uitgever"
 
@@ -1392,9 +1392,9 @@ msgid "Publishing Date"
 msgstr "Uitgever"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "uitgever"
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
@@ -1469,8 +1469,8 @@ msgstr "Tag opslaan"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
@@ -1537,12 +1537,12 @@ msgstr "Inzenden"
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
@@ -1623,7 +1623,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1648,9 +1648,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "titel"
 
@@ -1668,9 +1668,9 @@ msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "nummer"
 
@@ -1683,9 +1683,9 @@ msgid "Track"
 msgstr "Volgnummer"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -1709,15 +1709,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1731,30 +1731,30 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1789,7 +1789,7 @@ msgstr "Vormgeving"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Online-diensten"
@@ -1822,9 +1822,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "jaar"
 
@@ -1880,6 +1880,14 @@ msgstr "Vorige map heropenen na opstarten"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Ook onderliggende mappen doorzoeken"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 #, fuzzy

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
@@ -36,63 +36,67 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title% - %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<behouden>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -101,8 +105,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Over"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -129,18 +133,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId-api-sleutel"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr ""
 
@@ -151,7 +155,7 @@ msgid "Add to Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Extra eigenschappen"
 
@@ -160,10 +164,10 @@ msgstr "Extra eigenschappen"
 msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -185,22 +189,22 @@ msgstr "Album­omslag"
 msgid "Album Artist"
 msgstr "Albumartiest"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "albumartiest"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 #, fuzzy
 msgid "All files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
@@ -209,58 +213,58 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artiest"
 
@@ -280,70 +284,70 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Achterkant"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annuleren"
@@ -366,27 +370,27 @@ msgstr ""
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "opmerking"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "componist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Componist"
 
@@ -395,39 +399,39 @@ msgstr "Componist"
 msgid "Configure"
 msgstr "Configureren"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Bezig met omzetten van bestandsnamen in tags…"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Tag omzetten in bestandsnaam"
@@ -436,8 +440,8 @@ msgstr "Tag omzetten in bestandsnaam"
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -462,8 +466,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "aangepast"
 
@@ -475,21 +479,21 @@ msgid "Custom"
 msgstr "Aangepast"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Aangepaste eigenschappen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -501,21 +505,21 @@ msgstr "Tag verwijderen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Bezig met verwijderen van tags…"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "omschrijving"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -535,23 +539,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Verwerpen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Verwerpen"
 
@@ -565,10 +574,25 @@ msgstr "Wijzigingen verwerpen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Wijzigingen verwerpen"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Bezig met opslaan van tags…"
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "aantalnummers"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -597,26 +621,26 @@ msgstr "MusicBrainz-metagegevens ophalen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -682,6 +706,16 @@ msgstr ""
 msgid "Enter description here"
 msgstr "omschrijving"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "uitgever"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "aantalnummers"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -702,7 +736,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "uitgever"
@@ -724,12 +758,12 @@ msgstr "aantalnummers"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -745,20 +779,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Exporteren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 #, fuzzy
 msgid "Export Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 #, fuzzy
 msgid "Export Front Album Art"
@@ -771,12 +805,12 @@ msgstr "Albumhoes toevoegen"
 msgid "Export to LRC"
 msgstr "Exporteren"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
@@ -786,19 +820,19 @@ msgstr "Er zijn %d tags omgezet in bestandsnamen"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -815,9 +849,9 @@ msgstr "Bestandsnaam"
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 #, fuzzy
 msgid "File Name to Tag"
@@ -834,28 +868,28 @@ msgstr "Bestandsnaam naar tag"
 msgid "File Path"
 msgstr "Bestands­pad"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Bestands­eigenschappen"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "bestandsnaam"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Controlesom"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -865,29 +899,29 @@ msgstr ""
 msgid "Format"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Voorkant"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "genre"
 
@@ -908,19 +942,19 @@ msgstr "Api-sleutel ophalen"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -928,7 +962,7 @@ msgid "Help"
 msgstr "Hulp"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -944,33 +978,33 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Invoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 #, fuzzy
 msgid "Insert Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
@@ -988,19 +1022,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Taalcode"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1009,7 +1043,7 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -1037,7 +1071,7 @@ msgstr "Songtekst beheren"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Songtekst beheren"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix-chat"
 
@@ -1056,13 +1090,13 @@ msgstr "Muziekbestand"
 msgid "Music Library"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr ""
 
@@ -1071,24 +1105,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1097,21 +1131,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1121,12 +1155,12 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 #, fuzzy
 msgid "No music files in library."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1136,7 +1170,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1161,11 +1195,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "Oké"
 
@@ -1182,8 +1216,8 @@ msgstr "Oké"
 msgid "On"
 msgstr "Openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 #, fuzzy
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1192,8 +1226,8 @@ msgstr ""
 "U kunt slechts één bestand tegelijk naar AcoustId versturen. Kies een "
 "bestand en probeer het opnieuw."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Openen"
 
@@ -1206,7 +1240,7 @@ msgstr ""
 "gaan."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1216,12 +1250,12 @@ msgstr ""
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 #, fuzzy
 msgid "Open Music File"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1257,10 +1291,10 @@ msgstr "Bestands­pad"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1270,24 +1304,24 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "De tags zijn opgeslagen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Kies een opmaakmethode."
 
@@ -1301,39 +1335,39 @@ msgstr "Bewerktijdstip niet aanpassen"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Uitgever"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 #, fuzzy
 msgid "Reload"
 msgstr "Map herladen"
@@ -1346,20 +1380,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Songtekst verwijderen"
@@ -1374,7 +1408,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
@@ -1402,8 +1436,8 @@ msgstr "Tag opslaan"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
@@ -1422,27 +1456,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 #, fuzzy
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
@@ -1457,45 +1491,45 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Bestanden sorteren op"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Inzenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1509,9 +1543,9 @@ msgstr "Gesynchroniseerd"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 #, fuzzy
 msgid "Tag to File Name"
@@ -1522,9 +1556,8 @@ msgstr "Tag naar bestandsnaam"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Tag naar bestandsnaam"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tag uw muziek"
 
@@ -1533,9 +1566,8 @@ msgstr "Tag uw muziek"
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1544,8 +1576,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1556,7 +1588,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1580,10 +1612,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "titel"
 
@@ -1595,15 +1627,15 @@ msgstr "titel"
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "nummer"
 
@@ -1615,14 +1647,14 @@ msgstr "nummer"
 msgid "Track"
 msgstr "Volgnummer"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "aantalnummers"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
@@ -1642,15 +1674,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1664,30 +1696,30 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1696,7 +1728,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1710,8 +1742,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1741,18 +1773,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "jaar"
 
@@ -1764,10 +1796,10 @@ msgstr "jaar"
 msgid "Year"
 msgstr "Jaar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1909,15 +1941,24 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "Track Total"
 msgstr "Aantal nummers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Aantal nummers"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Tagacties"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
@@ -1925,41 +1966,9 @@ msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Tag;Music;Editor;Library;Nickvision;Muziek;Bewerker;Bibliotheek;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 #, fuzzy
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "Bezig met omzetten van tags in bestandsnamen…"
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "Bezig met omzetten van tags in bestandsnamen…"
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -23,8 +23,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -60,34 +60,24 @@ msgstr "%title% - %artist%"
 msgid "%track%- %title%"
 msgstr "%track% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -95,9 +85,19 @@ msgstr "%track% - %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -113,7 +113,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "Over"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #, fuzzy
 msgid ""
@@ -141,7 +141,7 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId-api-sleutel"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -173,9 +173,9 @@ msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -198,9 +198,9 @@ msgid "Album Artist"
 msgstr "Albumartiest"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "albumartiest"
 
@@ -211,8 +211,8 @@ msgstr "albumartiest"
 msgid "All files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
@@ -221,18 +221,18 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -249,14 +249,14 @@ msgstr ""
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -270,9 +270,9 @@ msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artiest"
 
@@ -293,8 +293,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -308,40 +308,40 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -385,9 +385,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "opmerking"
 
@@ -397,9 +397,9 @@ msgid "Comment"
 msgstr "Opmerking"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "componist"
 
@@ -417,8 +417,8 @@ msgstr "Configureren"
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -426,26 +426,26 @@ msgstr ""
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Bezig met omzetten van bestandsnamen in tags…"
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Tag omzetten in bestandsnaam"
@@ -481,7 +481,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "aangepast"
 
@@ -519,14 +519,14 @@ msgstr "Tag verwijderen"
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Bezig met verwijderen van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "omschrijving"
 
@@ -558,14 +558,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Verwerpen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -588,22 +588,22 @@ msgstr "Wijzigingen verwerpen"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Wijzigingen verwerpen"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Bezig met opslaan van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "aantalnummers"
@@ -635,22 +635,22 @@ msgstr "MusicBrainz-metagegevens ophalen"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
@@ -772,12 +772,12 @@ msgstr "aantalnummers"
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -800,13 +800,13 @@ msgstr ""
 msgid "Export"
 msgstr "Exporteren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 #, fuzzy
 msgid "Export Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 #, fuzzy
 msgid "Export Front Album Art"
@@ -819,12 +819,12 @@ msgstr "Albumhoes toevoegen"
 msgid "Export to LRC"
 msgstr "Exporteren"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
@@ -838,15 +838,15 @@ msgstr ""
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -863,7 +863,7 @@ msgstr "Bestandsnaam"
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -888,7 +888,7 @@ msgid "File Properties"
 msgstr "Bestands­eigenschappen"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "bestandsnaam"
 
@@ -897,12 +897,12 @@ msgstr "bestandsnaam"
 msgid "Fingerprint"
 msgstr "Controlesom"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -913,16 +913,16 @@ msgstr ""
 msgid "Format"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Opmaakmethode"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -935,9 +935,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "genre"
 
@@ -958,7 +958,7 @@ msgstr "Api-sleutel ophalen"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
@@ -969,9 +969,9 @@ msgstr "GitHub-repo"
 msgid "Height"
 msgstr "Licht"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1020,19 +1020,19 @@ msgstr "Info"
 msgid "Insert"
 msgstr "Invoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 #, fuzzy
 msgid "Insert Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
@@ -1050,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Taalcode"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1071,7 +1071,7 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -1086,6 +1086,10 @@ msgstr "Songtekst"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Hoofd­eigenschappen"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1123,12 +1127,12 @@ msgstr "Muziekbestand"
 msgid "Music Library"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
@@ -1138,7 +1142,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1147,15 +1151,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1164,21 +1168,21 @@ msgstr ""
 msgid "No file selected"
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1188,12 +1192,12 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 #, fuzzy
 msgid "No music files in library."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1203,7 +1207,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1228,7 +1232,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1249,7 +1253,7 @@ msgstr "Oké"
 msgid "On"
 msgstr "Openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 #, fuzzy
 msgid ""
@@ -1259,7 +1263,7 @@ msgstr ""
 "U kunt slechts één bestand tegelijk naar AcoustId versturen. Kies een "
 "bestand en probeer het opnieuw."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Openen"
@@ -1273,7 +1277,7 @@ msgstr ""
 "gaan."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1283,12 +1287,12 @@ msgstr ""
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 #, fuzzy
 msgid "Open Music File"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1324,8 +1328,8 @@ msgstr "Bestands­pad"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1337,22 +1341,22 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "De tags zijn opgeslagen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1368,15 +1372,15 @@ msgstr "Bewerktijdstip niet aanpassen"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "uitgever"
 
@@ -1392,14 +1396,14 @@ msgid "Publishing Date"
 msgstr "Uitgever"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
@@ -1420,12 +1424,12 @@ msgstr ""
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
@@ -1441,7 +1445,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
@@ -1469,8 +1473,8 @@ msgstr "Tag opslaan"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
@@ -1493,14 +1497,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1524,12 +1528,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Bestanden sorteren op"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Inzenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1537,17 +1541,17 @@ msgstr "Inzenden"
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1558,7 +1562,7 @@ msgstr "Bezig met versturen naar AcoustId…"
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1576,7 +1580,7 @@ msgstr "Gesynchroniseerd"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1611,7 +1615,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1623,7 +1627,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1648,9 +1652,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "titel"
 
@@ -1662,15 +1666,15 @@ msgstr "titel"
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "nummer"
 
@@ -1683,9 +1687,9 @@ msgid "Track"
 msgstr "Volgnummer"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -1709,15 +1713,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1731,30 +1735,30 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1777,7 +1781,7 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1813,7 +1817,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1822,9 +1826,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "jaar"
 
@@ -1836,8 +1840,8 @@ msgstr "jaar"
 msgid "Year"
 msgstr "Jaar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -18,17 +18,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
@@ -36,63 +44,63 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title% - %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track% - %title%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<behouden>"
 
@@ -100,13 +108,13 @@ msgstr "<behouden>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, fuzzy, csharp-format
 msgid "About {0}"
 msgstr "Over"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #, fuzzy
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -133,18 +141,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId-api-sleutel"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr ""
 
@@ -154,28 +162,28 @@ msgstr ""
 msgid "Add to Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Extra eigenschappen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Geavanceerd zoeken"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -184,27 +192,27 @@ msgstr "Album"
 msgid "Album Art"
 msgstr "Album­omslag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Albumartiest"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "albumartiest"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 #, fuzzy
 msgid "All files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 #, fuzzy
 msgid "All Supported Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
@@ -213,66 +221,66 @@ msgstr "Er zijn geen muziekbestanden aangetroffen"
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Wijzigingen toepassen?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artiest"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Artiest"
 
@@ -284,70 +292,72 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Achterkant"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Annuleren"
@@ -356,7 +366,7 @@ msgstr "Annuleren"
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -365,32 +375,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "opmerking"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Opmerking"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "componist"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Componist"
 
@@ -399,39 +413,39 @@ msgstr "Componist"
 msgid "Configure"
 msgstr "Configureren"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, fuzzy, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "Er zijn %d bestandsnamen omgezet in tags"
 msgstr[1] "Er zijn %d bestandsnamen omgezet in tags"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, fuzzy, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "Er zijn %d tags omgezet in bestandsnamen"
 msgstr[1] "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 #, fuzzy
 msgid "Converting file names to tags..."
 msgstr "Bezig met omzetten van bestandsnamen in tags…"
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 #, fuzzy
 msgid "Converting tags to file names..."
 msgstr "Tag omzetten in bestandsnaam"
@@ -440,8 +454,8 @@ msgstr "Tag omzetten in bestandsnaam"
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -466,8 +480,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "aangepast"
 
@@ -478,22 +492,22 @@ msgstr "aangepast"
 msgid "Custom"
 msgstr "Aangepast"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Aangepaste eigenschappen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -501,25 +515,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Tag verwijderen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Bezig met verwijderen van tags…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "omschrijving"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -539,28 +553,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Verwerpen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Verwerpen"
 
@@ -569,78 +583,78 @@ msgstr "Verwerpen"
 msgid "Discard Unapplied Changed"
 msgstr "Wijzigingen verwerpen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 #, fuzzy
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Wijzigingen verwerpen"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 #, fuzzy
 msgid "Discarding tags..."
 msgstr "Bezig met opslaan van tags…"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "aantalnummers"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 #, fuzzy
 msgid "Documentation"
 msgstr "Duur"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 #, fuzzy
 msgid "Download Lyrics"
 msgstr "Songtekst beheren"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 #, fuzzy
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz-metagegevens ophalen"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, fuzzy, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, fuzzy, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Er zijn metagegevens van %d bestanden opgehaald"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 #, fuzzy
 msgid "Downloading lyrics..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz-metagegevens downloaden…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -670,29 +684,29 @@ msgid ""
 "If disabled, only blank tag properties will be filled."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 #, fuzzy
 msgid "Enter album artist here"
 msgstr "albumartiest"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 #, fuzzy
 msgid "Enter beats per minute here"
 msgstr "bpm"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -701,26 +715,26 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 #, fuzzy
 msgid "Enter description here"
 msgstr "omschrijving"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "aantalnummers"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -736,34 +750,34 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 #, fuzzy
 msgid "Enter publisher here"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 #, fuzzy
 msgid "Enter track total here"
 msgstr "aantalnummers"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -778,21 +792,21 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Exporteren"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 #, fuzzy
 msgid "Export Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 #, fuzzy
 msgid "Export Front Album Art"
@@ -805,12 +819,12 @@ msgstr "Albumhoes toevoegen"
 msgid "Export to LRC"
 msgstr "Exporteren"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 #, fuzzy
 msgid "Exported back album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 #, fuzzy
 msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
@@ -820,19 +834,19 @@ msgstr "Er zijn %d tags omgezet in bestandsnamen"
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -842,22 +856,22 @@ msgid "File"
 msgstr "Bestandsnaam"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Bestandsnaam"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 #, fuzzy
 msgid "File Name to Tag"
 msgstr "Bestandsnaam naar tag"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 #, fuzzy
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Bestandsnaam naar tag"
@@ -868,28 +882,28 @@ msgstr "Bestandsnaam naar tag"
 msgid "File Path"
 msgstr "Bestands­pad"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Bestands­eigenschappen"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "bestandsnaam"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Controlesom"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -899,37 +913,39 @@ msgstr ""
 msgid "Format"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Opmaakmethode"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Voorkant"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "genre"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Genre"
 
@@ -942,27 +958,33 @@ msgstr "Api-sleutel ophalen"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Licht"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hulp"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -978,33 +1000,39 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Info"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Invoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 #, fuzzy
 msgid "Insert Back Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 #, fuzzy
 msgid "Insert Front Album Art"
 msgstr "Albumhoes toevoegen"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
@@ -1022,19 +1050,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Taalcode"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, fuzzy, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "Er zijn %d muziekbestanden geladen."
 msgstr[1] "Er zijn %d muziekbestanden geladen."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 #, fuzzy
 msgid "Loading music files from library..."
 msgstr "Bezig met laden van muziekbestanden…"
@@ -1043,41 +1071,46 @@ msgstr "Bezig met laden van muziekbestanden…"
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Songtekst"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Hoofd­eigenschappen"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Songtekst beheren"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 #, fuzzy
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Songtekst beheren"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix-chat"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+msgid "Mime Type"
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1090,13 +1123,13 @@ msgstr "Muziekbestand"
 msgid "Music Library"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz-opname-id"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
 
@@ -1105,24 +1138,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1131,46 +1164,46 @@ msgstr ""
 msgid "No file selected"
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 #, fuzzy
 msgid "No files selected for removal."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 #, fuzzy
 msgid "No music files are selected."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 #, fuzzy
 msgid "No music files in library."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 #, fuzzy
 msgid "No Selected Music Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1195,11 +1228,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "Oké"
 
@@ -1216,8 +1249,8 @@ msgstr "Oké"
 msgid "On"
 msgstr "Openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 #, fuzzy
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1226,13 +1259,13 @@ msgstr ""
 "U kunt slechts één bestand tegelijk naar AcoustId versturen. Kies een "
 "bestand en probeer het opnieuw."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Openen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 #, fuzzy
 msgid "Open a library with music to get started"
 msgstr ""
@@ -1240,27 +1273,27 @@ msgstr ""
 "gaan."
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 #, fuzzy
 msgid "Open Music File"
 msgstr "Muziekbestand"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1291,10 +1324,10 @@ msgstr "Bestands­pad"
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1304,24 +1337,24 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 #, fuzzy
 msgid "Playlist file created successfully."
 msgstr "De tags zijn opgeslagen."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Kies een opmaakmethode."
 
@@ -1335,39 +1368,39 @@ msgstr "Bewerktijdstip niet aanpassen"
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Eigenschaps­naam"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Uitgever"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "uitgever"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 #, fuzzy
 msgid "Reload"
 msgstr "Map herladen"
@@ -1379,21 +1412,21 @@ msgid "Reload Library"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #, fuzzy
 msgid "Remove Files?"
 msgstr "Songtekst verwijderen"
@@ -1408,12 +1441,12 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 #, fuzzy
 msgid "Removing album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1426,18 +1459,18 @@ msgid "Save Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Tag opslaan"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 #, fuzzy
 msgid "Save Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Bezig met opslaan van tags…"
 
@@ -1446,8 +1479,8 @@ msgstr "Bezig met opslaan van tags…"
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr ""
 
@@ -1456,27 +1489,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 #, fuzzy
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
@@ -1491,45 +1524,45 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Bestanden sorteren op"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Inzenden"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Versturen naar AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 #, fuzzy
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "De metagegevens zijn verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 #, fuzzy
 msgid "Submitting data to AcoustId..."
 msgstr "Bezig met versturen naar AcoustId…"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1543,41 +1576,43 @@ msgstr "Gesynchroniseerd"
 msgid "Tag"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 #, fuzzy
 msgid "Tag to File Name"
 msgstr "Tag naar bestandsnaam"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 #, fuzzy
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Tag naar bestandsnaam"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Tag uw muziek"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1588,7 +1623,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Thema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1612,54 +1647,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Tijdstempel (uu:mm:ss)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "titel"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Titel"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Teveel bestanden geselecteerd"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "nummer"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Volgnummer"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "aantalnummers"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr ""
 
@@ -1668,21 +1703,21 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 #, fuzzy
 msgid "Type ! for advanced search"
 msgstr "Zoeken naar bestand (typ ! om geavanceerd te zoeken)…"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1696,30 +1731,30 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 #, fuzzy
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "De metagegevens kunnen niet worden verstuurd naar AcoustId."
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1728,7 +1763,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1742,8 +1777,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1752,10 +1787,10 @@ msgstr ""
 msgid "User Interface"
 msgstr "Vormgeving"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Online-diensten"
 
@@ -1766,6 +1801,11 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1773,33 +1813,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "jaar"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Jaar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1878,7 +1918,7 @@ msgid "Remove Front Album Art"
 msgstr "Albumhoes verwijderen"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 #, fuzzy
 msgid "Switch Album Art"
 msgstr "Albumartiest"
@@ -1911,54 +1951,54 @@ msgstr "Afsluiten"
 msgid "About Tagger"
 msgstr "Over Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Hoofdmenu"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 #, fuzzy
 msgid "Open Folder (Ctrl+O)"
 msgstr "Muziekmap openen (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 #, fuzzy
 msgid "Select All Files"
 msgstr "Er zijn geen muziekbestanden aangetroffen"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Aantal nummers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Aantal nummers"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Tagacties"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 
@@ -1966,9 +2006,41 @@ msgstr "Tagwijzigingen opslaan (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Tag;Music;Editor;Library;Nickvision;Muziek;Bewerker;Bibliotheek;"
 
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
 #, fuzzy
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr "Bezig met omzetten van tags in bestandsnamen…"
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr "Bezig met omzetten van tags in bestandsnamen…"
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
 
 #, fuzzy
 #~ msgid "Open a library with music to get started."

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -25,8 +25,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -62,34 +62,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -97,9 +87,19 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -115,7 +115,7 @@ msgstr ""
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -134,7 +134,7 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -166,9 +166,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -191,9 +191,9 @@ msgid "Album Artist"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr ""
 
@@ -212,18 +212,18 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -240,14 +240,14 @@ msgstr ""
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -261,9 +261,9 @@ msgid "Apply Changes?"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artysta"
 
@@ -284,8 +284,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -299,40 +299,40 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Wyliczanie..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -376,9 +376,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr ""
 
@@ -388,9 +388,9 @@ msgid "Comment"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "kompozytor"
 
@@ -408,8 +408,8 @@ msgstr "Konfiguruj"
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -417,25 +417,25 @@ msgstr ""
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -469,7 +469,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr ""
 
@@ -507,14 +507,14 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "opis"
 
@@ -546,14 +546,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Odrzuć"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -574,21 +574,21 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 msgid "disctotal"
 msgstr ""
 
@@ -616,21 +616,21 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
@@ -745,12 +745,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -772,12 +772,12 @@ msgstr "Wyjdź"
 msgid "Export"
 msgstr "Eksportuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -788,11 +788,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -805,15 +805,15 @@ msgstr ""
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -829,7 +829,7 @@ msgstr "Plik"
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -852,7 +852,7 @@ msgid "File Properties"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "nazwa pliku"
 
@@ -861,12 +861,12 @@ msgstr "nazwa pliku"
 msgid "Fingerprint"
 msgstr "Odcisk palca"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -876,16 +876,16 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -898,9 +898,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "gatunek"
 
@@ -921,7 +921,7 @@ msgstr ""
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr ""
@@ -931,9 +931,9 @@ msgstr ""
 msgid "Height"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -981,17 +981,17 @@ msgstr "Informacje"
 msgid "Insert"
 msgstr "Wstaw"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1009,19 +1009,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Lryics"
 msgstr "Tekst"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "tekst"
 
@@ -1042,6 +1042,10 @@ msgstr "Tekst"
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
@@ -1078,12 +1082,12 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
@@ -1093,7 +1097,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1102,15 +1106,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1118,20 +1122,20 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr ""
 
@@ -1140,11 +1144,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr "Wyłącz"
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1198,14 +1202,14 @@ msgstr "OK"
 msgid "On"
 msgstr "Włącz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otwórz"
@@ -1216,7 +1220,7 @@ msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1226,11 +1230,11 @@ msgstr ""
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1264,8 +1268,8 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1277,21 +1281,21 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1306,15 +1310,15 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr ""
 
@@ -1329,13 +1333,13 @@ msgid "Publishing Date"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr ""
@@ -1355,12 +1359,12 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr ""
@@ -1375,7 +1379,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr ""
 
@@ -1401,8 +1405,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr ""
 
@@ -1425,14 +1429,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1453,12 +1457,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1466,15 +1470,15 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1485,7 +1489,7 @@ msgstr ""
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1502,7 +1506,7 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1535,7 +1539,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1547,7 +1551,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1568,9 +1572,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr ""
 
@@ -1582,15 +1586,15 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr ""
 
@@ -1603,9 +1607,9 @@ msgid "Track"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr ""
 
@@ -1628,15 +1632,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1650,29 +1654,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1695,7 +1699,7 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1731,7 +1735,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1740,9 +1744,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr ""
 
@@ -1754,8 +1758,8 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,15 +20,15 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
@@ -38,63 +38,67 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr ""
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr ""
 
@@ -103,8 +107,8 @@ msgstr ""
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -122,18 +126,18 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr ""
 
@@ -144,7 +148,7 @@ msgid "Add to Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr ""
 
@@ -153,10 +157,10 @@ msgstr ""
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -178,21 +182,21 @@ msgstr ""
 msgid "Album Artist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr ""
 
@@ -200,58 +204,58 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artysta"
 
@@ -271,70 +275,70 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Wstecz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Wyliczanie..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Anuluj"
@@ -357,27 +361,27 @@ msgstr ""
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "kompozytor"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Kompozytor"
 
@@ -386,38 +390,38 @@ msgstr "Kompozytor"
 msgid "Configure"
 msgstr "Konfiguruj"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -425,8 +429,8 @@ msgstr ""
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -450,8 +454,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr ""
 
@@ -463,21 +467,21 @@ msgid "Custom"
 msgstr "Niestandardowe"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr ""
 
@@ -489,21 +493,21 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "opis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Opis"
 
@@ -523,23 +527,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Odrzuć"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Odrzuć"
 
@@ -551,8 +560,22 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+msgid "disctotal"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
@@ -579,25 +602,25 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -660,6 +683,14 @@ msgstr ""
 msgid "Enter description here"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+msgid "Enter disc number here"
+msgstr ""
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+msgid "Enter disc total here"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -680,7 +711,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr ""
 
@@ -700,12 +731,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -720,19 +751,19 @@ msgstr "Wyjdź"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Eksportuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -743,11 +774,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -756,19 +787,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -784,9 +815,9 @@ msgstr "Plik"
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr ""
@@ -801,28 +832,28 @@ msgstr ""
 msgid "File Path"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "nazwa pliku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Odcisk palca"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -831,29 +862,29 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Przód"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "gatunek"
 
@@ -874,19 +905,19 @@ msgstr ""
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -894,7 +925,7 @@ msgid "Help"
 msgstr "Pomoc"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -909,31 +940,31 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Informacje"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Wstaw"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr ""
 
@@ -951,19 +982,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -971,7 +1002,7 @@ msgstr ""
 msgid "Lryics"
 msgstr "Tekst"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "tekst"
 
@@ -997,7 +1028,7 @@ msgstr ""
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr ""
 
@@ -1015,13 +1046,13 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr ""
 
@@ -1030,24 +1061,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1055,20 +1086,20 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr ""
 
@@ -1077,11 +1108,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1090,7 +1121,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1115,11 +1146,11 @@ msgstr "Wyłącz"
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "OK"
 
@@ -1135,15 +1166,15 @@ msgstr "OK"
 msgid "On"
 msgstr "Włącz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Otwórz"
 
@@ -1153,7 +1184,7 @@ msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1163,11 +1194,11 @@ msgstr ""
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1201,10 +1232,10 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1214,23 +1245,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr ""
 
@@ -1243,37 +1274,37 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 msgid "Publishing Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr ""
 
@@ -1285,20 +1316,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr ""
 
@@ -1312,7 +1343,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr ""
 
@@ -1338,8 +1369,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr ""
 
@@ -1358,27 +1389,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1390,43 +1421,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1439,9 +1470,9 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr ""
@@ -1450,9 +1481,8 @@ msgstr ""
 msgid "Tag to File Name (Ctrl+T)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
@@ -1461,9 +1491,8 @@ msgstr ""
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
@@ -1472,8 +1501,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1484,7 +1513,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1504,10 +1533,10 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr ""
 
@@ -1519,15 +1548,15 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr ""
 
@@ -1539,14 +1568,14 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr ""
 
@@ -1565,15 +1594,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1587,29 +1616,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1618,7 +1647,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1632,8 +1661,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1663,18 +1692,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr ""
 
@@ -1686,10 +1715,10 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1822,55 +1851,28 @@ msgstr ""
 msgid "Track Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+msgid "Disc Total"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;Nickvision;"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
 msgstr ""
 
 #~ msgid "Default"

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -20,17 +20,25 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
@@ -38,63 +46,63 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr ""
 
@@ -102,13 +110,13 @@ msgstr ""
 msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -126,18 +134,18 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr ""
 
@@ -147,28 +155,28 @@ msgstr ""
 msgid "Add to Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Album"
 
@@ -177,26 +185,26 @@ msgstr "Album"
 msgid "Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr ""
 
@@ -204,66 +212,66 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artysta"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Artysta"
 
@@ -275,70 +283,72 @@ msgstr ""
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Wstecz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Wyliczanie..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Anuluj"
@@ -347,7 +357,7 @@ msgstr "Anuluj"
 msgid "Changelog"
 msgstr "Dziennik zmian"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -356,32 +366,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "kompozytor"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Kompozytor"
 
@@ -390,38 +404,38 @@ msgstr "Kompozytor"
 msgid "Configure"
 msgstr "Konfiguruj"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -429,8 +443,8 @@ msgstr ""
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -454,8 +468,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr ""
 
@@ -466,22 +480,22 @@ msgstr ""
 msgid "Custom"
 msgstr "Niestandardowe"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr ""
 
@@ -489,25 +503,25 @@ msgstr ""
 msgid "Delete Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "opis"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Opis"
 
@@ -527,28 +541,28 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Odrzuć"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Odrzuć"
 
@@ -556,71 +570,71 @@ msgstr "Odrzuć"
 msgid "Discard Unapplied Changed"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 msgid "disctotal"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Dyskusje"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Dokumentacja"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -650,27 +664,27 @@ msgid ""
 "If disabled, only blank tag properties will be filled."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -679,23 +693,23 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 msgid "Enter disc number here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter disc total here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -711,32 +725,32 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -750,20 +764,20 @@ msgid "Exit"
 msgstr "Wyjdź"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Eksportuj"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -774,11 +788,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -787,19 +801,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -808,21 +822,21 @@ msgid "File"
 msgstr "Plik"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr ""
 
@@ -832,28 +846,28 @@ msgstr ""
 msgid "File Path"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "nazwa pliku"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Odcisk palca"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -862,37 +876,39 @@ msgstr ""
 msgid "Format"
 msgstr "Format"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Przód"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "gatunek"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Gatunek"
 
@@ -905,27 +921,32 @@ msgstr ""
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+msgid "Height"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoc"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -940,31 +961,37 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Informacje"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Wstaw"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr ""
 
@@ -982,19 +1009,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -1002,39 +1029,44 @@ msgstr ""
 msgid "Lryics"
 msgstr "Tekst"
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "tekst"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Tekst"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+msgid "Mime Type"
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1046,13 +1078,13 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
 
@@ -1061,24 +1093,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1086,42 +1118,42 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1146,11 +1178,11 @@ msgstr "Wyłącz"
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "OK"
 
@@ -1166,44 +1198,44 @@ msgstr "OK"
 msgid "On"
 msgstr "Włącz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1232,10 +1264,10 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1245,23 +1277,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr ""
 
@@ -1274,37 +1306,37 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Publishing Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr ""
 
@@ -1315,21 +1347,21 @@ msgid "Reload Library"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr ""
 
@@ -1343,11 +1375,11 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1360,17 +1392,17 @@ msgid "Save Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr ""
 
@@ -1379,8 +1411,8 @@ msgstr ""
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr ""
 
@@ -1389,27 +1421,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1421,43 +1453,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1470,39 +1502,41 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1513,7 +1547,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1533,54 +1567,54 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr ""
 
@@ -1589,20 +1623,20 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1616,29 +1650,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1647,7 +1681,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1661,8 +1695,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1671,10 +1705,10 @@ msgstr ""
 msgid "User Interface"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr ""
 
@@ -1685,6 +1719,11 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1692,33 +1731,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1792,7 +1831,7 @@ msgid "Remove Front Album Art"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr ""
 
@@ -1823,56 +1862,91 @@ msgstr ""
 msgid "About Tagger"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 msgid "Disc Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;Nickvision;"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
 msgstr ""
 
 #~ msgid "Default"

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -62,26 +62,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -97,7 +95,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -129,7 +129,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr ""
 
@@ -166,9 +166,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -191,9 +191,9 @@ msgid "Album Artist"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -261,9 +261,9 @@ msgid "Apply Changes?"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artysta"
 
@@ -299,21 +299,21 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -376,9 +376,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr ""
 
@@ -388,9 +388,9 @@ msgid "Comment"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "kompozytor"
 
@@ -417,25 +417,25 @@ msgstr ""
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -469,7 +469,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr ""
 
@@ -507,14 +507,14 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "opis"
 
@@ -574,21 +574,21 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 msgid "disctotal"
 msgstr ""
 
@@ -616,21 +616,21 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
@@ -646,19 +646,19 @@ msgid "Edit"
 msgstr "Edytuj"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -745,12 +745,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -788,11 +788,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -809,11 +809,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgid "File Properties"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "nazwa pliku"
 
@@ -898,9 +898,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "gatunek"
 
@@ -913,7 +913,7 @@ msgid "Genre"
 msgstr "Gatunek"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1009,19 +1009,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Lryics"
 msgstr "Tekst"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "tekst"
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1110,7 +1110,7 @@ msgstr ""
 msgid "No"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1123,15 +1123,15 @@ msgstr ""
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr ""
 
@@ -1140,11 +1140,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1153,7 +1153,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1240,17 +1240,17 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1312,9 +1312,9 @@ msgid "Property Name"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr ""
 
@@ -1329,9 +1329,9 @@ msgid "Publishing Date"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 msgid "publishingdate"
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr ""
 
@@ -1401,8 +1401,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr ""
 
@@ -1466,11 +1466,11 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
@@ -1547,7 +1547,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1568,9 +1568,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr ""
 
@@ -1588,9 +1588,9 @@ msgid "Too Many Files Selected"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr ""
 
@@ -1603,9 +1603,9 @@ msgid "Track"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr ""
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1650,29 +1650,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr ""
@@ -1740,9 +1740,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr ""
 
@@ -1796,6 +1796,14 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-19 19:10+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -62,26 +62,24 @@ msgstr "%название%- %исполнитель%"
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -97,7 +95,9 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -137,7 +137,7 @@ msgstr ""
 "вместе с отпечатком."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "Ключ API пользователя AcoustId"
 
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "альбом"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "альбомартист"
 
@@ -220,7 +220,7 @@ msgstr "Все поддерживаемые типы файлов"
 msgid "An application restart is required to change the theme."
 msgstr "Для применения темы необходим перезапуск приложения."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "MusicBrainz получил неверный RecordingId"
 
@@ -269,9 +269,9 @@ msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "artist"
 
@@ -307,21 +307,21 @@ msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -384,9 +384,9 @@ msgid "Close Library"
 msgstr "Закрыть библиотеку"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "комментарий"
 
@@ -396,9 +396,9 @@ msgid "Comment"
 msgstr "Комментарий"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "композитор"
 
@@ -425,7 +425,7 @@ msgstr "Участники на GitHub ❤️"
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -433,7 +433,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -441,11 +441,11 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr "Конвертирование имён файлов в теги..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr "Конвертирование тегов в имена файлов..."
 
@@ -479,7 +479,7 @@ msgid "Credits"
 msgstr "Авторы"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "пользовательский"
 
@@ -518,14 +518,14 @@ msgstr "Удалить тег"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Удалить тег (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Удаление тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "описание"
 
@@ -596,21 +596,21 @@ msgstr "Отменить непримененные изменения"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Отменить непримененные изменения (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Отбраковка тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "итогтрек"
@@ -639,21 +639,21 @@ msgstr "Загрузить метаданные MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Загрузить метаданные MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Успешно загружены тексты песен для {0} файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Загрузка текста..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
@@ -669,14 +669,14 @@ msgid "Edit"
 msgstr "Редактировать"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "Включите чтобы перезаписывать существующие обложки альбомов обложками, "
 "найденными из MusicBrainz."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -686,7 +686,7 @@ msgstr ""
 "заполняться только пустой текст."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -777,12 +777,12 @@ msgstr "Введите общее количество треков здесь"
 msgid "Enter year here"
 msgstr "Введите год"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -820,11 +820,11 @@ msgstr "Экспортировать переднюю обложку альбо�
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
@@ -841,11 +841,11 @@ msgstr "Не удалось выполнить поиск в MusicBrainz"
 msgid "Failed MusicBrainz Lookups"
 msgstr "Неудачные поиски в MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
@@ -884,7 +884,7 @@ msgid "File Properties"
 msgstr "Свойства файла"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "имя файла"
 
@@ -930,9 +930,9 @@ msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "жанр"
 
@@ -945,7 +945,7 @@ msgid "Genre"
 msgstr "Жанр"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Получить новый ключ API"
 
@@ -1024,7 +1024,7 @@ msgstr "Вставить заднюю обложку альбома"
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Добавление обложки альбома..."
 
@@ -1042,11 +1042,11 @@ msgstr "КиБ"
 msgid "Language Code"
 msgstr "Языковой код"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr "Библиотека была изменена на диске."
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1054,8 +1054,8 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
@@ -1063,7 +1063,7 @@ msgstr "Загрузка музыкальных файлов из библиот
 msgid "Lryics"
 msgstr "Текст"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "текст"
 
@@ -1128,7 +1128,7 @@ msgstr "Новое пользовательское свойство"
 msgid "New Synchronized Lyric"
 msgstr "Новый синхронизированный текст"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
@@ -1145,7 +1145,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Для отпечатка файла не найдено записи AcoustId"
 
@@ -1158,15 +1158,15 @@ msgstr "Файл не выбран"
 msgid "No files selected for removal."
 msgstr "Не выбраны файлы для удаления."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Текст не был загружен"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Не выбрано ни одного музыкального файла."
 
@@ -1175,11 +1175,11 @@ msgstr "Не выбрано ни одного музыкального файл�
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "В библиотеке нет музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Для записи AcoustId не был предоставлен MusicBrainz RecordingId"
 
@@ -1188,7 +1188,7 @@ msgstr "Для записи AcoustId не был предоставлен MusicB
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr "Не настроен пользовательский ключ api."
 
@@ -1277,17 +1277,17 @@ msgid "Open Playlist"
 msgstr "Открыть плейлист"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "Переписать обложку альбома с помощью MusicBrainz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Перезапись текст из веб-сервиса"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "Перезапись тегов с помощью MusicBrainz"
 
@@ -1314,7 +1314,7 @@ msgstr "Выберите дату"
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Файл плейлиста создан успешно."
 
@@ -1323,7 +1323,7 @@ msgstr "Файл плейлиста создан успешно."
 msgid "Playlist Mode"
 msgstr "Режим плейлиста"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr "Путь до плейлиста не должен быть пустым."
 
@@ -1349,9 +1349,9 @@ msgid "Property Name"
 msgstr "Имя свойства"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "издатель"
 
@@ -1366,9 +1366,9 @@ msgid "Publishing Date"
 msgstr "Дата публикации"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 msgid "publishingdate"
 msgstr "publishingdate"
 
@@ -1412,7 +1412,7 @@ msgstr "Удалить из плейлиста"
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr "Удаление обложки альбома..."
 
@@ -1438,8 +1438,8 @@ msgstr "Сохранить тег"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Сохранить тег (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
@@ -1505,11 +1505,11 @@ msgstr "Отправить"
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
@@ -1588,7 +1588,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Тема"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Этот файл не имеет действительного отпечатка"
 
@@ -1611,9 +1611,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "название"
 
@@ -1631,9 +1631,9 @@ msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "трек"
 
@@ -1646,9 +1646,9 @@ msgid "Track"
 msgstr "Номер трека"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -1673,15 +1673,15 @@ msgstr "Тип"
 msgid "Type ! for advanced search"
 msgstr "Введите ! для расширенного поиска"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Не удалось добавить файл в плейлист. Возможно, он уже добавлен."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Не удалось создать плейлист."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr "Не удалось загрузить и установить обновление."
 
@@ -1695,29 +1695,29 @@ msgstr "Невозможно экспортировать в LRC."
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Не удалось удалить некоторые файлы из плейлиста."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1752,7 +1752,7 @@ msgstr "Интерфейс"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Веб-сервисы"
@@ -1792,9 +1792,9 @@ msgstr ""
 "Если нет, вместо этого будет использован полный путь."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "год"
 
@@ -1849,6 +1849,14 @@ msgstr "Запомнить последнюю открытую библиоте�
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Включать подпапки"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-19 19:10+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -25,8 +25,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -62,34 +62,24 @@ msgstr "%название%- %исполнитель%"
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -97,9 +87,19 @@ msgstr "%трек%- %название%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -115,7 +115,7 @@ msgstr "0 МиБ"
 msgid "About {0}"
 msgstr "О приложении"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -142,7 +142,7 @@ msgid "AcoustId User API Key"
 msgstr "Ключ API пользователя AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -174,9 +174,9 @@ msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "альбом"
 
@@ -199,9 +199,9 @@ msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "альбомартист"
 
@@ -211,8 +211,8 @@ msgstr "альбомартист"
 msgid "All files"
 msgstr "Все файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Все поддерживаемые типы файлов"
 
@@ -220,18 +220,18 @@ msgstr "Все поддерживаемые типы файлов"
 msgid "An application restart is required to change the theme."
 msgstr "Для применения темы необходим перезапуск приложения."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "MusicBrainz получил неверный RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -248,14 +248,14 @@ msgstr "MusicBrainz получил неверный RecordingId"
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -269,9 +269,9 @@ msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "artist"
 
@@ -292,8 +292,8 @@ msgid "B"
 msgstr "Б"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -307,40 +307,40 @@ msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Вычисление..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -384,9 +384,9 @@ msgid "Close Library"
 msgstr "Закрыть библиотеку"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "комментарий"
 
@@ -396,9 +396,9 @@ msgid "Comment"
 msgstr "Комментарий"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "композитор"
 
@@ -416,8 +416,8 @@ msgstr "Настроить"
 msgid "Contributors on GitHub ❤️"
 msgstr "Участники на GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -425,7 +425,7 @@ msgstr "Участники на GitHub ❤️"
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -433,7 +433,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -441,11 +441,11 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr "Конвертирование имён файлов в теги..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr "Конвертирование тегов в имена файлов..."
 
@@ -479,7 +479,7 @@ msgid "Credits"
 msgstr "Авторы"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "пользовательский"
 
@@ -518,14 +518,14 @@ msgstr "Удалить тег"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Удалить тег (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Удаление тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "описание"
 
@@ -568,14 +568,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Отменить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -596,21 +596,21 @@ msgstr "Отменить непримененные изменения"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Отменить непримененные изменения (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Отбраковка тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "итогтрек"
@@ -639,21 +639,21 @@ msgstr "Загрузить метаданные MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Загрузить метаданные MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Успешно загружены тексты песен для {0} файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Загрузка текста..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
@@ -777,12 +777,12 @@ msgstr "Введите общее количество треков здесь"
 msgid "Enter year here"
 msgstr "Введите год"
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -804,12 +804,12 @@ msgstr "Выход"
 msgid "Export"
 msgstr "Экспортировать"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Экспортировать заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
@@ -820,11 +820,11 @@ msgstr "Экспортировать переднюю обложку альбо�
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
@@ -837,15 +837,15 @@ msgstr "Успешно экспортировано в: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "Не удалось выполнить поиск в MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "Неудачные поиски в MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
@@ -861,7 +861,7 @@ msgstr "Файл"
 msgid "File Name"
 msgstr "Имя файла"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -884,7 +884,7 @@ msgid "File Properties"
 msgstr "Свойства файла"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "имя файла"
 
@@ -893,12 +893,12 @@ msgstr "имя файла"
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Отпечаток был скопирован в буфер обмена."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Режим папки"
@@ -908,16 +908,16 @@ msgstr "Режим папки"
 msgid "Format"
 msgstr "Формат"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Формат строки"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -930,9 +930,9 @@ msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "жанр"
 
@@ -953,7 +953,7 @@ msgstr "Получить новый ключ API"
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
@@ -964,9 +964,9 @@ msgstr "Репозиторий GitHub"
 msgid "Height"
 msgstr "Светлая"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -994,7 +994,7 @@ msgstr "Импорт из LRC"
 msgid "Include Only Selected Files"
 msgstr "Включать только выбранные файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1014,17 +1014,17 @@ msgstr "Информация"
 msgid "Insert"
 msgstr "Вставить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Вставить заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Добавление обложки альбома..."
 
@@ -1042,11 +1042,11 @@ msgstr "КиБ"
 msgid "Language Code"
 msgstr "Языковой код"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr "Библиотека была изменена на диске."
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -1054,8 +1054,8 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
@@ -1063,7 +1063,7 @@ msgstr "Загрузка музыкальных файлов из библиот
 msgid "Lryics"
 msgstr "Текст"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "текст"
 
@@ -1077,6 +1077,10 @@ msgstr "Текст"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Основные свойства"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1113,12 +1117,12 @@ msgstr "Файлы"
 msgid "Music Library"
 msgstr "Музыкальная библиотека"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
@@ -1128,7 +1132,7 @@ msgstr "Новое пользовательское свойство"
 msgid "New Synchronized Lyric"
 msgstr "Новый синхронизированный текст"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
@@ -1137,15 +1141,15 @@ msgstr "Доступно новое обновление."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Для отпечатка файла не найдено записи AcoustId"
 
@@ -1153,20 +1157,20 @@ msgstr "Для отпечатка файла не найдено записи Ac
 msgid "No file selected"
 msgstr "Файл не выбран"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Не выбраны файлы для удаления."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Текст не был загружен"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Не выбрано ни одного музыкального файла."
 
@@ -1175,11 +1179,11 @@ msgstr "Не выбрано ни одного музыкального файл�
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "В библиотеке нет музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Для записи AcoustId не был предоставлен MusicBrainz RecordingId"
 
@@ -1188,7 +1192,7 @@ msgstr "Для записи AcoustId не был предоставлен MusicB
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr "Не настроен пользовательский ключ api."
 
@@ -1213,7 +1217,7 @@ msgstr "Выкл."
 msgid "Offset (in milliseconds)"
 msgstr "Смещение (в миллисекундах)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1233,7 +1237,7 @@ msgstr "ОК"
 msgid "On"
 msgstr "Вкл."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1242,7 +1246,7 @@ msgstr ""
 "Одновременно в AcoustID может быть представлен только один файл. Пожалуйста, "
 "выберите только один файл и повторите попытку."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Открыть"
@@ -1253,7 +1257,7 @@ msgid "Open a library with music to get started"
 msgstr "Откройте библиотеку с музыкой, чтобы начать"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1263,11 +1267,11 @@ msgstr "Откройте библиотеку с музыкой, чтобы на
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Открыть музыкальный файл"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1301,8 +1305,8 @@ msgstr "Путь"
 msgid "Path (Empty)"
 msgstr "Путь (пуст)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1314,21 +1318,21 @@ msgstr "Выберите дату"
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Файл плейлиста создан успешно."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Режим плейлиста"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr "Путь до плейлиста не должен быть пустым."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1343,15 +1347,15 @@ msgstr "Сохранение временной метки модификаци�
 msgid "PREVIEW"
 msgstr "ПРЕДПРОСМОТР"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Имя свойства"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "издатель"
 
@@ -1366,13 +1370,13 @@ msgid "Publishing Date"
 msgstr "Дата публикации"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 msgid "publishingdate"
 msgstr "publishingdate"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Перезагрузить"
@@ -1392,12 +1396,12 @@ msgstr "Перезагрузить библиотеку"
 msgid "Remove"
 msgstr "Удалить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Удалить файлы?"
@@ -1412,7 +1416,7 @@ msgstr "Удалить из плейлиста"
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr "Удаление обложки альбома..."
 
@@ -1438,8 +1442,8 @@ msgstr "Сохранить тег"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Сохранить тег (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
@@ -1462,14 +1466,14 @@ msgstr "Настройки"
 msgid "Show Extras Pane"
 msgstr "Показать дополнительную панель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1492,12 +1496,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Сортировать файлы по"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Отправить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1505,15 +1509,15 @@ msgstr "Отправить"
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1524,7 +1528,7 @@ msgstr "Отправка данных в AcoustId..."
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1541,7 +1545,7 @@ msgstr "Синхронизированные"
 msgid "Tag"
 msgstr "Тег"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1574,7 +1578,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr "Документация и каналы поддержки Tagger доступны через меню Справка."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1588,7 +1592,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Тема"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Этот файл не имеет действительного отпечатка"
 
@@ -1611,9 +1615,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "название"
 
@@ -1625,15 +1629,15 @@ msgstr "название"
 msgid "Title"
 msgstr "Название"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "трек"
 
@@ -1646,9 +1650,9 @@ msgid "Track"
 msgstr "Номер трека"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "итогтрек"
 
@@ -1673,15 +1677,15 @@ msgstr "Тип"
 msgid "Type ! for advanced search"
 msgstr "Введите ! для расширенного поиска"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Не удалось добавить файл в плейлист. Возможно, он уже добавлен."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Не удалось создать плейлист."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr "Не удалось загрузить и установить обновление."
 
@@ -1695,29 +1699,29 @@ msgstr "Невозможно экспортировать в LRC."
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Не удалось удалить некоторые файлы из плейлиста."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1740,7 +1744,7 @@ msgstr "Использовать текст из LRC"
 msgid "Use Relative Paths"
 msgstr "Использовать относительные пути"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Использовать относительные пути?"
@@ -1780,7 +1784,7 @@ msgstr ""
 "Хотите ли вы перезапустить {0}, чтобы применить новую тему?\n"
 "Вся несохраненная работа будет потеряна."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1792,9 +1796,9 @@ msgstr ""
 "Если нет, вместо этого будет использован полный путь."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "год"
 
@@ -1806,8 +1810,8 @@ msgstr "год"
 msgid "Year"
 msgstr "Год"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-12 14:20+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} � {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "Выбрано {0} из {1}"
@@ -38,63 +38,67 @@ msgstr "Выбрано {0} из {1}"
 msgid "{0} Playlist (*{1})"
 msgstr "Плейлист {0} (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%исполнитель%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%название%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%название%- %исполнитель%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<keep>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 МиБ"
 
@@ -103,8 +107,8 @@ msgstr "0 МиБ"
 msgid "About {0}"
 msgstr "О приложении"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -130,18 +134,18 @@ msgid "AcoustId User API Key"
 msgstr "Ключ API пользователя AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Добавить новое свойство"
 
@@ -152,7 +156,7 @@ msgid "Add to Playlist"
 msgstr "Добавить в плейлист"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Дополнительные свойства"
 
@@ -161,10 +165,10 @@ msgstr "Дополнительные свойства"
 msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "альбом"
 
@@ -186,21 +190,21 @@ msgstr "Обложка альбома"
 msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "альбомартист"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Все файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Все поддерживаемые типы файлов"
 
@@ -208,58 +212,58 @@ msgstr "Все поддерживаемые типы файлов"
 msgid "An application restart is required to change the theme."
 msgstr "Для применения темы необходим перезапуск приложения."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "MusicBrainz получил неверный RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "artist"
 
@@ -279,70 +283,70 @@ msgstr "Проверять обновления автоматически"
 msgid "B"
 msgstr "Б"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Задняя"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Вычисление..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Отмена"
@@ -365,27 +369,27 @@ msgstr "Очистить весь текст"
 msgid "Close Library"
 msgstr "Закрыть библиотеку"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "комментарий"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "композитор"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Композитор"
 
@@ -394,20 +398,20 @@ msgstr "Композитор"
 msgid "Configure"
 msgstr "Настроить"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "Участники на GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -415,7 +419,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -423,11 +427,11 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr "Конвертирование имён файлов в теги..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr "Конвертирование тегов в имена файлов..."
 
@@ -435,8 +439,8 @@ msgstr "Конвертирование тегов в имена файлов..."
 msgid "Copied debug info to clipboard."
 msgstr "Отладочная информация скопирована в буфер обмена."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Скопировать отпечаток в буфер обмена"
 
@@ -460,8 +464,8 @@ msgstr "Создать плейлист"
 msgid "Credits"
 msgstr "Авторы"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "пользовательский"
 
@@ -473,22 +477,22 @@ msgid "Custom"
 msgstr "Пользовательский"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Пользовательские свойства"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Пользовательские свойства можно редактировать только для отдельных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "Давид Лапшин"
 
@@ -500,21 +504,21 @@ msgstr "Удалить тег"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Удалить тег (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Удаление тегов..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "описание"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Описание"
 
@@ -545,23 +549,28 @@ msgstr ""
 "Переводчики:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Отменить"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Отменить"
 
@@ -573,9 +582,24 @@ msgstr "Отменить непримененные изменения"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Отменить непримененные изменения (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Отбраковка тегов..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "итогтрек"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -601,25 +625,25 @@ msgstr "Загрузить метаданные MusicBrainz"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Загрузить метаданные MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Успешно загружены тексты песен для {0} файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Загрузка текста..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr "Отпустите сюда чтобы открыть библиотеку"
 
@@ -689,6 +713,16 @@ msgstr "Введите свой выбор здесь"
 msgid "Enter description here"
 msgstr "Введите описание здесь"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Введите имя файла здесь"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Введите общее количество треков здесь"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr "Введите имя файла здесь"
@@ -709,7 +743,7 @@ msgstr "Введите код языка здесь"
 msgid "Enter offset here"
 msgstr "Введите смещение здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr "Введите издателя здесь"
 
@@ -729,12 +763,12 @@ msgstr "Введите общее количество треков здесь"
 msgid "Enter year here"
 msgstr "Введите год"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -749,19 +783,19 @@ msgstr "Выход"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Экспортировать"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Экспортировать заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
@@ -772,11 +806,11 @@ msgstr "Экспортировать переднюю обложку альбо�
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
@@ -785,19 +819,19 @@ msgstr "Успешно экспортированы в файл передние
 msgid "Exported successfully to: {0}"
 msgstr "Успешно экспортировано в: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr "Не удалось выполнить поиск в MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "Неудачные поиски в MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
@@ -813,9 +847,9 @@ msgstr "Файл"
 msgid "File Name"
 msgstr "Имя файла"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
@@ -830,28 +864,28 @@ msgstr "Имя файла в тег (Ctrl+F)"
 msgid "File Path"
 msgstr "Путь к файлу"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Свойства файла"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "имя файла"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Отпечаток был скопирован в буфер обмена."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr "Режим папки"
 
@@ -860,29 +894,29 @@ msgstr "Режим папки"
 msgid "Format"
 msgstr "Формат"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Формат строки"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Передняя"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "жанр"
 
@@ -903,19 +937,19 @@ msgstr "Получить новый ключ API"
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -923,7 +957,7 @@ msgid "Help"
 msgstr "Справка"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr "Скрыть панель дополнительных настроек"
 
@@ -938,31 +972,31 @@ msgstr "Импорт из LRC"
 msgid "Include Only Selected Files"
 msgstr "Включать только выбранные файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Информация"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Вставить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Вставить заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Добавление обложки альбома..."
 
@@ -980,11 +1014,11 @@ msgstr "КиБ"
 msgid "Language Code"
 msgstr "Языковой код"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr "Библиотека была изменена на диске."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -992,8 +1026,8 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
@@ -1001,7 +1035,7 @@ msgstr "Загрузка музыкальных файлов из библиот
 msgid "Lryics"
 msgstr "Текст"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "текст"
 
@@ -1027,7 +1061,7 @@ msgstr "Управление текстом песни"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Управление текстом (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
@@ -1045,13 +1079,13 @@ msgstr "Файлы"
 msgid "Music Library"
 msgstr "Музыкальная библиотека"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
@@ -1060,24 +1094,24 @@ msgstr "Новое пользовательское свойство"
 msgid "New Synchronized Lyric"
 msgstr "Новый синхронизированный текст"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Для отпечатка файла не найдено записи AcoustId"
 
@@ -1085,20 +1119,20 @@ msgstr "Для отпечатка файла не найдено записи Ac
 msgid "No file selected"
 msgstr "Файл не выбран"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Не выбраны файлы для удаления."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Текст не был загружен"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Не выбрано ни одного музыкального файла."
 
@@ -1107,11 +1141,11 @@ msgstr "Не выбрано ни одного музыкального файл�
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "В библиотеке нет музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Для записи AcoustId не был предоставлен MusicBrainz RecordingId"
 
@@ -1120,7 +1154,7 @@ msgstr "Для записи AcoustId не был предоставлен MusicB
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr "Не настроен пользовательский ключ api."
 
@@ -1145,11 +1179,11 @@ msgstr "Выкл."
 msgid "Offset (in milliseconds)"
 msgstr "Смещение (в миллисекундах)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "ОК"
 
@@ -1165,8 +1199,8 @@ msgstr "ОК"
 msgid "On"
 msgstr "Вкл."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1174,8 +1208,8 @@ msgstr ""
 "Одновременно в AcoustID может быть представлен только один файл. Пожалуйста, "
 "выберите только один файл и повторите попытку."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Открыть"
 
@@ -1185,7 +1219,7 @@ msgid "Open a library with music to get started"
 msgstr "Откройте библиотеку с музыкой, чтобы начать"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1195,11 +1229,11 @@ msgstr "Откройте библиотеку с музыкой, чтобы на
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Открыть музыкальный файл"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1233,10 +1267,10 @@ msgstr "Путь"
 msgid "Path (Empty)"
 msgstr "Путь (пуст)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1246,23 +1280,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Файл плейлиста создан успешно."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr "Режим плейлиста"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr "Путь до плейлиста не должен быть пустым."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Выберите формат строки."
 
@@ -1275,39 +1309,39 @@ msgstr "Сохранение временной метки модификаци�
 msgid "PREVIEW"
 msgstr "ПРЕДПРОСМОТР"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "издатель"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Издатель"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Издатель"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "издатель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr "Перезагрузить"
 
@@ -1319,20 +1353,20 @@ msgstr "Перезагрузить библиотеку"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Удалить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Удалить файлы?"
 
@@ -1346,7 +1380,7 @@ msgstr "Удалить из плейлиста"
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr "Удаление обложки альбома..."
 
@@ -1372,8 +1406,8 @@ msgstr "Сохранить тег"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Сохранить тег (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
@@ -1392,27 +1426,27 @@ msgstr "Выберите несколько файлов"
 msgid "Settings"
 msgstr "Настройки"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr "Показать дополнительную панель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1426,43 +1460,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Сортировать файлы по"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Отправить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Переключиться на переднюю обложку"
 
@@ -1475,9 +1509,9 @@ msgstr "Синхронизированные"
 msgid "Tag"
 msgstr "Тег"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Тег в имя файла"
@@ -1486,9 +1520,8 @@ msgstr "Тег в имя файла"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Тег в имя файла (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Редактируйте ваши музыкальные теги"
 
@@ -1497,9 +1530,8 @@ msgstr "Редактируйте ваши музыкальные теги"
 msgid "Tag Your Music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1508,8 +1540,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1522,7 +1554,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Тема"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Этот файл не имеет действительного отпечатка"
 
@@ -1544,10 +1576,10 @@ msgstr "ТиБ"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "название"
 
@@ -1559,15 +1591,15 @@ msgstr "название"
 msgid "Title"
 msgstr "Название"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "трек"
 
@@ -1579,14 +1611,14 @@ msgstr "трек"
 msgid "Track"
 msgstr "Номер трека"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "итогтрек"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Давид Лапшин <ddaudix@gmail.com>, 2023"
 
@@ -1605,15 +1637,15 @@ msgstr "Тип"
 msgid "Type ! for advanced search"
 msgstr "Введите ! для расширенного поиска"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Не удалось добавить файл в плейлист. Возможно, он уже добавлен."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Не удалось создать плейлист."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr "Не удалось загрузить и установить обновление."
 
@@ -1627,29 +1659,29 @@ msgstr "Невозможно экспортировать в LRC."
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Не удалось удалить некоторые файлы из плейлиста."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1658,7 +1690,7 @@ msgstr "Неизвестен"
 msgid "Unsynchronized"
 msgstr "Несинхронизированные"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr "Обновить"
 
@@ -1672,8 +1704,8 @@ msgstr "Использовать текст из LRC"
 msgid "Use Relative Paths"
 msgstr "Использовать относительные пути"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr "Использовать относительные пути?"
 
@@ -1707,8 +1739,8 @@ msgstr ""
 "Хотите ли вы перезапустить {0}, чтобы применить новую тему?\n"
 "Вся несохраненная работа будет потеряна."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1718,10 +1750,10 @@ msgstr ""
 "путь?\n"
 "Если нет, вместо этого будет использован полный путь."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "год"
 
@@ -1733,10 +1765,10 @@ msgstr "год"
 msgid "Year"
 msgstr "Год"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Да"
@@ -1869,15 +1901,24 @@ msgstr "Выбрать все файлы"
 msgid "Track Total"
 msgstr "Трек Всего"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Трек Всего"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Переключить панели тегов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Действия с тегами"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Применить изменения в тегах (Ctrl+S)"
 
@@ -1885,47 +1926,41 @@ msgstr "Применить изменения в тегах (Ctrl+S)"
 msgid "Tag;Music;Editor;Library;Nickvision;"
 msgstr "Тег;Музыка;Редактор;Библиотека;Nickvision;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Поддержка многих типов музыкальных файлов (mp3, ogg, flac, wma, wav и др.)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Поддержка многих типов музыкальных файлов (mp3, ogg, flac, wma, wav и "
+#~ "др.)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Редактируйте теги и обложки альбомов сразу для нескольких файлов, даже в "
-"под-папках"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Редактируйте теги и обложки альбомов сразу для нескольких файлов, даже "
+#~ "в под-папках"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Редактирование несинхронизированного и синхронизированного текста для "
-"файла (с поддержкой импорта и экспорта LRC)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Редактирование несинхронизированного и синхронизированного текста для "
+#~ "файла (с поддержкой импорта и экспорта LRC)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr "— Легко конвертируйте имена файлов в теги и теги в имена файлов"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr "— Легко конвертируйте имена файлов в теги и теги в имена файлов"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— Поиск информации о файлах с помощью MusicBrainz"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— Поиск информации о файлах с помощью MusicBrainz"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Поиск информации о тексте с помощью Music163 и Letras"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Поиск информации о тексте с помощью Music163 и Letras"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Открытие, управление и создание плейлистов в различных форматах (m3u, pls, "
-"xspf и др.)"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Открытие, управление и создание плейлистов в различных форматах (m3u, "
+#~ "pls, xspf и др.)"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Откройте библиотеку с музыкой, чтобы начать."

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-19 19:10+0000\n"
 "Last-Translator: Daudix UFO <ddaudix@gmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,91 +20,103 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.1\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr "{0} • {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "Выбрано {0} из {1}"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr "Плейлист {0} (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%исполнитель%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%название%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%название%- %исполнитель%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%трек%- %название%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<keep>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 МиБ"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "О приложении"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -130,18 +142,18 @@ msgid "AcoustId User API Key"
 msgstr "Ключ API пользователя AcoustId"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Добавить новое свойство"
 
@@ -151,28 +163,28 @@ msgstr "Добавить новое свойство"
 msgid "Add to Playlist"
 msgstr "Добавить в плейлист"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Дополнительные свойства"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Информация по продвинутому поиску"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "альбом"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Альбом"
 
@@ -181,26 +193,26 @@ msgstr "Альбом"
 msgid "Album Art"
 msgstr "Обложка альбома"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Исполнитель альбома"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "альбомартист"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Все файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Все поддерживаемые типы файлов"
 
@@ -208,66 +220,66 @@ msgstr "Все поддерживаемые типы файлов"
 msgid "An application restart is required to change the theme."
 msgstr "Для применения темы необходим перезапуск приложения."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "MusicBrainz получил неверный RecordingId"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Применить изменения?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "artist"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Исполнитель"
 
@@ -279,70 +291,72 @@ msgstr "Проверять обновления автоматически"
 msgid "B"
 msgstr "Б"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Задняя"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Ударов в минуту"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Вычисление..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "Отмена"
@@ -351,7 +365,7 @@ msgstr "Отмена"
 msgid "Changelog"
 msgstr "Список изменений"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr "Проверить обновления"
 
@@ -360,32 +374,36 @@ msgstr "Проверить обновления"
 msgid "Clear All Lyrics"
 msgstr "Очистить весь текст"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Закрыть библиотеку"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "комментарий"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Комментарий"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "композитор"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Композитор"
 
@@ -394,20 +412,20 @@ msgstr "Композитор"
 msgid "Configure"
 msgstr "Настроить"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "Участники на GitHub ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
@@ -415,7 +433,7 @@ msgstr[0] "Успешно преобразовано {0} имя файла в т
 msgstr[1] "Успешно преобразовано {0} имен файлов в теги"
 msgstr[2] "Успешно преобразовано {0} имен файлов в теги"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
@@ -423,11 +441,11 @@ msgstr[0] "Успешно преобразован {0} тег в имя файл
 msgstr[1] "Успешно преобразованы {0} тегов в имена файлов"
 msgstr[2] "Успешно преобразованы {0} тегов в имена файлов"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr "Конвертирование имён файлов в теги..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr "Конвертирование тегов в имена файлов..."
 
@@ -435,8 +453,8 @@ msgstr "Конвертирование тегов в имена файлов..."
 msgid "Copied debug info to clipboard."
 msgstr "Отладочная информация скопирована в буфер обмена."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Скопировать отпечаток в буфер обмена"
 
@@ -460,8 +478,8 @@ msgstr "Создать плейлист"
 msgid "Credits"
 msgstr "Авторы"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "пользовательский"
 
@@ -472,23 +490,23 @@ msgstr "пользовательский"
 msgid "Custom"
 msgstr "Пользовательский"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Пользовательские свойства"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 "Пользовательские свойства можно редактировать только для отдельных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "Давид Лапшин"
 
@@ -496,25 +514,25 @@ msgstr "Давид Лапшин"
 msgid "Delete Tag"
 msgstr "Удалить тег"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Удалить тег (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Удаление тегов..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "описание"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Описание"
 
@@ -545,23 +563,28 @@ msgstr ""
 "Переводчики:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Disc"
+msgstr "Отменить"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Отменить"
 
@@ -569,57 +592,72 @@ msgstr "Отменить"
 msgid "Discard Unapplied Changed"
 msgstr "Отменить непримененные изменения"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Отменить непримененные изменения (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Отбраковка тегов..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
+#, fuzzy
+msgid "disctotal"
+msgstr "итогтрек"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Обсуждения"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Документация"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Загрузить текст песни"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "Загрузить метаданные MusicBrainz"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "Загрузить метаданные MusicBrainz (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "Успешно загружены тексты песен для {0} файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "Метаданные для {0} файлов загружены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Загрузка текста..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "Загрузка метаданных MusicBrainz..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr "Отпустите сюда чтобы открыть библиотеку"
 
@@ -656,27 +694,27 @@ msgstr ""
 "Включает перезапись существующих метаданных тега данными, найденными из "
 "MusicBrainz. Если отключить, будут заполнены только пустые свойства тегов."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr "Введите исполнителя альбома здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr "Введите альбом здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr "Введите исполнителя здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr "Введите частоту ударов в минуту здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr "Введите комментарий здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr "Введите композитора здесь"
 
@@ -685,15 +723,25 @@ msgid "Enter custom choice here"
 msgstr "Введите свой выбор здесь"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr "Введите описание здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Введите имя файла здесь"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Введите общее количество треков здесь"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr "Введите имя файла здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr "Введите жанр здесь"
 
@@ -709,32 +757,32 @@ msgstr "Введите код языка здесь"
 msgid "Enter offset here"
 msgstr "Введите смещение здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr "Введите издателя здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr "Введите название"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr "Введите трек здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr "Введите общее количество треков здесь"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr "Введите год"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -748,20 +796,20 @@ msgid "Exit"
 msgstr "Выход"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Экспортировать"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Экспортировать заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
@@ -772,11 +820,11 @@ msgstr "Экспортировать переднюю обложку альбо�
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Успешный экспорт обложек альбомов в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
@@ -785,19 +833,19 @@ msgstr "Успешно экспортированы в файл передние
 msgid "Exported successfully to: {0}"
 msgstr "Успешно экспортировано в: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr "Не удалось выполнить поиск в MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "Неудачные поиски в MusicBrainz"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Не удалось экспортировать обложку альбома в файл"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Не удалось экспортировать обложки альбомов в файл"
 
@@ -806,21 +854,21 @@ msgid "File"
 msgstr "Файл"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Имя файла"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Имя файла в тег"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Имя файла в тег (Ctrl+F)"
 
@@ -830,28 +878,28 @@ msgstr "Имя файла в тег (Ctrl+F)"
 msgid "File Path"
 msgstr "Путь к файлу"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Свойства файла"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "имя файла"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Отпечаток был скопирован в буфер обмена."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Режим папки"
 
@@ -860,37 +908,39 @@ msgstr "Режим папки"
 msgid "Format"
 msgstr "Формат"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Формат строки"
 
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Передняя"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Фёдор Соболев"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "жанр"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Жанр"
 
@@ -903,27 +953,33 @@ msgstr "Получить новый ключ API"
 msgid "GiB"
 msgstr "ГиБ"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Светлая"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Справка"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr "Скрыть панель дополнительных настроек"
 
@@ -938,31 +994,37 @@ msgstr "Импорт из LRC"
 msgid "Include Only Selected Files"
 msgstr "Включать только выбранные файлы"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Информация"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Вставить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Вставить заднюю обложку альбома"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Вставить переднюю обложку альбома"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Добавление обложки альбома..."
 
@@ -980,11 +1042,11 @@ msgstr "КиБ"
 msgid "Language Code"
 msgstr "Языковой код"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr "Библиотека была изменена на диске."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
@@ -992,8 +1054,8 @@ msgstr[0] "Загружен {0} музыкальный файл."
 msgstr[1] "Загружено {0} музыкальных файлов."
 msgstr[2] "Загружено {0} музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
@@ -1001,39 +1063,45 @@ msgstr "Загрузка музыкальных файлов из библиот
 msgid "Lryics"
 msgstr "Текст"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "текст"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Текст"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Основные свойства"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Управление текстом песни"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Управление текстом (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Чат Matrix"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "МиБ"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Тип"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1045,13 +1113,13 @@ msgstr "Файлы"
 msgid "Music Library"
 msgstr "Музыкальная библиотека"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "ID записи MusicBrainz"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
@@ -1060,24 +1128,24 @@ msgstr "Новое пользовательское свойство"
 msgid "New Synchronized Lyric"
 msgstr "Новый синхронизированный текст"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr "Доступно новое обновление."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Нет"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Для отпечатка файла не найдено записи AcoustId"
 
@@ -1085,42 +1153,42 @@ msgstr "Для отпечатка файла не найдено записи Ac
 msgid "No file selected"
 msgstr "Файл не выбран"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Не выбраны файлы для удаления."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Текст не был загружен"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Метаданные не были загружены"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Не выбрано ни одного музыкального файла."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Не найдено музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "В библиотеке нет музыкальных файлов."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "Для записи AcoustId не был предоставлен MusicBrainz RecordingId"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Нет выбранных музыкальных файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr "Не настроен пользовательский ключ api."
 
@@ -1145,11 +1213,11 @@ msgstr "Выкл."
 msgid "Offset (in milliseconds)"
 msgstr "Смещение (в миллисекундах)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "ОК"
 
@@ -1165,8 +1233,8 @@ msgstr "ОК"
 msgid "On"
 msgstr "Вкл."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1174,37 +1242,37 @@ msgstr ""
 "Одновременно в AcoustID может быть представлен только один файл. Пожалуйста, "
 "выберите только один файл и повторите попытку."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Открыть"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Откройте библиотеку с музыкой, чтобы начать"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Открыть музыкальный файл"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Открыть плейлист"
 
@@ -1233,10 +1301,10 @@ msgstr "Путь"
 msgid "Path (Empty)"
 msgstr "Путь (пуст)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr "Выберите дату"
 
@@ -1246,23 +1314,23 @@ msgstr "Выберите дату"
 msgid "Playlist"
 msgstr "Плейлист"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Файл плейлиста создан успешно."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Режим плейлиста"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr "Путь до плейлиста не должен быть пустым."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Выберите формат строки."
 
@@ -1275,37 +1343,37 @@ msgstr "Сохранение временной метки модификаци�
 msgid "PREVIEW"
 msgstr "ПРЕДПРОСМОТР"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Имя свойства"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "издатель"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Издатель"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Publishing Date"
 msgstr "Дата публикации"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 msgid "publishingdate"
 msgstr "publishingdate"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Перезагрузить"
 
@@ -1316,21 +1384,21 @@ msgid "Reload Library"
 msgstr "Перезагрузить библиотеку"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Удалить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Удалить пользовательское свойство"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Удалить файлы?"
 
@@ -1344,11 +1412,11 @@ msgstr "Удалить из плейлиста"
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr "Удаление обложки альбома..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr "Сообщить об ошибке"
 
@@ -1361,17 +1429,17 @@ msgid "Save Playlist"
 msgstr "Сохранить плейлист"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Сохранить тег"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr "Сохранить тег (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Сохранение тегов..."
 
@@ -1380,8 +1448,8 @@ msgstr "Сохранение тегов..."
 msgid "Select Save Location"
 msgstr "Выберите путь для сохранения"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Выберите несколько файлов"
 
@@ -1390,27 +1458,27 @@ msgstr "Выберите несколько файлов"
 msgid "Settings"
 msgstr "Настройки"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr "Показать дополнительную панель"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1424,43 +1492,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Сортировать файлы по"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Отправить"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "Отправить в AcoustId"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "Метаданные для AcoustId предоставлены успешно"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "Отправка данных в AcoustId..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Переключиться на заднюю обложку"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Переключиться на переднюю обложку"
 
@@ -1473,41 +1541,41 @@ msgstr "Синхронизированные"
 msgid "Tag"
 msgstr "Тег"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Тег в имя файла"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Тег в имя файла (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Редактируйте ваши музыкальные теги"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
 #: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr "Документация и каналы поддержки Tagger доступны через меню Справка."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1520,7 +1588,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Тема"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Этот файл не имеет действительного отпечатка"
 
@@ -1542,56 +1610,56 @@ msgstr "ТиБ"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "название"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Название"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Выбрано слишком много файлов"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "трек"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Номер трека"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "итогтрек"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr ""
 "Давид Лапшин <ddaudix@gmail.com>, 2023\n"
 "0куе <>, 2023"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Попробовать другую библиотеку"
 
@@ -1600,20 +1668,20 @@ msgstr "Попробовать другую библиотеку"
 msgid "Type"
 msgstr "Тип"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr "Введите ! для расширенного поиска"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr "Не удалось добавить файл в плейлист. Возможно, он уже добавлен."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Не удалось создать плейлист."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr "Не удалось загрузить и установить обновление."
 
@@ -1627,29 +1695,29 @@ msgstr "Невозможно экспортировать в LRC."
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Не удалось загрузить файл изображения"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Не удалось удалить некоторые файлы из плейлиста."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "Невозможно сохранить {0}"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "Невозможно сохранить {0}."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "Невозможно отправить заявку на AcoustId. Проверьте ключ API"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1658,7 +1726,7 @@ msgstr "Неизвестен"
 msgid "Unsynchronized"
 msgstr "Несинхронизированные"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr "Обновить"
 
@@ -1672,8 +1740,8 @@ msgstr "Использовать текст из LRC"
 msgid "Use Relative Paths"
 msgstr "Использовать относительные пути"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Использовать относительные пути?"
 
@@ -1682,10 +1750,10 @@ msgstr "Использовать относительные пути?"
 msgid "User Interface"
 msgstr "Интерфейс"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Веб-сервисы"
 
@@ -1698,6 +1766,11 @@ msgstr ""
 "Что вы хотите, чтобы Tagger делал с текстом, найденном в файле LRC, которые "
 "конфликтуют с существующим текстом с той же временной меткой?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1707,8 +1780,8 @@ msgstr ""
 "Хотите ли вы перезапустить {0}, чтобы применить новую тему?\n"
 "Вся несохраненная работа будет потеряна."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1718,25 +1791,25 @@ msgstr ""
 "путь?\n"
 "Если нет, вместо этого будет использован полный путь."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "год"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Год"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Да"
@@ -1810,7 +1883,7 @@ msgid "Remove Front Album Art"
 msgstr "Удалить переднюю обложку альбома"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Переключить обложку альбома"
 
@@ -1841,43 +1914,52 @@ msgstr "Выйти"
 msgid "About Tagger"
 msgstr "О Tagger"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Меню библиотеки"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Библиотека"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Главное меню"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Открыть папку (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Открыть плейлист (Ctrl+Shift+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Выбрать все файлы"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Трек Всего"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
+#, fuzzy
+msgid "Disc Total"
+msgstr "Трек Всего"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Переключить панели тегов"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Действия с тегами"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Применить изменения в тегах (Ctrl+S)"
 

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,26 +60,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -95,7 +93,9 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -127,7 +127,7 @@ msgid ""
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr ""
 
@@ -164,9 +164,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr ""
 
@@ -189,9 +189,9 @@ msgid "Album Artist"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
@@ -259,9 +259,9 @@ msgid "Apply Changes?"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr ""
 
@@ -297,21 +297,21 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -374,9 +374,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr ""
 
@@ -386,9 +386,9 @@ msgid "Comment"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr ""
 
@@ -415,25 +415,25 @@ msgstr ""
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -467,7 +467,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr ""
 
@@ -505,14 +505,14 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 msgid "disctotal"
 msgstr ""
 
@@ -613,21 +613,21 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
@@ -643,19 +643,19 @@ msgid "Edit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -742,12 +742,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr ""
 
@@ -785,11 +785,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -806,11 +806,11 @@ msgstr ""
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgid "File Properties"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr ""
 
@@ -895,9 +895,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgid "Genre"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1006,19 +1006,19 @@ msgstr ""
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr ""
 
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1120,15 +1120,15 @@ msgstr ""
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr ""
 
@@ -1137,11 +1137,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr ""
 
@@ -1237,17 +1237,17 @@ msgid "Open Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr ""
 
@@ -1309,9 +1309,9 @@ msgid "Property Name"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr ""
 
@@ -1326,9 +1326,9 @@ msgid "Publishing Date"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 msgid "publishingdate"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr ""
 
@@ -1398,8 +1398,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr ""
 
@@ -1463,11 +1463,11 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1565,9 +1565,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr ""
 
@@ -1585,9 +1585,9 @@ msgid "Too Many Files Selected"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr ""
 
@@ -1600,9 +1600,9 @@ msgid "Track"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr ""
 
@@ -1625,15 +1625,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1647,29 +1647,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr ""
 
@@ -1704,7 +1704,7 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr ""
@@ -1737,9 +1737,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr ""
 
@@ -1793,6 +1793,14 @@ msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,17 +18,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
@@ -36,63 +44,63 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr ""
 
@@ -100,13 +108,13 @@ msgstr ""
 msgid "0 MiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -124,18 +132,18 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr ""
 
@@ -145,28 +153,28 @@ msgstr ""
 msgid "Add to Playlist"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr ""
 
@@ -175,26 +183,26 @@ msgstr ""
 msgid "Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr ""
 
@@ -202,66 +210,66 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr ""
 
@@ -273,70 +281,72 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr ""
@@ -345,7 +355,7 @@ msgstr ""
 msgid "Changelog"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr ""
 
@@ -354,32 +364,36 @@ msgstr ""
 msgid "Clear All Lyrics"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr ""
 
@@ -388,38 +402,38 @@ msgstr ""
 msgid "Configure"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -427,8 +441,8 @@ msgstr ""
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -452,8 +466,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr ""
 
@@ -464,22 +478,22 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr ""
 
@@ -487,25 +501,25 @@ msgstr ""
 msgid "Delete Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr ""
 
@@ -525,27 +539,27 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 msgid "Disc"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr ""
 
@@ -553,71 +567,71 @@ msgstr ""
 msgid "Discard Unapplied Changed"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 msgid "disctotal"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr ""
 
@@ -647,27 +661,27 @@ msgid ""
 "If disabled, only blank tag properties will be filled."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr ""
 
@@ -676,23 +690,23 @@ msgid "Enter custom choice here"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 msgid "Enter disc number here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter disc total here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr ""
 
@@ -708,32 +722,32 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr ""
 
@@ -747,20 +761,20 @@ msgid "Exit"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -771,11 +785,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -784,19 +798,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -805,21 +819,21 @@ msgid "File"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr ""
 
@@ -829,28 +843,28 @@ msgstr ""
 msgid "File Path"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
 
@@ -859,37 +873,39 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr ""
 
@@ -902,27 +918,32 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+msgid "Height"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -937,31 +958,37 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr ""
 
@@ -979,19 +1006,19 @@ msgstr ""
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -999,38 +1026,43 @@ msgstr ""
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
+msgstr ""
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+msgid "Mime Type"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
@@ -1043,13 +1075,13 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
 
@@ -1058,24 +1090,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1083,42 +1115,42 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr ""
 
@@ -1143,11 +1175,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr ""
 
@@ -1163,44 +1195,44 @@ msgstr ""
 msgid "On"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr ""
 
@@ -1229,10 +1261,10 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1242,23 +1274,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr ""
 
@@ -1271,37 +1303,37 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Publishing Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr ""
 
@@ -1312,21 +1344,21 @@ msgid "Reload Library"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr ""
 
@@ -1340,11 +1372,11 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr ""
 
@@ -1357,17 +1389,17 @@ msgid "Save Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr ""
 
@@ -1376,8 +1408,8 @@ msgstr ""
 msgid "Select Save Location"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr ""
 
@@ -1386,27 +1418,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1418,43 +1450,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1467,39 +1499,41 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1510,7 +1544,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1530,54 +1564,54 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr ""
 
@@ -1586,20 +1620,20 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1613,29 +1647,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr ""
 
@@ -1644,7 +1678,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr ""
 
@@ -1658,8 +1692,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1668,10 +1702,10 @@ msgstr ""
 msgid "User Interface"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr ""
 
@@ -1682,6 +1716,11 @@ msgid ""
 "conflict with existing lyrics of the same timestamp?"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1689,33 +1728,33 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1789,7 +1828,7 @@ msgid "Remove Front Album Art"
 msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr ""
 
@@ -1820,54 +1859,89 @@ msgstr ""
 msgid "About Tagger"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 msgid "Disc Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;Nickvision;"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr ""
+
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
 msgstr ""

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,8 +23,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -60,34 +60,24 @@ msgstr ""
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -95,9 +85,19 @@ msgstr ""
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -113,7 +113,7 @@ msgstr ""
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -132,7 +132,7 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -164,9 +164,9 @@ msgid "Advanced Search Info"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr ""
 
@@ -189,9 +189,9 @@ msgid "Album Artist"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr ""
 
@@ -201,8 +201,8 @@ msgstr ""
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr ""
 
@@ -210,18 +210,18 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -238,14 +238,14 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -259,9 +259,9 @@ msgid "Apply Changes?"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr ""
 
@@ -282,8 +282,8 @@ msgid "B"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -297,40 +297,40 @@ msgid "Beats Per Minute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -374,9 +374,9 @@ msgid "Close Library"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr ""
 
@@ -386,9 +386,9 @@ msgid "Comment"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr ""
 
@@ -406,8 +406,8 @@ msgstr ""
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -415,25 +415,25 @@ msgstr ""
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -467,7 +467,7 @@ msgid "Credits"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr ""
 
@@ -505,14 +505,14 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr ""
 
@@ -543,14 +543,14 @@ msgstr ""
 msgid "Disc"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -571,21 +571,21 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 msgid "disctotal"
 msgstr ""
 
@@ -613,21 +613,21 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
@@ -742,12 +742,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr ""
 
@@ -769,12 +769,12 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -785,11 +785,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -802,15 +802,15 @@ msgstr ""
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -849,7 +849,7 @@ msgid "File Properties"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr ""
 
@@ -858,12 +858,12 @@ msgstr ""
 msgid "Fingerprint"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr ""
@@ -873,16 +873,16 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -895,9 +895,9 @@ msgid "Fyodor Sobolev"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr ""
@@ -928,9 +928,9 @@ msgstr ""
 msgid "Height"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -978,17 +978,17 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr ""
 
@@ -1006,19 +1006,19 @@ msgstr ""
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr ""
 
@@ -1039,6 +1039,10 @@ msgstr ""
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
@@ -1075,12 +1079,12 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr ""
@@ -1090,7 +1094,7 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr ""
 
@@ -1099,15 +1103,15 @@ msgstr ""
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1115,20 +1119,20 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr ""
 
@@ -1137,11 +1141,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1150,7 +1154,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr ""
 
@@ -1175,7 +1179,7 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1195,14 +1199,14 @@ msgstr ""
 msgid "On"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr ""
@@ -1213,7 +1217,7 @@ msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1223,11 +1227,11 @@ msgstr ""
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1261,8 +1265,8 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1274,21 +1278,21 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1303,15 +1307,15 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr ""
 
@@ -1326,13 +1330,13 @@ msgid "Publishing Date"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr ""
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr ""
@@ -1372,7 +1376,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr ""
 
@@ -1398,8 +1402,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr ""
 
@@ -1422,14 +1426,14 @@ msgstr ""
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1450,12 +1454,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1463,15 +1467,15 @@ msgstr ""
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1499,7 +1503,7 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1532,7 +1536,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1544,7 +1548,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1565,9 +1569,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr ""
 
@@ -1579,15 +1583,15 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr ""
 
@@ -1600,9 +1604,9 @@ msgid "Track"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr ""
 
@@ -1625,15 +1629,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1647,29 +1651,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr ""
 
@@ -1692,7 +1696,7 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr ""
@@ -1728,7 +1732,7 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1737,9 +1741,9 @@ msgid ""
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr ""
 
@@ -1751,8 +1755,8 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, csharp-format
 msgid "{0} • {1}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr ""
@@ -36,63 +36,67 @@ msgstr ""
 msgid "{0} Playlist (*{1})"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr ""
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr ""
 
@@ -101,8 +105,8 @@ msgstr ""
 msgid "About {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -120,18 +124,18 @@ msgid "AcoustId User API Key"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr ""
 
@@ -142,7 +146,7 @@ msgid "Add to Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr ""
 
@@ -151,10 +155,10 @@ msgstr ""
 msgid "Advanced Search Info"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr ""
 
@@ -176,21 +180,21 @@ msgstr ""
 msgid "Album Artist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr ""
 
@@ -198,58 +202,58 @@ msgstr ""
 msgid "An application restart is required to change the theme."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr ""
 
@@ -269,70 +273,70 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr ""
@@ -355,27 +359,27 @@ msgstr ""
 msgid "Close Library"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr ""
 
@@ -384,38 +388,38 @@ msgstr ""
 msgid "Configure"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr ""
 
@@ -423,8 +427,8 @@ msgstr ""
 msgid "Copied debug info to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr ""
 
@@ -448,8 +452,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr ""
 
@@ -461,21 +465,21 @@ msgid "Custom"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr ""
 
@@ -487,21 +491,21 @@ msgstr ""
 msgid "Delete Tag (Shift+Delete)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr ""
 
@@ -521,23 +525,27 @@ msgid ""
 "{3}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+msgid "Disc"
+msgstr ""
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr ""
 
@@ -549,8 +557,22 @@ msgstr ""
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+msgid "disctotal"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
@@ -577,25 +599,25 @@ msgstr ""
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr ""
 
@@ -658,6 +680,14 @@ msgstr ""
 msgid "Enter description here"
 msgstr ""
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+msgid "Enter disc number here"
+msgstr ""
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+msgid "Enter disc total here"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr ""
@@ -678,7 +708,7 @@ msgstr ""
 msgid "Enter offset here"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr ""
 
@@ -698,12 +728,12 @@ msgstr ""
 msgid "Enter year here"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr ""
 
@@ -718,19 +748,19 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr ""
@@ -741,11 +771,11 @@ msgstr ""
 msgid "Export to LRC"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr ""
 
@@ -754,19 +784,19 @@ msgstr ""
 msgid "Exported successfully to: {0}"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr ""
 
@@ -782,9 +812,9 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr ""
@@ -799,28 +829,28 @@ msgstr ""
 msgid "File Path"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr ""
 
@@ -829,29 +859,29 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr ""
 
@@ -872,19 +902,19 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -892,7 +922,7 @@ msgid "Help"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr ""
 
@@ -907,31 +937,31 @@ msgstr ""
 msgid "Include Only Selected Files"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr ""
 
@@ -949,19 +979,19 @@ msgstr ""
 msgid "Language Code"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr ""
 
@@ -969,7 +999,7 @@ msgstr ""
 msgid "Lryics"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr ""
 
@@ -995,7 +1025,7 @@ msgstr ""
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr ""
 
@@ -1013,13 +1043,13 @@ msgstr ""
 msgid "Music Library"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr ""
 
@@ -1028,24 +1058,24 @@ msgstr ""
 msgid "New Synchronized Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr ""
 
@@ -1053,20 +1083,20 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr ""
 
@@ -1075,11 +1105,11 @@ msgstr ""
 msgid "No Music Files Found"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr ""
 
@@ -1088,7 +1118,7 @@ msgstr ""
 msgid "No Selected Music Files"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr ""
 
@@ -1113,11 +1143,11 @@ msgstr ""
 msgid "Offset (in milliseconds)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr ""
 
@@ -1133,15 +1163,15 @@ msgstr ""
 msgid "On"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr ""
 
@@ -1151,7 +1181,7 @@ msgid "Open a library with music to get started"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1161,11 +1191,11 @@ msgstr ""
 msgid "Open Folder"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1199,10 +1229,10 @@ msgstr ""
 msgid "Path (Empty)"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1212,23 +1242,23 @@ msgstr ""
 msgid "Playlist"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr ""
 
@@ -1241,37 +1271,37 @@ msgstr ""
 msgid "PREVIEW"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 msgid "Publishing Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 msgid "publishingdate"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr ""
 
@@ -1283,20 +1313,20 @@ msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr ""
 
@@ -1310,7 +1340,7 @@ msgstr ""
 msgid "Remove Lyric"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr ""
 
@@ -1336,8 +1366,8 @@ msgstr ""
 msgid "Save Tag (Ctrl+S)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr ""
 
@@ -1356,27 +1386,27 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1388,43 +1418,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr ""
 
@@ -1437,9 +1467,9 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr ""
@@ -1448,9 +1478,8 @@ msgstr ""
 msgid "Tag to File Name (Ctrl+T)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr ""
 
@@ -1459,9 +1488,8 @@ msgstr ""
 msgid "Tag Your Music"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr ""
 
@@ -1470,8 +1498,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Theme"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr ""
 
@@ -1502,10 +1530,10 @@ msgstr ""
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr ""
 
@@ -1517,15 +1545,15 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr ""
 
@@ -1537,14 +1565,14 @@ msgstr ""
 msgid "Track"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr ""
 
@@ -1563,15 +1591,15 @@ msgstr ""
 msgid "Type ! for advanced search"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr ""
 
@@ -1585,29 +1613,29 @@ msgstr ""
 msgid "Unable to import from LRC."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr ""
 
@@ -1616,7 +1644,7 @@ msgstr ""
 msgid "Unsynchronized"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr ""
 
@@ -1630,8 +1658,8 @@ msgstr ""
 msgid "Use Relative Paths"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr ""
 
@@ -1661,18 +1689,18 @@ msgid ""
 "Any unsaved work will be lost."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
 "If not, the full path will be used instead."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr ""
 
@@ -1684,10 +1712,10 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr ""
@@ -1820,53 +1848,26 @@ msgstr ""
 msgid "Track Total"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+msgid "Disc Total"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr ""
 
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:11
 msgid "Tag;Music;Editor;Library;Nickvision;"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr ""
-
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
 msgstr ""

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-18 16:41-0400\n"
+"POT-Creation-Date: 2023-10-19 11:17-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1421
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0}  /  {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1452
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1483
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1349
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1399
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} / {1} seçildi"
@@ -37,63 +37,67 @@ msgstr "{0} / {1} seçildi"
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Çalma Listesi (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:199
+#: ../../../Controllers/MainWindowController.cs:209
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:595
-#: ../../../Controllers/MainWindowController.cs:606
-#: ../../../Controllers/MainWindowController.cs:611
+#: ../../../Controllers/MainWindowController.cs:605
 #: ../../../Controllers/MainWindowController.cs:616
 #: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:633
-#: ../../../Controllers/MainWindowController.cs:645
-#: ../../../Controllers/MainWindowController.cs:657
-#: ../../../Controllers/MainWindowController.cs:662
+#: ../../../Controllers/MainWindowController.cs:626
+#: ../../../Controllers/MainWindowController.cs:631
+#: ../../../Controllers/MainWindowController.cs:643
+#: ../../../Controllers/MainWindowController.cs:655
 #: ../../../Controllers/MainWindowController.cs:667
 #: ../../../Controllers/MainWindowController.cs:672
 #: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:689
-#: ../../../Controllers/MainWindowController.cs:694
+#: ../../../Controllers/MainWindowController.cs:682
+#: ../../../Controllers/MainWindowController.cs:687
 #: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:715
-#: ../../../Controllers/MainWindowController.cs:1752
-#: ../../../Controllers/MainWindowController.cs:1753
-#: ../../../Controllers/MainWindowController.cs:1754
-#: ../../../Controllers/MainWindowController.cs:1755
-#: ../../../Controllers/MainWindowController.cs:1756
-#: ../../../Controllers/MainWindowController.cs:1757
-#: ../../../Controllers/MainWindowController.cs:1758
-#: ../../../Controllers/MainWindowController.cs:1759
-#: ../../../Controllers/MainWindowController.cs:1760
-#: ../../../Controllers/MainWindowController.cs:1761
-#: ../../../Controllers/MainWindowController.cs:1762
-#: ../../../Controllers/MainWindowController.cs:1763
-#: ../../../Controllers/MainWindowController.cs:1764
-#: ../../../Controllers/MainWindowController.cs:1765
-#: ../../../Controllers/MainWindowController.cs:1766
-#: ../../../Controllers/MainWindowController.cs:1770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1511
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1514
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1419
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1506
+#: ../../../Controllers/MainWindowController.cs:704
+#: ../../../Controllers/MainWindowController.cs:716
+#: ../../../Controllers/MainWindowController.cs:728
+#: ../../../Controllers/MainWindowController.cs:733
+#: ../../../Controllers/MainWindowController.cs:749
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1839
+#: ../../../Controllers/MainWindowController.cs:1840
+#: ../../../Controllers/MainWindowController.cs:1841
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../Controllers/MainWindowController.cs:1843
+#: ../../../Controllers/MainWindowController.cs:1844
+#: ../../../Controllers/MainWindowController.cs:1845
+#: ../../../Controllers/MainWindowController.cs:1846
+#: ../../../Controllers/MainWindowController.cs:1847
+#: ../../../Controllers/MainWindowController.cs:1848
+#: ../../../Controllers/MainWindowController.cs:1849
+#: ../../../Controllers/MainWindowController.cs:1850
+#: ../../../Controllers/MainWindowController.cs:1851
+#: ../../../Controllers/MainWindowController.cs:1855
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
 msgid "<keep>"
 msgstr "<koru>"
 
-#: ../../../Models/PropertyMap.cs:132
+#: ../../../Models/PropertyMap.cs:142
 msgid "0 MiB"
 msgstr "0 MiB"
 
@@ -102,8 +106,8 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "{0} Hakkında"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -128,18 +132,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Kullanıcı API Anahtarı"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:558
+#: NickvisionTagger.GNOME/Blueprints/window.blp:590
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
 msgid "Add New Property"
 msgstr "Yeni Özellik Ekle"
 
@@ -150,7 +154,7 @@ msgid "Add to Playlist"
 msgstr "Çalma Listesine Ekle"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:506
+#: NickvisionTagger.GNOME/Blueprints/window.blp:538
 msgid "Additional Properties"
 msgstr "Ek Özellikler"
 
@@ -159,10 +163,10 @@ msgstr "Ek Özellikler"
 msgid "Advanced Search Info"
 msgstr "Gelişmiş Arama Bilgisi"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:649
-#: ../../../Models/MusicFile.cs:760
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1357
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
+#: ../../../Models/MusicFile.cs:805
 msgid "album"
 msgstr "album"
 
@@ -184,21 +188,21 @@ msgstr "Albüm Kapağı"
 msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1373
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:677
-#: ../../../Models/MusicFile.cs:776
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1406
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
+#: ../../../Models/MusicFile.cs:821
 msgid "albumartist"
 msgstr "albumartist"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1060
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
 msgid "All files"
 msgstr "Tüm Dosyalar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:715
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
 msgid "All Supported Files"
 msgstr "Tüm Desteklenen Dosyalar"
 
@@ -206,58 +210,58 @@ msgstr "Tüm Desteklenen Dosyalar"
 msgid "An application restart is required to change the theme."
 msgstr "Temayı değiştirmek için uygulamanın yeniden başlatılması gerekir."
 
-#: ../../../Controllers/MainWindowController.cs:1210
+#: ../../../Controllers/MainWindowController.cs:1244
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:647
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:753
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:793
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:861
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:933
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1146
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1204
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1251
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:295
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:569
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:703
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:781
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:847
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:907
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1202
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:659
+#: NickvisionTagger.GNOME/Blueprints/window.blp:691
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:293
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:567
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:602
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:701
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:779
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:845
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:905
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1200
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1320
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:645
-#: ../../../Models/MusicFile.cs:756
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1353
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
+#: ../../../Models/MusicFile.cs:801
 msgid "artist"
 msgstr "sanatçı"
 
@@ -277,70 +281,70 @@ msgstr "Güncellemeleri Kendiliğinden Denetle"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:49
 msgid "Back"
 msgstr "Arka"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:545
 msgid "Beats Per Minute"
 msgstr "Dakika Başına Vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:689
-#: ../../../Models/MusicFile.cs:788
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1418
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
+#: ../../../Models/MusicFile.cs:833
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1644
-#: ../../../Controllers/MainWindowController.cs:1650
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1733
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1529
+#: ../../../Controllers/MainWindowController.cs:1717
+#: ../../../Controllers/MainWindowController.cs:1723
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
 msgid "Calculating..."
 msgstr "Hesaplanıyor..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:642
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:748
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:788
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:856
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:928
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1141
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1246
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "İptal"
@@ -363,27 +367,27 @@ msgstr "Tüm Şarkı Sözlerini Temizle"
 msgid "Close Library"
 msgstr "Kitaplığı Kapat"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:685
-#: ../../../Models/MusicFile.cs:784
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1414
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
+#: ../../../Models/MusicFile.cs:829
 msgid "comment"
 msgstr "yorum"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:509
+#: NickvisionTagger.GNOME/Blueprints/window.blp:541
 msgid "Comment"
 msgstr "Yorum"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1400
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:792
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1433
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
+#: ../../../Models/MusicFile.cs:837
 msgid "composer"
 msgstr "besteci"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:517
+#: NickvisionTagger.GNOME/Blueprints/window.blp:549
 msgid "Composer"
 msgstr "Besteci"
 
@@ -392,38 +396,38 @@ msgstr "Besteci"
 msgid "Configure"
 msgstr "Yapılandır"
 
-#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:176
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:60
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:938
+#: ../../../Controllers/MainWindowController.cs:972
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:1006
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:917
+#: ../../../Controllers/MainWindowController.cs:951
 msgid "Converting file names to tags..."
 msgstr "Dosya adları etikete dönüştürülüyor..."
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:985
 msgid "Converting tags to file names..."
 msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 
@@ -431,8 +435,8 @@ msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 msgid "Copied debug info to clipboard."
 msgstr "Hata ayıklama bilgisi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:598
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:630
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Parmak İzini Panoya Kopyala"
 
@@ -456,8 +460,8 @@ msgstr "Çalma Listesi Oluştur"
 msgid "Credits"
 msgstr "Hazırlayanlar"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Controllers/MainWindowController.cs:194
+#: ../../../Controllers/MainWindowController.cs:1490
 msgid "custom"
 msgstr "özel"
 
@@ -469,21 +473,21 @@ msgid "Custom"
 msgstr "Özel"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
-#: NickvisionTagger.GNOME/Blueprints/window.blp:550
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 msgid "Custom Properties"
 msgstr "Özel Özellikler"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:567
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: NickvisionTagger.GNOME/Blueprints/window.blp:599
 msgid "Custom properties can only be edited for individual files."
 msgstr "Özel özellikler yalnızca bağımsız dosyalar için düzenlenebilir."
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:179
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:180
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -495,21 +499,21 @@ msgstr "Etiketi Sil"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Etiketi Sil (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:884
+#: ../../../Controllers/MainWindowController.cs:918
 msgid "Deleting tags..."
 msgstr "Etiketler siliniyor..."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:796
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1437
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
+#: ../../../Models/MusicFile.cs:841
 msgid "description"
 msgstr "açıklama"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:521
+#: NickvisionTagger.GNOME/Blueprints/window.blp:553
 msgid "Description"
 msgstr "Açıklama"
 
@@ -540,23 +544,28 @@ msgstr ""
 "Çevirmenler:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:645
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:751
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:791
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:859
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1144
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1202
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1249
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#, fuzzy
+msgid "Disc"
+msgstr "Gözden Çıkar"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
 msgid "Discard"
 msgstr "Gözden Çıkar"
 
@@ -568,9 +577,24 @@ msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:852
+#: ../../../Controllers/MainWindowController.cs:886
 msgid "Discarding tags..."
 msgstr "Etiketler gözden çıkarılıyor..."
+
+#: ../../../Controllers/MainWindowController.cs:192
+#: ../../../Controllers/MainWindowController.cs:1441
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
+#: ../../../Models/MusicFile.cs:845
+msgid "discnumber"
+msgstr ""
+
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1456
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
+#: ../../../Models/MusicFile.cs:849
+#, fuzzy
+msgid "disctotal"
+msgstr "toplam parça"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "Discussions"
@@ -596,25 +620,25 @@ msgstr "MusicBrainz Üst Verilerini İndir"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz Üst Verilerini İndir (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} dosya için şarkı sözleri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "Downloading lyrics..."
 msgstr "Şarkı sözleri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:1179
+#: ../../../Controllers/MainWindowController.cs:1213
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:395
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
 msgid "Drop here to open library"
 msgstr "Kitaplık açmak için buraya bırakın"
 
@@ -685,6 +709,16 @@ msgstr "Özel seçimi buraya girin"
 msgid "Enter description here"
 msgstr "Açıklamayı buraya girin"
 
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#, fuzzy
+msgid "Enter disc number here"
+msgstr "Dosya adını buraya girin"
+
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#, fuzzy
+msgid "Enter disc total here"
+msgstr "Toplam parça sayısını buraya girin"
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
 msgid "Enter file name here"
 msgstr "Dosya adını buraya girin"
@@ -705,7 +739,7 @@ msgstr "Dil kodunu buraya girin"
 msgid "Enter offset here"
 msgstr "Ofseti buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 msgid "Enter publisher here"
 msgstr "Yayımcıyı buraya girin"
 
@@ -725,12 +759,12 @@ msgstr "Toplam parça sayısını buraya girin"
 msgid "Enter year here"
 msgstr "Yılı buraya girin"
 
-#: ../../../Controllers/MainWindowController.cs:1212
+#: ../../../Controllers/MainWindowController.cs:1246
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:404 ../../../Models/MusicFile.cs:833
-#: ../../../Models/MusicFile.cs:992
+#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
+#: ../../../Models/MusicFile.cs:1051
 msgid "ERROR"
 msgstr "HATA"
 
@@ -745,19 +779,19 @@ msgstr "Çık"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
 #: NickvisionTagger.GNOME/Blueprints/window.blp:53
 #: NickvisionTagger.GNOME/Blueprints/window.blp:337
 msgid "Export"
 msgstr "Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Albüm Arka Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1078
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
@@ -768,11 +802,11 @@ msgstr "Albüm Ön Kapağını Dışa Aktar"
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:1106
+#: ../../../Controllers/MainWindowController.cs:1140
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:1090
+#: ../../../Controllers/MainWindowController.cs:1124
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
@@ -781,19 +815,19 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 msgid "Exported successfully to: {0}"
 msgstr "Dışa aktarıldı: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:476
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
 msgid "Failed MusicBrainz Lookup"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:582
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:1111
+#: ../../../Controllers/MainWindowController.cs:1145
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:1095
+#: ../../../Controllers/MainWindowController.cs:1129
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
@@ -809,9 +843,9 @@ msgstr "Dosya"
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
 #: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
@@ -826,28 +860,28 @@ msgstr "Dosya Adından Etikete (Ctrl+F)"
 msgid "File Path"
 msgstr "Dosya Yolu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: NickvisionTagger.GNOME/Blueprints/window.blp:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
+#: NickvisionTagger.GNOME/Blueprints/window.blp:608
 msgid "File Properties"
 msgstr "Dosya Özellikleri"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1312
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1345
 msgid "filename"
 msgstr "dosya adı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
-#: NickvisionTagger.GNOME/Blueprints/window.blp:579
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Fingerprint"
 msgstr "Parmak izi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1750
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1681
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
 msgid "Fingerprint was copied to clipboard."
 msgstr "Parmak izi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Folder Mode"
 msgstr "Klasör Kipi"
 
@@ -856,29 +890,29 @@ msgstr "Klasör Kipi"
 msgid "Format"
 msgstr "Biçim"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Format String"
 msgstr "Biçimlendirme Dizgesi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1032
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Ön"
 
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:178
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1377
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:681
-#: ../../../Models/MusicFile.cs:780
+#: ../../../Controllers/MainWindowController.cs:191
+#: ../../../Controllers/MainWindowController.cs:1410
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
+#: ../../../Models/MusicFile.cs:825
 msgid "genre"
 msgstr "tür"
 
@@ -899,19 +933,19 @@ msgstr "Yeni API Anahtarı Al"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1359
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:564
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:569
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:574
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:443
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:454
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:465
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
@@ -919,7 +953,7 @@ msgid "Help"
 msgstr "Yardım"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:757
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
 msgid "Hide Extras Pane"
 msgstr "İlaveler Panelini Gizle"
 
@@ -934,31 +968,31 @@ msgstr "LRC'den İçe Aktar"
 msgid "Include Only Selected Files"
 msgstr "Yalnızca Seçili Dosyaları İçer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:579
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
 msgid "Info"
 msgstr "Bilgi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
 #: NickvisionTagger.GNOME/Blueprints/window.blp:51
 #: NickvisionTagger.GNOME/Blueprints/window.blp:319
 msgid "Insert"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Albüm Arka Kapağı Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1043
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:994
+#: ../../../Controllers/MainWindowController.cs:1028
 msgid "Inserting album art..."
 msgstr "Albüm kapağı ekleniyor..."
 
@@ -976,19 +1010,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Dil Kodu"
 
-#: ../../../Controllers/MainWindowController.cs:451
+#: ../../../Controllers/MainWindowController.cs:461
 msgid "Library was changed on disk."
 msgstr "Kitaplık diskte değiştirildi."
 
-#: ../../../Controllers/MainWindowController.cs:504
+#: ../../../Controllers/MainWindowController.cs:514
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../Controllers/MainWindowController.cs:490
-#: ../../../Controllers/MainWindowController.cs:1597
+#: ../../../Controllers/MainWindowController.cs:500
+#: ../../../Controllers/MainWindowController.cs:1668
 msgid "Loading music files from library..."
 msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 
@@ -996,7 +1030,7 @@ msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 msgid "Lryics"
 msgstr "Şarkı Sözleri"
 
-#: ../../../Models/MusicFile.cs:73
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
@@ -1022,7 +1056,7 @@ msgstr "Şarkı Sözlerini Yönet"
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Şarkı Sözlerini Yönet (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:173
+#: ../../../Controllers/MainWindowController.cs:174
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
@@ -1040,13 +1074,13 @@ msgstr "Müzik Dosyası"
 msgid "Music Library"
 msgstr "Müzik Kitaplığı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz Kayıt Kimliği"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
@@ -1055,24 +1089,24 @@ msgstr "Yeni Özel Özellik"
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:408
+#: ../../../Controllers/MainWindowController.cs:418
 msgid "New update available."
 msgstr "Yeni güncelleme var."
 
-#: ../../../Controllers/MainWindowController.cs:174
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:175
+#: ../../../Controllers/MainWindowController.cs:177
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:848
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:915
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:1208
+#: ../../../Controllers/MainWindowController.cs:1242
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
@@ -1080,20 +1114,20 @@ msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 msgid "No file selected"
 msgstr "Hiçbir dosya seçilmedi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:885
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
 msgid "No files selected for removal."
 msgstr "Kaldırmak için hiçbir dosya seçilmedi."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1277
 msgid "No lyrics were downloaded"
 msgstr "Hiçbir şarkı sözü indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:527
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "No music files are selected."
 msgstr "Hiçbir müzik dosyası seçilmedi."
 
@@ -1102,11 +1136,11 @@ msgstr "Hiçbir müzik dosyası seçilmedi."
 msgid "No Music Files Found"
 msgstr "Hiçbir Müzik Dosyası Bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:531
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "No music files in library."
 msgstr "Kitaplıkta müzik dosyası yok."
 
-#: ../../../Controllers/MainWindowController.cs:1209
+#: ../../../Controllers/MainWindowController.cs:1243
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
@@ -1115,7 +1149,7 @@ msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 msgid "No Selected Music Files"
 msgstr "Seçili Müzik Dosyası Yok"
 
-#: ../../../Controllers/MainWindowController.cs:1256
+#: ../../../Controllers/MainWindowController.cs:1290
 msgid "No user api key configured."
 msgstr "Hiçbir kullanıcı anahtarı yapılandırılmadı."
 
@@ -1140,11 +1174,11 @@ msgstr "Kapalı"
 msgid "Offset (in milliseconds)"
 msgstr "Ofset (milisaniye cinsinden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:481
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
 msgid "OK"
 msgstr "Tamam"
 
@@ -1160,8 +1194,8 @@ msgstr "Tamam"
 msgid "On"
 msgstr "Açık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1169,8 +1203,8 @@ msgstr ""
 "AcoustIDʼye aynı anda yalnızca bir dosya gönderilebilir. Lütfen yalnızca bir "
 "dosya seçip tekrar deneyin."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:588
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:498
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
 msgid "Open"
 msgstr "Aç"
 
@@ -1180,7 +1214,7 @@ msgid "Open a library with music to get started"
 msgstr "Başlamak için müzik içeren bir kitaplık açın"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:697
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
@@ -1190,11 +1224,11 @@ msgstr "Başlamak için müzik içeren bir kitaplık açın"
 msgid "Open Folder"
 msgstr "Klasör Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:827
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
 msgid "Open Music File"
 msgstr "Müzik Dosyası Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:712
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1228,10 +1262,10 @@ msgstr "Yol"
 msgid "Path (Empty)"
 msgstr "Yol (Boş)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1509
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1710
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1420
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
 msgid "Pick a date"
 msgstr ""
 
@@ -1241,23 +1275,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
-#: ../../../Controllers/MainWindowController.cs:536
+#: ../../../Controllers/MainWindowController.cs:546
 msgid "Playlist file created successfully."
 msgstr "Çalma listesi oluşturuldu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1431
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1347
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
 msgid "Playlist Mode"
 msgstr "Çalma Listesi Kipi"
 
-#: ../../../Controllers/MainWindowController.cs:523
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "Playlist path can not be empty."
 msgstr "Çalma listesi yolu boş olamaz."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:992
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1094
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 msgid "Please select a format string."
 msgstr "Lütfen biçimlendirme dizgesi seçin."
 
@@ -1270,39 +1304,39 @@ msgstr "Değişiklik Zaman Damgasını Koru"
 msgid "PREVIEW"
 msgstr "ÖN İZLEME"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1076
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:800
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1471
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
+#: ../../../Models/MusicFile.cs:853
 msgid "publisher"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
-#: NickvisionTagger.GNOME/Blueprints/window.blp:525
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
+#: NickvisionTagger.GNOME/Blueprints/window.blp:557
 msgid "Publisher"
 msgstr "Yayımcı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
-#: NickvisionTagger.GNOME/Blueprints/window.blp:529
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:561
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Yayımcı"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:709
-#: ../../../Models/MusicFile.cs:804
+#: ../../../Controllers/MainWindowController.cs:193
+#: ../../../Controllers/MainWindowController.cs:1475
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
+#: ../../../Models/MusicFile.cs:857
 #, fuzzy
 msgid "publishingdate"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:432
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
 msgid "Reload"
 msgstr "Yeniden Yükle"
 
@@ -1314,20 +1348,20 @@ msgstr "Kitaplığı Yeniden Yükle"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
 #: NickvisionTagger.GNOME/Blueprints/window.blp:52
 #: NickvisionTagger.GNOME/Blueprints/window.blp:328
 msgid "Remove"
 msgstr "Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1569
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
 msgid "Remove Files?"
 msgstr "Dosyalar Kaldırılsın Mı?"
 
@@ -1341,7 +1375,7 @@ msgstr "Çalma Listesinden Kaldır"
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
-#: ../../../Controllers/MainWindowController.cs:1038
+#: ../../../Controllers/MainWindowController.cs:1072
 msgid "Removing album art..."
 msgstr "Albüm kapağı kaldırılıyor..."
 
@@ -1367,8 +1401,8 @@ msgstr "Etiketi Kaydet"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Etiketi Kaydet (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:769
-#: ../../../Controllers/MainWindowController.cs:812
+#: ../../../Controllers/MainWindowController.cs:803
+#: ../../../Controllers/MainWindowController.cs:846
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
@@ -1387,27 +1421,27 @@ msgstr "Bazı dosyaları seçin"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:749
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
 msgid "Show Extras Pane"
 msgstr "İlaveler Panelini Göster"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:640
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:746
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:786
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:926
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1139
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1244
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:568
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:603
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:702
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:780
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:906
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1201
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1421,43 +1455,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dosyaları Sırala"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 msgid "Submit"
 msgstr "Gönder"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1190
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
 #: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../Controllers/MainWindowController.cs:1259
+#: ../../../Controllers/MainWindowController.cs:1293
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 #: NickvisionTagger.GNOME/Blueprints/window.blp:346
 msgid "Switch to Back Cover"
 msgstr "Arka Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1031
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1237
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1238
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1559
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1560
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
 msgid "Switch to Front Cover"
 msgstr "Ön Kapağa Geç"
 
@@ -1470,9 +1504,9 @@ msgstr "Eşitlenmiş"
 msgid "Tag"
 msgstr "Etiket"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1011
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1112
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:63
 msgid "Tag to File Name"
 msgstr "Etiketten Dosya Adına"
@@ -1481,9 +1515,8 @@ msgstr "Etiketten Dosya Adına"
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Etiketten Dosya Adına (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:170
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Müziklerinizi etiketleyin"
 
@@ -1492,9 +1525,8 @@ msgstr "Müziklerinizi etiketleyin"
 msgid "Tag Your Music"
 msgstr "Müziklerinizi Etiketleyin"
 
-#: ../../../Controllers/MainWindowController.cs:168
+#: ../../../Controllers/MainWindowController.cs:169
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
@@ -1503,8 +1535,8 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:913
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:892
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1516,7 +1548,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1211
+#: ../../../Controllers/MainWindowController.cs:1245
 msgid "This file does not have a valid fingerprint"
 msgstr "Bu dosyanın geçerli bir parmak izi yok"
 
@@ -1538,10 +1570,10 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1316
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:641
-#: ../../../Models/MusicFile.cs:752
+#: ../../../Controllers/MainWindowController.cs:189
+#: ../../../Controllers/MainWindowController.cs:1349
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
+#: ../../../Models/MusicFile.cs:797
 msgid "title"
 msgstr "başlık"
 
@@ -1553,15 +1585,15 @@ msgstr "başlık"
 msgid "Title"
 msgstr "Başlık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1180
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1343
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:661
-#: ../../../Models/MusicFile.cs:768
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1376
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
+#: ../../../Models/MusicFile.cs:813
 msgid "track"
 msgstr "parça"
 
@@ -1573,14 +1605,14 @@ msgstr "parça"
 msgid "Track"
 msgstr "Parça"
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1358
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:669
-#: ../../../Models/MusicFile.cs:772
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1391
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
+#: ../../../Models/MusicFile.cs:817
 msgid "tracktotal"
 msgstr "toplam parça"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:181
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
@@ -1599,16 +1631,16 @@ msgstr "Tür"
 msgid "Type ! for advanced search"
 msgstr "gelişmiş arama için ! yazın"
 
-#: ../../../Controllers/MainWindowController.cs:560
+#: ../../../Controllers/MainWindowController.cs:570
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Dosya çalma listesine eklenemiyor. Dosya zaten çalma listesinde olabilir."
 
-#: ../../../Controllers/MainWindowController.cs:540
+#: ../../../Controllers/MainWindowController.cs:550
 msgid "Unable to create playlist."
 msgstr "Çalma listesi oluşturulamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:425
+#: ../../../Controllers/MainWindowController.cs:435
 msgid "Unable to download and install update."
 msgstr "Güncellemeler indirilip kurulamadı."
 
@@ -1622,29 +1654,29 @@ msgstr "LRC'ye dışa aktarılamıyor."
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:990
+#: ../../../Controllers/MainWindowController.cs:1024
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:575
+#: ../../../Controllers/MainWindowController.cs:585
 msgid "Unable to remove some files from playlist."
 msgstr "Kimi dosyalar çalma listesinden kaldırılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:832
+#: ../../../Controllers/MainWindowController.cs:866
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:790
+#: ../../../Controllers/MainWindowController.cs:824
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:1262
+#: ../../../Controllers/MainWindowController.cs:1296
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:1575
+#: ../../../Controllers/MainWindowController.cs:1646
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1653,7 +1685,7 @@ msgstr "Bilinmiyor"
 msgid "Unsynchronized"
 msgstr "Eşitlenmemiş"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:425
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
 msgid "Update"
 msgstr "Güncelle"
 
@@ -1667,8 +1699,8 @@ msgstr "LRC şarkı sözlerini kullan"
 msgid "Use Relative Paths"
 msgstr "Göreli Yolları Kullan"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:834
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
 msgid "Use Relative Paths?"
 msgstr "Göreli Yollar Kullanılsın Mı?"
 
@@ -1703,8 +1735,8 @@ msgstr ""
 "misiniz?\n"
 "Kaydedilmemiş tüm çalışmalar kaybolacaktır."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:835
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1714,10 +1746,10 @@ msgstr ""
 "misiniz?\n"
 "Aksi takdirde göreli yol yerine tam yol kullanılacaktır."
 
-#: ../../../Controllers/MainWindowController.cs:1286
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:653
-#: ../../../Models/MusicFile.cs:764
+#: ../../../Controllers/MainWindowController.cs:190
+#: ../../../Controllers/MainWindowController.cs:1361
+#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
+#: ../../../Models/MusicFile.cs:809
 msgid "year"
 msgstr "yıl"
 
@@ -1729,10 +1761,10 @@ msgstr "yıl"
 msgid "Year"
 msgstr "Yıl"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:851
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:918
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:836
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:893
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Evet"
@@ -1865,15 +1897,24 @@ msgstr "Tüm Dosyaları Seç"
 msgid "Track Total"
 msgstr "Toplam Parça"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:626
+#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+msgid "Disc Number"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#, fuzzy
+msgid "Disc Total"
+msgstr "Toplam Parça"
+
+#: NickvisionTagger.GNOME/Blueprints/window.blp:658
 msgid "Toggle Tags Pane"
 msgstr "Etiket Bölmesini Aç/Kapat"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:654
+#: NickvisionTagger.GNOME/Blueprints/window.blp:686
 msgid "Tag Actions"
 msgstr "Etiket Eylemleri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:660
+#: NickvisionTagger.GNOME/Blueprints/window.blp:692
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Etiket Değişikliklerini Uygula (Ctrl+S)"
 
@@ -1883,49 +1924,43 @@ msgstr ""
 "Tag;Music;Editor;Library;Nickvision;Etiket;Müzik;Düzenleyici;Kütüphane;"
 "Kitaplık;"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
-msgid ""
-"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-msgstr ""
-"— Pek çok müzik dosyası türünü destekler (mp3, ogg, flac, wma ve çok daha "
-"fazlası)"
+#~ msgid ""
+#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+#~ msgstr ""
+#~ "— Pek çok müzik dosyası türünü destekler (mp3, ogg, flac, wma ve çok daha "
+#~ "fazlası)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
-msgid ""
-"— Edit tags and album art of multiple files, even across subfolders, all at "
-"once"
-msgstr ""
-"— Alt klasörler de dahil olmak üzere birden fazla dosyanın etiketlerini ve "
-"albüm kapaklarını aynı anda düzenleyin"
+#~ msgid ""
+#~ "— Edit tags and album art of multiple files, even across subfolders, all "
+#~ "at once"
+#~ msgstr ""
+#~ "— Alt klasörler de dahil olmak üzere birden fazla dosyanın etiketlerini "
+#~ "ve albüm kapaklarını aynı anda düzenleyin"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
-msgid ""
-"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-"and export support)"
-msgstr ""
-"— Dosya için eşzamanlanmış ve eşzamanlanmış şarkı sözlerini düzenleyin (LRC "
-"içe ve dışa aktarma desteğiyle)"
+#~ msgid ""
+#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+#~ "and export support)"
+#~ msgstr ""
+#~ "— Dosya için eşzamanlanmış ve eşzamanlanmış şarkı sözlerini düzenleyin "
+#~ "(LRC içe ve dışa aktarma desteğiyle)"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
-msgid "— Convert filenames to tags and tags to filenames with ease"
-msgstr ""
-"— Dosya adlarını etiketlere ve etiketleri dosya adlarına kolayca dönüştürün"
+#~ msgid "— Convert filenames to tags and tags to filenames with ease"
+#~ msgstr ""
+#~ "— Dosya adlarını etiketlere ve etiketleri dosya adlarına kolayca "
+#~ "dönüştürün"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
-msgid "— Lookup file information using MusicBrainz"
-msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
+#~ msgid "— Lookup file information using MusicBrainz"
+#~ msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
-msgid "— Lookup lyric information using Music163 and Letras"
-msgstr "— Music163 ve Letras kullanarak şarkı sözü bilgilerini arayın"
+#~ msgid "— Lookup lyric information using Music163 and Letras"
+#~ msgstr "— Music163 ve Letras kullanarak şarkı sözü bilgilerini arayın"
 
-#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
-msgid ""
-"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-"more)"
-msgstr ""
-"— Birçok biçimde (m3u, pls, xspf ve daha fazlası) çalma listeleri açın, "
-"yönetin ve oluşturun"
+#~ msgid ""
+#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+#~ "more)"
+#~ msgstr ""
+#~ "— Birçok biçimde (m3u, pls, xspf ve daha fazlası) çalma listeleri açın, "
+#~ "yönetin ve oluşturun"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Başlamak için müzik içeren bir kitaplık açın."

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 11:17-0400\n"
+"POT-Creation-Date: 2023-10-19 15:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -19,81 +19,89 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1426
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1452
 #, fuzzy, csharp-format
 msgid "{0} • {1}"
 msgstr "{0}  /  {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1468
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1499
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1352
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1402
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
 msgid "{0} of {1} selected"
 msgstr "{0} / {1} seçildi"
+
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:34
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:35
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:28
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:29
+#, csharp-format
+msgid "{0} pixels"
+msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CreatePlaylistDialog.cs:103
 #, csharp-format
 msgid "{0} Playlist (*{1})"
 msgstr "{0} Çalma Listesi (*{1})"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%artist%- %title%"
 msgstr "%artist%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%"
 msgstr "%title%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%title%- %artist%"
 msgstr "%title%- %artist%"
 
-#: ../../../Controllers/MainWindowController.cs:209
+#: ../../../Controllers/MainWindowController.cs:200
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:605
-#: ../../../Controllers/MainWindowController.cs:616
-#: ../../../Controllers/MainWindowController.cs:621
-#: ../../../Controllers/MainWindowController.cs:626
-#: ../../../Controllers/MainWindowController.cs:631
-#: ../../../Controllers/MainWindowController.cs:643
-#: ../../../Controllers/MainWindowController.cs:655
-#: ../../../Controllers/MainWindowController.cs:667
-#: ../../../Controllers/MainWindowController.cs:672
-#: ../../../Controllers/MainWindowController.cs:677
-#: ../../../Controllers/MainWindowController.cs:682
-#: ../../../Controllers/MainWindowController.cs:687
-#: ../../../Controllers/MainWindowController.cs:699
-#: ../../../Controllers/MainWindowController.cs:704
-#: ../../../Controllers/MainWindowController.cs:716
-#: ../../../Controllers/MainWindowController.cs:728
-#: ../../../Controllers/MainWindowController.cs:733
-#: ../../../Controllers/MainWindowController.cs:749
-#: ../../../Controllers/MainWindowController.cs:1835
-#: ../../../Controllers/MainWindowController.cs:1836
-#: ../../../Controllers/MainWindowController.cs:1837
-#: ../../../Controllers/MainWindowController.cs:1838
-#: ../../../Controllers/MainWindowController.cs:1839
-#: ../../../Controllers/MainWindowController.cs:1840
-#: ../../../Controllers/MainWindowController.cs:1841
-#: ../../../Controllers/MainWindowController.cs:1842
-#: ../../../Controllers/MainWindowController.cs:1843
-#: ../../../Controllers/MainWindowController.cs:1844
-#: ../../../Controllers/MainWindowController.cs:1845
-#: ../../../Controllers/MainWindowController.cs:1846
-#: ../../../Controllers/MainWindowController.cs:1847
-#: ../../../Controllers/MainWindowController.cs:1848
-#: ../../../Controllers/MainWindowController.cs:1849
-#: ../../../Controllers/MainWindowController.cs:1850
-#: ../../../Controllers/MainWindowController.cs:1851
-#: ../../../Controllers/MainWindowController.cs:1855
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1529
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1532
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1424
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1513
+#: ../../../Controllers/MainWindowController.cs:596
+#: ../../../Controllers/MainWindowController.cs:607
+#: ../../../Controllers/MainWindowController.cs:612
+#: ../../../Controllers/MainWindowController.cs:617
+#: ../../../Controllers/MainWindowController.cs:622
+#: ../../../Controllers/MainWindowController.cs:634
+#: ../../../Controllers/MainWindowController.cs:646
+#: ../../../Controllers/MainWindowController.cs:658
+#: ../../../Controllers/MainWindowController.cs:663
+#: ../../../Controllers/MainWindowController.cs:668
+#: ../../../Controllers/MainWindowController.cs:673
+#: ../../../Controllers/MainWindowController.cs:678
+#: ../../../Controllers/MainWindowController.cs:690
+#: ../../../Controllers/MainWindowController.cs:695
+#: ../../../Controllers/MainWindowController.cs:707
+#: ../../../Controllers/MainWindowController.cs:719
+#: ../../../Controllers/MainWindowController.cs:724
+#: ../../../Controllers/MainWindowController.cs:740
+#: ../../../Controllers/MainWindowController.cs:1810
+#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:1812
+#: ../../../Controllers/MainWindowController.cs:1813
+#: ../../../Controllers/MainWindowController.cs:1814
+#: ../../../Controllers/MainWindowController.cs:1815
+#: ../../../Controllers/MainWindowController.cs:1816
+#: ../../../Controllers/MainWindowController.cs:1817
+#: ../../../Controllers/MainWindowController.cs:1818
+#: ../../../Controllers/MainWindowController.cs:1819
+#: ../../../Controllers/MainWindowController.cs:1820
+#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:1822
+#: ../../../Controllers/MainWindowController.cs:1823
+#: ../../../Controllers/MainWindowController.cs:1824
+#: ../../../Controllers/MainWindowController.cs:1825
+#: ../../../Controllers/MainWindowController.cs:1826
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
 msgid "<keep>"
 msgstr "<koru>"
 
@@ -101,13 +109,13 @@ msgstr "<koru>"
 msgid "0 MiB"
 msgstr "0 MiB"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
 #, csharp-format
 msgid "About {0}"
 msgstr "{0} Hakkında"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
 "for easy identification.\n"
@@ -132,18 +140,18 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Kullanıcı API Anahtarı"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:128
-#: NickvisionTagger.GNOME/Blueprints/window.blp:590
+#: NickvisionTagger.GNOME/Blueprints/window.blp:611
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 msgid "Add New Property"
 msgstr "Yeni Özellik Ekle"
 
@@ -153,28 +161,28 @@ msgstr "Yeni Özellik Ekle"
 msgid "Add to Playlist"
 msgstr "Çalma Listesine Ekle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
-#: NickvisionTagger.GNOME/Blueprints/window.blp:538
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: NickvisionTagger.GNOME/Blueprints/window.blp:559
 msgid "Additional Properties"
 msgstr "Ek Özellikler"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
-#: NickvisionTagger.GNOME/Blueprints/window.blp:225
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
+#: NickvisionTagger.GNOME/Blueprints/window.blp:227
 msgid "Advanced Search Info"
 msgstr "Gelişmiş Arama Bilgisi"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1357
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:678
-#: ../../../Models/MusicFile.cs:805
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1332
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
+#: ../../../Models/MusicFile.cs:802
 msgid "album"
 msgstr "album"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:118
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:53
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:456
+#: NickvisionTagger.GNOME/Blueprints/window.blp:477
 msgid "Album"
 msgstr "Albüm"
 
@@ -183,26 +191,26 @@ msgstr "Albüm"
 msgid "Album Art"
 msgstr "Albüm Kapağı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:188
-#: NickvisionTagger.GNOME/Blueprints/window.blp:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: NickvisionTagger.GNOME/Blueprints/window.blp:481
 msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1406
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:706
-#: ../../../Models/MusicFile.cs:821
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1381
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:818
 msgid "albumartist"
 msgstr "albumartist"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1063
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1066
 msgid "All files"
 msgstr "Tüm Dosyalar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:731
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:846
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
 msgid "All Supported Files"
 msgstr "Tüm Desteklenen Dosyalar"
 
@@ -210,66 +218,66 @@ msgstr "Tüm Desteklenen Dosyalar"
 msgid "An application restart is required to change the theme."
 msgstr "Temayı değiştirmek için uygulamanın yeniden başlatılması gerekir."
 
-#: ../../../Controllers/MainWindowController.cs:1244
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:663
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:769
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:809
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:877
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:949
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1162
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1267
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:298
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:572
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:607
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:706
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:784
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:850
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:910
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:575
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:709
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:787
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:853
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:913
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1231
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:30
-#: NickvisionTagger.GNOME/Blueprints/window.blp:691
+#: NickvisionTagger.GNOME/Blueprints/window.blp:712
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:296
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:570
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:605
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:704
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:782
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:848
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:908
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1203
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1229
 msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1353
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:674
-#: ../../../Models/MusicFile.cs:801
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1328
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
+#: ../../../Models/MusicFile.cs:798
 msgid "artist"
 msgstr "sanatçı"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:117
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:186
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:52
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:452
+#: NickvisionTagger.GNOME/Blueprints/window.blp:473
 msgid "Artist"
 msgstr "Sanatçı"
 
@@ -281,70 +289,72 @@ msgstr "Güncellemeleri Kendiliğinden Denetle"
 msgid "B"
 msgstr "B"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
-#: NickvisionTagger.GNOME/Blueprints/window.blp:49
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
+#: NickvisionTagger.GNOME/Blueprints/window.blp:50
 msgid "Back"
 msgstr "Arka"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
-#: NickvisionTagger.GNOME/Blueprints/window.blp:545
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
+#: NickvisionTagger.GNOME/Blueprints/window.blp:566
 msgid "Beats Per Minute"
 msgstr "Dakika Başına Vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1418
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:718
-#: ../../../Models/MusicFile.cs:833
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1393
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1717
-#: ../../../Controllers/MainWindowController.cs:1723
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1753
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1536
+#: ../../../Controllers/MainWindowController.cs:1692
+#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Hesaplanıyor..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:658
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:764
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:804
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:872
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:944
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1157
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1262
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1148
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:303
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:577
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:612
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:711
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:789
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:855
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:915
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1233
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:31
 msgid "Cancel"
 msgstr "İptal"
@@ -353,7 +363,7 @@ msgstr "İptal"
 msgid "Changelog"
 msgstr "Değişiklik günlüğü"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
 msgid "Check for Updates"
 msgstr "Güncellemeleri Denetle"
 
@@ -362,32 +372,36 @@ msgstr "Güncellemeleri Denetle"
 msgid "Clear All Lyrics"
 msgstr "Tüm Şarkı Sözlerini Temizle"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:22
+msgid "Close"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:110
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:26
 msgid "Close Library"
 msgstr "Kitaplığı Kapat"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1414
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:714
-#: ../../../Models/MusicFile.cs:829
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1389
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:826
 msgid "comment"
 msgstr "yorum"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
-#: NickvisionTagger.GNOME/Blueprints/window.blp:541
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:200
+#: NickvisionTagger.GNOME/Blueprints/window.blp:562
 msgid "Comment"
 msgstr "Yorum"
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1433
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:726
-#: ../../../Models/MusicFile.cs:837
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1408
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:834
 msgid "composer"
 msgstr "besteci"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:202
-#: NickvisionTagger.GNOME/Blueprints/window.blp:549
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: NickvisionTagger.GNOME/Blueprints/window.blp:570
 msgid "Composer"
 msgstr "Besteci"
 
@@ -396,38 +410,38 @@ msgstr "Besteci"
 msgid "Configure"
 msgstr "Yapılandır"
 
-#: ../../../Controllers/MainWindowController.cs:176
+#: ../../../Controllers/MainWindowController.cs:167
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:60
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:62
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:972
+#: ../../../Controllers/MainWindowController.cs:963
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:1006
+#: ../../../Controllers/MainWindowController.cs:997
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:951
+#: ../../../Controllers/MainWindowController.cs:942
 msgid "Converting file names to tags..."
 msgstr "Dosya adları etikete dönüştürülüyor..."
 
-#: ../../../Controllers/MainWindowController.cs:985
+#: ../../../Controllers/MainWindowController.cs:976
 msgid "Converting tags to file names..."
 msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 
@@ -435,8 +449,8 @@ msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 msgid "Copied debug info to clipboard."
 msgstr "Hata ayıklama bilgisi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
-#: NickvisionTagger.GNOME/Blueprints/window.blp:630
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: NickvisionTagger.GNOME/Blueprints/window.blp:651
 msgid "Copy Fingerprint To Clipboard"
 msgstr "Parmak İzini Panoya Kopyala"
 
@@ -460,8 +474,8 @@ msgstr "Çalma Listesi Oluştur"
 msgid "Credits"
 msgstr "Hazırlayanlar"
 
-#: ../../../Controllers/MainWindowController.cs:194
-#: ../../../Controllers/MainWindowController.cs:1490
+#: ../../../Controllers/MainWindowController.cs:185
+#: ../../../Controllers/MainWindowController.cs:1465
 msgid "custom"
 msgstr "özel"
 
@@ -472,22 +486,22 @@ msgstr "özel"
 msgid "Custom"
 msgstr "Özel"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
-#: NickvisionTagger.GNOME/Blueprints/window.blp:582
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:144
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:215
+#: NickvisionTagger.GNOME/Blueprints/window.blp:603
 msgid "Custom Properties"
 msgstr "Özel Özellikler"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:216
-#: NickvisionTagger.GNOME/Blueprints/window.blp:599
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
+#: NickvisionTagger.GNOME/Blueprints/window.blp:620
 msgid "Custom properties can only be edited for individual files."
 msgstr "Özel özellikler yalnızca bağımsız dosyalar için düzenlenebilir."
 
-#: ../../../Controllers/MainWindowController.cs:179
+#: ../../../Controllers/MainWindowController.cs:170
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:171
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -495,25 +509,25 @@ msgstr "David Lapshin"
 msgid "Delete Tag"
 msgstr "Etiketi Sil"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Etiketi Sil (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:918
+#: ../../../Controllers/MainWindowController.cs:909
 msgid "Deleting tags..."
 msgstr "Etiketler siliniyor..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1437
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:730
-#: ../../../Models/MusicFile.cs:841
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1412
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:838
 msgid "description"
 msgstr "açıklama"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:48
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:204
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:64
-#: NickvisionTagger.GNOME/Blueprints/window.blp:553
+#: NickvisionTagger.GNOME/Blueprints/window.blp:574
 msgid "Description"
 msgstr "Açıklama"
 
@@ -544,28 +558,28 @@ msgstr ""
 "Çevirmenler:\n"
 "{3}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:206
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
 #, fuzzy
 msgid "Disc"
 msgstr "Gözden Çıkar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:661
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:767
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:807
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:947
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1160
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1265
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:707
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:785
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:851
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:911
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1147
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1206
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:710
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:788
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:854
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:914
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1232
 msgid "Discard"
 msgstr "Gözden Çıkar"
 
@@ -573,72 +587,72 @@ msgstr "Gözden Çıkar"
 msgid "Discard Unapplied Changed"
 msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:886
+#: ../../../Controllers/MainWindowController.cs:877
 msgid "Discarding tags..."
 msgstr "Etiketler gözden çıkarılıyor..."
 
-#: ../../../Controllers/MainWindowController.cs:192
-#: ../../../Controllers/MainWindowController.cs:1441
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:734
-#: ../../../Models/MusicFile.cs:845
+#: ../../../Controllers/MainWindowController.cs:183
+#: ../../../Controllers/MainWindowController.cs:1416
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
+#: ../../../Models/MusicFile.cs:842
 msgid "discnumber"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1456
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:742
-#: ../../../Models/MusicFile.cs:849
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1431
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "disctotal"
 msgstr "toplam parça"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
 msgid "Discussions"
 msgstr "Tartışmalar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
 msgid "Documentation"
 msgstr "Belgelendirme"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:129
-#: NickvisionTagger.GNOME/Blueprints/window.blp:70
+#: NickvisionTagger.GNOME/Blueprints/window.blp:72
 msgid "Download Lyrics"
 msgstr "Şarkı Sözlerini İndir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:124
-#: NickvisionTagger.GNOME/Blueprints/window.blp:69
+#: NickvisionTagger.GNOME/Blueprints/window.blp:71
 msgid "Download MusicBrainz Metadata"
 msgstr "MusicBrainz Üst Verilerini İndir"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz Üst Verilerini İndir (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} dosya için şarkı sözleri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1263
+#: ../../../Controllers/MainWindowController.cs:1238
 msgid "Downloading lyrics..."
 msgstr "Şarkı sözleri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:1213
+#: ../../../Controllers/MainWindowController.cs:1188
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:398
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:401
 msgid "Drop here to open library"
 msgstr "Kitaplık açmak için buraya bırakın"
 
@@ -676,27 +690,27 @@ msgstr ""
 "yazmak için etkinleştirin. Devre dışı bırakılırsa, yalnızca boş etiket "
 "özellikleri doldurulur."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
 msgid "Enter album artist here"
 msgstr "Albüm sanatçısını buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:189
 msgid "Enter album here"
 msgstr "Albümü buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:187
 msgid "Enter artist here"
 msgstr "Sanatçıyı buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
 msgid "Enter beats per minute here"
 msgstr "Dakika başına vuruşu buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:199
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:201
 msgid "Enter comment here"
 msgstr "Yorumu buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:203
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
 msgid "Enter composer here"
 msgstr "Besteciyi buraya girin"
 
@@ -705,25 +719,25 @@ msgid "Enter custom choice here"
 msgstr "Özel seçimi buraya girin"
 
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:49
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:205
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
 msgid "Enter description here"
 msgstr "Açıklamayı buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:207
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
 #, fuzzy
 msgid "Enter disc number here"
 msgstr "Dosya adını buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:208
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
 #, fuzzy
 msgid "Enter disc total here"
 msgstr "Toplam parça sayısını buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
 msgid "Enter file name here"
 msgstr "Dosya adını buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:191
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
 msgid "Enter genre here"
 msgstr "Türü buraya girin"
 
@@ -739,32 +753,32 @@ msgstr "Dil kodunu buraya girin"
 msgid "Enter offset here"
 msgstr "Ofseti buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:210
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
 msgid "Enter publisher here"
 msgstr "Yayımcıyı buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:185
 msgid "Enter title here"
 msgstr "Başlığı buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:197
 msgid "Enter track here"
 msgstr "Parçayı buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:198
 msgid "Enter track total here"
 msgstr "Toplam parça sayısını buraya girin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:193
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:195
 msgid "Enter year here"
 msgstr "Yılı buraya girin"
 
-#: ../../../Controllers/MainWindowController.cs:1246
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:429 ../../../Models/MusicFile.cs:886
-#: ../../../Models/MusicFile.cs:1051
+#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
+#: ../../../Models/MusicFile.cs:1048
 msgid "ERROR"
 msgstr "HATA"
 
@@ -778,20 +792,20 @@ msgid "Exit"
 msgstr "Çık"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:136
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:226
 #: NickvisionTagger.GNOME/Blueprints/window.blp:45
-#: NickvisionTagger.GNOME/Blueprints/window.blp:53
-#: NickvisionTagger.GNOME/Blueprints/window.blp:337
+#: NickvisionTagger.GNOME/Blueprints/window.blp:54
+#: NickvisionTagger.GNOME/Blueprints/window.blp:345
 msgid "Export"
 msgstr "Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Albüm Arka Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1094
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
@@ -802,11 +816,11 @@ msgstr "Albüm Ön Kapağını Dışa Aktar"
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:1140
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:1124
+#: ../../../Controllers/MainWindowController.cs:1115
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
@@ -815,19 +829,19 @@ msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 msgid "Exported successfully to: {0}"
 msgstr "Dışa aktarıldı: {0}"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:479
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:482
 msgid "Failed MusicBrainz Lookup"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:598
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:1145
+#: ../../../Controllers/MainWindowController.cs:1136
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:1129
+#: ../../../Controllers/MainWindowController.cs:1120
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
@@ -836,21 +850,21 @@ msgid "File"
 msgstr "Dosya"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:114
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:179
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:49
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:419
+#: NickvisionTagger.GNOME/Blueprints/window.blp:440
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: NickvisionTagger.GNOME/Blueprints/window.blp:62
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: NickvisionTagger.GNOME/Blueprints/window.blp:64
 msgid "File Name to Tag"
 msgstr "Dosya Adından Etikete"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:177
 msgid "File Name to Tag (Ctrl+F)"
 msgstr "Dosya Adından Etikete (Ctrl+F)"
 
@@ -860,28 +874,28 @@ msgstr "Dosya Adından Etikete (Ctrl+F)"
 msgid "File Path"
 msgstr "Dosya Yolu"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
-#: NickvisionTagger.GNOME/Blueprints/window.blp:608
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:219
+#: NickvisionTagger.GNOME/Blueprints/window.blp:629
 msgid "File Properties"
 msgstr "Dosya Özellikleri"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1345
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1320
 msgid "filename"
 msgstr "dosya adı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:218
-#: NickvisionTagger.GNOME/Blueprints/window.blp:611
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:220
+#: NickvisionTagger.GNOME/Blueprints/window.blp:632
 msgid "Fingerprint"
 msgstr "Parmak izi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1770
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1688
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Parmak izi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Klasör Kipi"
 
@@ -890,37 +904,39 @@ msgstr "Klasör Kipi"
 msgid "Format"
 msgstr "Biçim"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Biçimlendirme Dizgesi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:190
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1048
+#: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1456
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
 #: NickvisionTagger.GNOME/Blueprints/window.blp:41
 msgid "Front"
 msgstr "Ön"
 
-#: ../../../Controllers/MainWindowController.cs:178
+#: ../../../Controllers/MainWindowController.cs:169
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Controllers/MainWindowController.cs:191
-#: ../../../Controllers/MainWindowController.cs:1410
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:710
-#: ../../../Models/MusicFile.cs:825
+#: ../../../Controllers/MainWindowController.cs:182
+#: ../../../Controllers/MainWindowController.cs:1385
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:822
 msgid "genre"
 msgstr "tür"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:121
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:190
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:56
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:464
+#: NickvisionTagger.GNOME/Blueprints/window.blp:485
 msgid "Genre"
 msgstr "Tür"
 
@@ -933,27 +949,33 @@ msgstr "Yeni API Anahtarı Al"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1375
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:154
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:580
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:585
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:590
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:25
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:42
+#, fuzzy
+msgid "Height"
+msgstr "Açık"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:151
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:446
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:457
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:468
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:460
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:471
 #: NickvisionTagger.GNOME/Blueprints/corrupted_files_dialog.blp:18
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:153
 #: NickvisionTagger.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Yardım"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:760
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:180
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:763
 msgid "Hide Extras Pane"
 msgstr "İlaveler Panelini Gizle"
 
@@ -968,31 +990,37 @@ msgstr "LRC'den İçe Aktar"
 msgid "Include Only Selected Files"
 msgstr "Yalnızca Seçili Dosyaları İçer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:595
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:490
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:493
+#: NickvisionTagger.GNOME/Blueprints/window.blp:46
+#: NickvisionTagger.GNOME/Blueprints/window.blp:55
+#: NickvisionTagger.GNOME/Blueprints/window.blp:356
 msgid "Info"
 msgstr "Bilgi"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:134
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
 #: NickvisionTagger.GNOME/Blueprints/window.blp:43
-#: NickvisionTagger.GNOME/Blueprints/window.blp:51
-#: NickvisionTagger.GNOME/Blueprints/window.blp:319
+#: NickvisionTagger.GNOME/Blueprints/window.blp:52
+#: NickvisionTagger.GNOME/Blueprints/window.blp:323
 msgid "Insert"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Albüm Arka Kapağı Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:1028
+#: ../../../Controllers/MainWindowController.cs:1019
 msgid "Inserting album art..."
 msgstr "Albüm kapağı ekleniyor..."
 
@@ -1010,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Dil Kodu"
 
-#: ../../../Controllers/MainWindowController.cs:461
+#: ../../../Controllers/MainWindowController.cs:452
 msgid "Library was changed on disk."
 msgstr "Kitaplık diskte değiştirildi."
 
-#: ../../../Controllers/MainWindowController.cs:514
+#: ../../../Controllers/MainWindowController.cs:505
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../Controllers/MainWindowController.cs:500
-#: ../../../Controllers/MainWindowController.cs:1668
+#: ../../../Controllers/MainWindowController.cs:491
+#: ../../../Controllers/MainWindowController.cs:1643
 msgid "Loading music files from library..."
 msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 
@@ -1030,39 +1058,45 @@ msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 msgid "Lryics"
 msgstr "Şarkı Sözleri"
 
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:793
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:173
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:175
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:32
-#: NickvisionTagger.GNOME/Blueprints/window.blp:439
+#: NickvisionTagger.GNOME/Blueprints/window.blp:460
 msgid "Lyrics"
 msgstr "Şarkı Sözleri"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:181
-#: NickvisionTagger.GNOME/Blueprints/window.blp:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:183
+#: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Ana Özellikler"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
 #: NickvisionTagger.GNOME/Blueprints/window.blp:35
-#: NickvisionTagger.GNOME/Blueprints/window.blp:435
+#: NickvisionTagger.GNOME/Blueprints/window.blp:456
 msgid "Manage Lyrics"
 msgstr "Şarkı Sözlerini Yönet"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:174
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
 msgid "Manage Lyrics (Ctrl+L)"
 msgstr "Şarkı Sözlerini Yönet (Ctrl+L)"
 
-#: ../../../Controllers/MainWindowController.cs:174
+#: ../../../Controllers/MainWindowController.cs:165
 msgid "Matrix Chat"
 msgstr "Matrix Sohbet"
 
 #: ../../../Helpers/MediaHelpers.cs:25
 msgid "MiB"
 msgstr "MiB"
+
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:23
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:32
+#, fuzzy
+msgid "Mime Type"
+msgstr "Tür"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:77
@@ -1074,13 +1108,13 @@ msgstr "Müzik Dosyası"
 msgid "Music Library"
 msgstr "Müzik Kitaplığı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz Kayıt Kimliği"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
@@ -1089,24 +1123,24 @@ msgstr "Yeni Özel Özellik"
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:418
+#: ../../../Controllers/MainWindowController.cs:409
 msgid "New update available."
 msgstr "Yeni güncelleme var."
 
-#: ../../../Controllers/MainWindowController.cs:175
-#: ../../../Controllers/MainWindowController.cs:177
+#: ../../../Controllers/MainWindowController.cs:166
+#: ../../../Controllers/MainWindowController.cs:168
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:864
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:1242
+#: ../../../Controllers/MainWindowController.cs:1217
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
@@ -1114,42 +1148,42 @@ msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 msgid "No file selected"
 msgstr "Hiçbir dosya seçilmedi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:925
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Kaldırmak için hiçbir dosya seçilmedi."
 
-#: ../../../Controllers/MainWindowController.cs:1277
+#: ../../../Controllers/MainWindowController.cs:1252
 msgid "No lyrics were downloaded"
 msgstr "Hiçbir şarkı sözü indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:528
 msgid "No music files are selected."
 msgstr "Hiçbir müzik dosyası seçilmedi."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
-#: NickvisionTagger.GNOME/Blueprints/window.blp:200
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
+#: NickvisionTagger.GNOME/Blueprints/window.blp:202
 msgid "No Music Files Found"
 msgstr "Hiçbir Müzik Dosyası Bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:532
 msgid "No music files in library."
 msgstr "Kitaplıkta müzik dosyası yok."
 
-#: ../../../Controllers/MainWindowController.cs:1243
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
-#: NickvisionTagger.GNOME/Blueprints/window.blp:277
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: NickvisionTagger.GNOME/Blueprints/window.blp:279
 msgid "No Selected Music Files"
 msgstr "Seçili Müzik Dosyası Yok"
 
-#: ../../../Controllers/MainWindowController.cs:1290
+#: ../../../Controllers/MainWindowController.cs:1265
 msgid "No user api key configured."
 msgstr "Hiçbir kullanıcı anahtarı yapılandırılmadı."
 
@@ -1174,11 +1208,11 @@ msgstr "Kapalı"
 msgid "Offset (in milliseconds)"
 msgstr "Ofset (milisaniye cinsinden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1199
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:484
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1185
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1211
 msgid "OK"
 msgstr "Tamam"
 
@@ -1194,8 +1228,8 @@ msgstr "Tamam"
 msgid "On"
 msgstr "Açık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1184
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
 "file and try again."
@@ -1203,37 +1237,37 @@ msgstr ""
 "AcoustIDʼye aynı anda yalnızca bir dosya gönderilebilir. Lütfen yalnızca bir "
 "dosya seçip tekrar deneyin."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:501
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Aç"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:159
-#: NickvisionTagger.GNOME/Blueprints/window.blp:116
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: NickvisionTagger.GNOME/Blueprints/window.blp:118
 msgid "Open a library with music to get started"
 msgstr "Başlamak için müzik içeren bir kitaplık açın"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:713
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:16
 #: NickvisionTagger.GNOME/Blueprints/window.blp:13
-#: NickvisionTagger.GNOME/Blueprints/window.blp:129
+#: NickvisionTagger.GNOME/Blueprints/window.blp:131
 msgid "Open Folder"
 msgstr "Klasör Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:843
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
 msgid "Open Music File"
 msgstr "Müzik Dosyası Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:728
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:161
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
 #: NickvisionTagger.GNOME/Blueprints/window.blp:14
-#: NickvisionTagger.GNOME/Blueprints/window.blp:142
+#: NickvisionTagger.GNOME/Blueprints/window.blp:144
 msgid "Open Playlist"
 msgstr "Çalma Listesi Aç"
 
@@ -1262,10 +1296,10 @@ msgstr "Yol"
 msgid "Path (Empty)"
 msgstr "Yol (Boş)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1527
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1730
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:212
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1425
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
 msgstr ""
 
@@ -1275,23 +1309,23 @@ msgstr ""
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
-#: ../../../Controllers/MainWindowController.cs:546
+#: ../../../Controllers/MainWindowController.cs:537
 msgid "Playlist file created successfully."
 msgstr "Çalma listesi oluşturuldu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1447
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1350
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Çalma Listesi Kipi"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:524
 msgid "Playlist path can not be empty."
 msgstr "Çalma listesi yolu boş olamaz."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1008
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1097
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
 msgstr "Lütfen biçimlendirme dizgesi seçin."
 
@@ -1304,39 +1338,39 @@ msgstr "Değişiklik Zaman Damgasını Koru"
 msgid "PREVIEW"
 msgstr "ÖN İZLEME"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1132
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1079
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Özellik Adı"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1471
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:750
-#: ../../../Models/MusicFile.cs:853
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1446
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:850
 msgid "publisher"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:209
-#: NickvisionTagger.GNOME/Blueprints/window.blp:557
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
+#: NickvisionTagger.GNOME/Blueprints/window.blp:578
 msgid "Publisher"
 msgstr "Yayımcı"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:211
-#: NickvisionTagger.GNOME/Blueprints/window.blp:561
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:213
+#: NickvisionTagger.GNOME/Blueprints/window.blp:582
 #, fuzzy
 msgid "Publishing Date"
 msgstr "Yayımcı"
 
-#: ../../../Controllers/MainWindowController.cs:193
-#: ../../../Controllers/MainWindowController.cs:1475
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:754
-#: ../../../Models/MusicFile.cs:857
+#: ../../../Controllers/MainWindowController.cs:184
+#: ../../../Controllers/MainWindowController.cs:1450
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:854
 #, fuzzy
 msgid "publishingdate"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:575
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:435
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Yeniden Yükle"
 
@@ -1347,21 +1381,21 @@ msgid "Reload Library"
 msgstr "Kitaplığı Yeniden Yükle"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:135
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:139
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:140
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:225
 #: NickvisionTagger.GNOME/Blueprints/window.blp:44
-#: NickvisionTagger.GNOME/Blueprints/window.blp:52
-#: NickvisionTagger.GNOME/Blueprints/window.blp:328
+#: NickvisionTagger.GNOME/Blueprints/window.blp:53
+#: NickvisionTagger.GNOME/Blueprints/window.blp:334
 msgid "Remove"
 msgstr "Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1587
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:894
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Dosyalar Kaldırılsın Mı?"
 
@@ -1375,11 +1409,11 @@ msgstr "Çalma Listesinden Kaldır"
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
-#: ../../../Controllers/MainWindowController.cs:1072
+#: ../../../Controllers/MainWindowController.cs:1063
 msgid "Removing album art..."
 msgstr "Albüm kapağı kaldırılıyor..."
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:155
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:157
 msgid "Report a Bug"
 msgstr "Hata Raporla"
 
@@ -1392,17 +1426,17 @@ msgid "Save Playlist"
 msgstr "Çalma Listesini Kaydet"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:128
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:169
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:171
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:55
 msgid "Save Tag"
 msgstr "Etiketi Kaydet"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:172
 msgid "Save Tag (Ctrl+S)"
 msgstr "Etiketi Kaydet (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:803
-#: ../../../Controllers/MainWindowController.cs:846
+#: ../../../Controllers/MainWindowController.cs:794
+#: ../../../Controllers/MainWindowController.cs:837
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
@@ -1411,8 +1445,8 @@ msgstr "Etiketler kaydediliyor..."
 msgid "Select Save Location"
 msgstr "Kayıt Konumu Seç"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:168
-#: NickvisionTagger.GNOME/Blueprints/window.blp:278
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:170
+#: NickvisionTagger.GNOME/Blueprints/window.blp:280
 msgid "Select some files"
 msgstr "Bazı dosyaları seçin"
 
@@ -1421,27 +1455,27 @@ msgstr "Bazı dosyaları seçin"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:752
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:755
 msgid "Show Extras Pane"
 msgstr "İlaveler Panelini Göster"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:656
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:762
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:802
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1155
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1260
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:297
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:571
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:606
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:705
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:783
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:849
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:909
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1145
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1204
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:708
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:786
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:852
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:912
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1171
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1230
 msgid ""
 "Some music files still have changes waiting to be applied. What would you "
 "like to do?"
@@ -1455,43 +1489,43 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dosyaları Sırala"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Gönder"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1206
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:150
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1192
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
-#: NickvisionTagger.GNOME/Blueprints/window.blp:71
+#: NickvisionTagger.GNOME/Blueprints/window.blp:73
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../Controllers/MainWindowController.cs:1293
+#: ../../../Controllers/MainWindowController.cs:1268
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:141
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:224
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
-#: NickvisionTagger.GNOME/Blueprints/window.blp:346
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
+#: NickvisionTagger.GNOME/Blueprints/window.blp:367
 msgid "Switch to Back Cover"
 msgstr "Arka Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1047
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1240
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1241
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1566
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1567
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1596
 msgid "Switch to Front Cover"
 msgstr "Ön Kapağa Geç"
 
@@ -1504,39 +1538,41 @@ msgstr "Eşitlenmiş"
 msgid "Tag"
 msgstr "Etiket"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1027
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1115
-#: NickvisionTagger.GNOME/Blueprints/window.blp:63
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
+#: NickvisionTagger.GNOME/Blueprints/window.blp:65
 msgid "Tag to File Name"
 msgstr "Etiketten Dosya Adına"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:176
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:178
 msgid "Tag to File Name (Ctrl+T)"
 msgstr "Etiketten Dosya Adına (Ctrl+T)"
 
-#: ../../../Controllers/MainWindowController.cs:170
+#: ../../../Controllers/MainWindowController.cs:161
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:5
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:8
 msgid "Tag your music"
 msgstr "Müziklerinizi etiketleyin"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:158
-#: NickvisionTagger.GNOME/Blueprints/window.blp:115
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:160
+#: NickvisionTagger.GNOME/Blueprints/window.blp:117
 msgid "Tag Your Music"
 msgstr "Müziklerinizi Etiketleyin"
 
-#: ../../../Controllers/MainWindowController.cs:169
+#: ../../../Controllers/MainWindowController.cs:160
 #: NickvisionTagger.Shared/org.nickvision.tagger.desktop.in:4
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:6
 msgid "Tagger"
 msgstr "Tagger"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
 msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:929
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:895
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
 "this playlist."
@@ -1548,7 +1584,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1245
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "This file does not have a valid fingerprint"
 msgstr "Bu dosyanın geçerli bir parmak izi yok"
 
@@ -1570,54 +1606,54 @@ msgstr "TiB"
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
-#: ../../../Controllers/MainWindowController.cs:189
-#: ../../../Controllers/MainWindowController.cs:1349
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:670
-#: ../../../Models/MusicFile.cs:797
+#: ../../../Controllers/MainWindowController.cs:180
+#: ../../../Controllers/MainWindowController.cs:1324
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
+#: ../../../Models/MusicFile.cs:794
 msgid "title"
 msgstr "başlık"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:116
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:182
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:184
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:51
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:448
+#: NickvisionTagger.GNOME/Blueprints/window.blp:469
 msgid "Title"
 msgstr "Başlık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1197
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1376
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:690
-#: ../../../Models/MusicFile.cs:813
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1351
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:810
 msgid "track"
 msgstr "parça"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:120
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:196
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:55
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:481
+#: NickvisionTagger.GNOME/Blueprints/window.blp:502
 msgid "Track"
 msgstr "Parça"
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1391
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:698
-#: ../../../Models/MusicFile.cs:817
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1366
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
+#: ../../../Models/MusicFile.cs:814
 msgid "tracktotal"
 msgstr "toplam parça"
 
-#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:172
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:164
-#: NickvisionTagger.GNOME/Blueprints/window.blp:201
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:166
+#: NickvisionTagger.GNOME/Blueprints/window.blp:203
 msgid "Try a different library"
 msgstr "Başka bir kitaplık dene"
 
@@ -1626,21 +1662,21 @@ msgstr "Başka bir kitaplık dene"
 msgid "Type"
 msgstr "Tür"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:165
-#: NickvisionTagger.GNOME/Blueprints/window.blp:220
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:167
+#: NickvisionTagger.GNOME/Blueprints/window.blp:222
 msgid "Type ! for advanced search"
 msgstr "gelişmiş arama için ! yazın"
 
-#: ../../../Controllers/MainWindowController.cs:570
+#: ../../../Controllers/MainWindowController.cs:561
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Dosya çalma listesine eklenemiyor. Dosya zaten çalma listesinde olabilir."
 
-#: ../../../Controllers/MainWindowController.cs:550
+#: ../../../Controllers/MainWindowController.cs:541
 msgid "Unable to create playlist."
 msgstr "Çalma listesi oluşturulamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:435
+#: ../../../Controllers/MainWindowController.cs:426
 msgid "Unable to download and install update."
 msgstr "Güncellemeler indirilip kurulamadı."
 
@@ -1654,29 +1690,29 @@ msgstr "LRC'ye dışa aktarılamıyor."
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:1024
+#: ../../../Controllers/MainWindowController.cs:1015
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:585
+#: ../../../Controllers/MainWindowController.cs:576
 msgid "Unable to remove some files from playlist."
 msgstr "Kimi dosyalar çalma listesinden kaldırılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:866
+#: ../../../Controllers/MainWindowController.cs:857
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:824
+#: ../../../Controllers/MainWindowController.cs:815
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:1296
+#: ../../../Controllers/MainWindowController.cs:1271
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:1646
+#: ../../../Controllers/MainWindowController.cs:1621
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1685,7 +1721,7 @@ msgstr "Bilinmiyor"
 msgid "Unsynchronized"
 msgstr "Eşitlenmemiş"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:428
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:431
 msgid "Update"
 msgstr "Güncelle"
 
@@ -1699,8 +1735,8 @@ msgstr "LRC şarkı sözlerini kullan"
 msgid "Use Relative Paths"
 msgstr "Göreli Yolları Kullan"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:837
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Göreli Yollar Kullanılsın Mı?"
 
@@ -1709,10 +1745,10 @@ msgstr "Göreli Yollar Kullanılsın Mı?"
 msgid "User Interface"
 msgstr "Kullanıcı Arayüzü"
 
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
-#: NickvisionTagger.GNOME/Blueprints/window.blp:67
+#: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web Servisleri"
 
@@ -1725,6 +1761,11 @@ msgstr ""
 "Tagger'ın, LRC dosyasında bulunan ve aynı zaman damgasına sahip mevcut şarkı "
 "sözleriyle çelişen şarkı sözleriyle ne yapmasını istersiniz?"
 
+#: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:24
+#: NickvisionTagger.GNOME/Blueprints/album_art_info_dialog.blp:37
+msgid "Width"
+msgstr ""
+
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:120
 #, csharp-format
 msgid ""
@@ -1735,8 +1776,8 @@ msgstr ""
 "misiniz?\n"
 "Kaydedilmemiş tüm çalışmalar kaybolacaktır."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:862
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:838
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
 "path?\n"
@@ -1746,25 +1787,25 @@ msgstr ""
 "misiniz?\n"
 "Aksi takdirde göreli yol yerine tam yol kullanılacaktır."
 
-#: ../../../Controllers/MainWindowController.cs:190
-#: ../../../Controllers/MainWindowController.cs:1361
-#: ../../../Models/MusicFile.cs:74 ../../../Models/MusicFile.cs:682
-#: ../../../Models/MusicFile.cs:809
+#: ../../../Controllers/MainWindowController.cs:181
+#: ../../../Controllers/MainWindowController.cs:1336
+#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "year"
 msgstr "yıl"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:119
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:192
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:194
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:54
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:66
-#: NickvisionTagger.GNOME/Blueprints/window.blp:468
+#: NickvisionTagger.GNOME/Blueprints/window.blp:489
 msgid "Year"
 msgstr "Yıl"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:867
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:934
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:839
-#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:896
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
+#: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121
 msgid "Yes"
 msgstr "Evet"
@@ -1838,7 +1879,7 @@ msgid "Remove Front Album Art"
 msgstr "Albüm Ön Kapağını Kaldır"
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:95
-#: NickvisionTagger.GNOME/Blueprints/window.blp:56
+#: NickvisionTagger.GNOME/Blueprints/window.blp:58
 msgid "Switch Album Art"
 msgstr "Albüm Kapağını Değiştir"
 
@@ -1869,52 +1910,52 @@ msgstr "Çık"
 msgid "About Tagger"
 msgstr "Tagger Hakkında"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:85
+#: NickvisionTagger.GNOME/Blueprints/window.blp:87
 msgid "Library Menu"
 msgstr "Kitaplık Menüsü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:90
+#: NickvisionTagger.GNOME/Blueprints/window.blp:92
 msgid "Library"
 msgstr "Kitaplık"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:99
+#: NickvisionTagger.GNOME/Blueprints/window.blp:101
 msgid "Main Menu"
 msgstr "Ana Menü"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:130
+#: NickvisionTagger.GNOME/Blueprints/window.blp:132
 msgid "Open Folder (Ctrl+O)"
 msgstr "Klasör Aç (Ctrl+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:143
+#: NickvisionTagger.GNOME/Blueprints/window.blp:145
 msgid "Open Playlist (Ctrl+Shift+O)"
 msgstr "Çalma Listesi Aç (Ctrl+Shift+O)"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:231
+#: NickvisionTagger.GNOME/Blueprints/window.blp:233
 msgid "Select All Files"
 msgstr "Tüm Dosyaları Seç"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:499
+#: NickvisionTagger.GNOME/Blueprints/window.blp:520
 msgid "Track Total"
 msgstr "Toplam Parça"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:513
+#: NickvisionTagger.GNOME/Blueprints/window.blp:534
 msgid "Disc Number"
 msgstr ""
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:531
+#: NickvisionTagger.GNOME/Blueprints/window.blp:552
 #, fuzzy
 msgid "Disc Total"
 msgstr "Toplam Parça"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:658
+#: NickvisionTagger.GNOME/Blueprints/window.blp:679
 msgid "Toggle Tags Pane"
 msgstr "Etiket Bölmesini Aç/Kapat"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:686
+#: NickvisionTagger.GNOME/Blueprints/window.blp:707
 msgid "Tag Actions"
 msgstr "Etiket Eylemleri"
 
-#: NickvisionTagger.GNOME/Blueprints/window.blp:692
+#: NickvisionTagger.GNOME/Blueprints/window.blp:713
 msgid "Apply Changes To Tag (Ctrl+S)"
 msgstr "Etiket Değişikliklerini Uygula (Ctrl+S)"
 
@@ -1924,43 +1965,49 @@ msgstr ""
 "Tag;Music;Editor;Library;Nickvision;Etiket;Müzik;Düzenleyici;Kütüphane;"
 "Kitaplık;"
 
-#~ msgid ""
-#~ "— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
-#~ msgstr ""
-#~ "— Pek çok müzik dosyası türünü destekler (mp3, ogg, flac, wma ve çok daha "
-#~ "fazlası)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:10
+msgid ""
+"— Support for many music file types (mp3, ogg, flac, wma, wav, and more)"
+msgstr ""
+"— Pek çok müzik dosyası türünü destekler (mp3, ogg, flac, wma ve çok daha "
+"fazlası)"
 
-#~ msgid ""
-#~ "— Edit tags and album art of multiple files, even across subfolders, all "
-#~ "at once"
-#~ msgstr ""
-#~ "— Alt klasörler de dahil olmak üzere birden fazla dosyanın etiketlerini "
-#~ "ve albüm kapaklarını aynı anda düzenleyin"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:11
+msgid ""
+"— Edit tags and album art of multiple files, even across subfolders, all at "
+"once"
+msgstr ""
+"— Alt klasörler de dahil olmak üzere birden fazla dosyanın etiketlerini ve "
+"albüm kapaklarını aynı anda düzenleyin"
 
-#~ msgid ""
-#~ "— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
-#~ "and export support)"
-#~ msgstr ""
-#~ "— Dosya için eşzamanlanmış ve eşzamanlanmış şarkı sözlerini düzenleyin "
-#~ "(LRC içe ve dışa aktarma desteğiyle)"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:12
+msgid ""
+"— Edit unsynchronized and synchronized lyrics for a file (with LRC import "
+"and export support)"
+msgstr ""
+"— Dosya için eşzamanlanmış ve eşzamanlanmış şarkı sözlerini düzenleyin (LRC "
+"içe ve dışa aktarma desteğiyle)"
 
-#~ msgid "— Convert filenames to tags and tags to filenames with ease"
-#~ msgstr ""
-#~ "— Dosya adlarını etiketlere ve etiketleri dosya adlarına kolayca "
-#~ "dönüştürün"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:13
+msgid "— Convert filenames to tags and tags to filenames with ease"
+msgstr ""
+"— Dosya adlarını etiketlere ve etiketleri dosya adlarına kolayca dönüştürün"
 
-#~ msgid "— Lookup file information using MusicBrainz"
-#~ msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:14
+msgid "— Lookup file information using MusicBrainz"
+msgstr "— MusicBrainz kullanarak dosya bilgilerine bakın"
 
-#~ msgid "— Lookup lyric information using Music163 and Letras"
-#~ msgstr "— Music163 ve Letras kullanarak şarkı sözü bilgilerini arayın"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:15
+msgid "— Lookup lyric information using Music163 and Letras"
+msgstr "— Music163 ve Letras kullanarak şarkı sözü bilgilerini arayın"
 
-#~ msgid ""
-#~ "— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
-#~ "more)"
-#~ msgstr ""
-#~ "— Birçok biçimde (m3u, pls, xspf ve daha fazlası) çalma listeleri açın, "
-#~ "yönetin ve oluşturun"
+#: NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in:16
+msgid ""
+"— Open, manage, and create playlists in many formats (m3u, pls, xspf, and "
+"more)"
+msgstr ""
+"— Birçok biçimde (m3u, pls, xspf ve daha fazlası) çalma listeleri açın, "
+"yönetin ve oluşturun"
 
 #~ msgid "Open a library with music to get started."
 #~ msgstr "Başlamak için müzik içeren bir kitaplık açın."

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 15:12-0400\n"
+"POT-Creation-Date: 2023-10-19 21:31-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -61,26 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:596
-#: ../../../Controllers/MainWindowController.cs:607
-#: ../../../Controllers/MainWindowController.cs:612
-#: ../../../Controllers/MainWindowController.cs:617
-#: ../../../Controllers/MainWindowController.cs:622
-#: ../../../Controllers/MainWindowController.cs:634
-#: ../../../Controllers/MainWindowController.cs:646
-#: ../../../Controllers/MainWindowController.cs:658
-#: ../../../Controllers/MainWindowController.cs:663
-#: ../../../Controllers/MainWindowController.cs:668
-#: ../../../Controllers/MainWindowController.cs:673
-#: ../../../Controllers/MainWindowController.cs:678
-#: ../../../Controllers/MainWindowController.cs:690
-#: ../../../Controllers/MainWindowController.cs:695
-#: ../../../Controllers/MainWindowController.cs:707
-#: ../../../Controllers/MainWindowController.cs:719
-#: ../../../Controllers/MainWindowController.cs:724
-#: ../../../Controllers/MainWindowController.cs:740
-#: ../../../Controllers/MainWindowController.cs:1810
-#: ../../../Controllers/MainWindowController.cs:1811
+#: ../../../Controllers/MainWindowController.cs:597
+#: ../../../Controllers/MainWindowController.cs:608
+#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:618
+#: ../../../Controllers/MainWindowController.cs:623
+#: ../../../Controllers/MainWindowController.cs:635
+#: ../../../Controllers/MainWindowController.cs:647
+#: ../../../Controllers/MainWindowController.cs:659
+#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:669
+#: ../../../Controllers/MainWindowController.cs:674
+#: ../../../Controllers/MainWindowController.cs:679
+#: ../../../Controllers/MainWindowController.cs:691
+#: ../../../Controllers/MainWindowController.cs:696
+#: ../../../Controllers/MainWindowController.cs:708
+#: ../../../Controllers/MainWindowController.cs:720
+#: ../../../Controllers/MainWindowController.cs:725
+#: ../../../Controllers/MainWindowController.cs:741
 #: ../../../Controllers/MainWindowController.cs:1812
 #: ../../../Controllers/MainWindowController.cs:1813
 #: ../../../Controllers/MainWindowController.cs:1814
@@ -96,7 +94,9 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1824
 #: ../../../Controllers/MainWindowController.cs:1825
 #: ../../../Controllers/MainWindowController.cs:1826
-#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1827
+#: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1832
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
@@ -135,7 +135,7 @@ msgstr ""
 "iziyle ilişkili olarak gönderir."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:74
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:163
 msgid "AcoustId User API Key"
 msgstr "AcoustId Kullanıcı API Anahtarı"
 
@@ -172,9 +172,9 @@ msgid "Advanced Search Info"
 msgstr "Gelişmiş Arama Bilgisi"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1332
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:675
-#: ../../../Models/MusicFile.cs:802
+#: ../../../Controllers/MainWindowController.cs:1333
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
+#: ../../../Models/MusicFile.cs:815
 msgid "album"
 msgstr "album"
 
@@ -197,9 +197,9 @@ msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1381
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:703
-#: ../../../Models/MusicFile.cs:818
+#: ../../../Controllers/MainWindowController.cs:1382
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
+#: ../../../Models/MusicFile.cs:831
 msgid "albumartist"
 msgstr "albumartist"
 
@@ -218,7 +218,7 @@ msgstr "Tüm Desteklenen Dosyalar"
 msgid "An application restart is required to change the theme."
 msgstr "Temayı değiştirmek için uygulamanın yeniden başlatılması gerekir."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1220
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
@@ -267,9 +267,9 @@ msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1328
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:671
-#: ../../../Models/MusicFile.cs:798
+#: ../../../Controllers/MainWindowController.cs:1329
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
+#: ../../../Models/MusicFile.cs:811
 msgid "artist"
 msgstr "sanatçı"
 
@@ -305,21 +305,21 @@ msgid "Beats Per Minute"
 msgstr "Dakika Başına Vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1393
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:715
-#: ../../../Models/MusicFile.cs:830
+#: ../../../Controllers/MainWindowController.cs:1394
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
+#: ../../../Models/MusicFile.cs:843
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1692
-#: ../../../Controllers/MainWindowController.cs:1698
+#: ../../../Controllers/MainWindowController.cs:1694
+#: ../../../Controllers/MainWindowController.cs:1700
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
@@ -382,9 +382,9 @@ msgid "Close Library"
 msgstr "Kitaplığı Kapat"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:711
-#: ../../../Models/MusicFile.cs:826
+#: ../../../Controllers/MainWindowController.cs:1390
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
+#: ../../../Models/MusicFile.cs:839
 msgid "comment"
 msgstr "yorum"
 
@@ -394,9 +394,9 @@ msgid "Comment"
 msgstr "Yorum"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:723
-#: ../../../Models/MusicFile.cs:834
+#: ../../../Controllers/MainWindowController.cs:1409
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
+#: ../../../Models/MusicFile.cs:847
 msgid "composer"
 msgstr "besteci"
 
@@ -423,25 +423,25 @@ msgstr "GitHub Katkıcıları ❤️"
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:963
+#: ../../../Controllers/MainWindowController.cs:964
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:997
+#: ../../../Controllers/MainWindowController.cs:998
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:942
+#: ../../../Controllers/MainWindowController.cs:943
 msgid "Converting file names to tags..."
 msgstr "Dosya adları etikete dönüştürülüyor..."
 
-#: ../../../Controllers/MainWindowController.cs:976
+#: ../../../Controllers/MainWindowController.cs:977
 msgid "Converting tags to file names..."
 msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 
@@ -475,7 +475,7 @@ msgid "Credits"
 msgstr "Hazırlayanlar"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1465
+#: ../../../Controllers/MainWindowController.cs:1466
 msgid "custom"
 msgstr "özel"
 
@@ -513,14 +513,14 @@ msgstr "Etiketi Sil"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Etiketi Sil (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:909
+#: ../../../Controllers/MainWindowController.cs:910
 msgid "Deleting tags..."
 msgstr "Etiketler siliniyor..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:727
-#: ../../../Models/MusicFile.cs:838
+#: ../../../Controllers/MainWindowController.cs:1413
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
+#: ../../../Models/MusicFile.cs:851
 msgid "description"
 msgstr "açıklama"
 
@@ -591,21 +591,21 @@ msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:877
+#: ../../../Controllers/MainWindowController.cs:878
 msgid "Discarding tags..."
 msgstr "Etiketler gözden çıkarılıyor..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:731
-#: ../../../Models/MusicFile.cs:842
+#: ../../../Controllers/MainWindowController.cs:1417
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
+#: ../../../Models/MusicFile.cs:855
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:739
-#: ../../../Models/MusicFile.cs:846
+#: ../../../Controllers/MainWindowController.cs:1432
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
+#: ../../../Models/MusicFile.cs:859
 #, fuzzy
 msgid "disctotal"
 msgstr "toplam parça"
@@ -634,21 +634,21 @@ msgstr "MusicBrainz Üst Verilerini İndir"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz Üst Verilerini İndir (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} dosya için şarkı sözleri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1238
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "Downloading lyrics..."
 msgstr "Şarkı sözleri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:1188
+#: ../../../Controllers/MainWindowController.cs:1189
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
@@ -664,14 +664,14 @@ msgid "Edit"
 msgstr "Düzenle"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:67
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
 msgid "Enable to overwrite existing album art with art found from MusicBrainz."
 msgstr ""
 "MusicBrainzʼden bulunan kapakla var olan albüm kapağının üzerine yazmayı "
 "etkinleştir."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:71
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:132
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:148
 msgid ""
 "Enable to overwrite existing lyrics with that found from downloading lyrics "
 "from the web. If disabled, only blank lyrics will be filled."
@@ -681,7 +681,7 @@ msgstr ""
 "doldurulur."
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:63
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:100
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:116
 msgid ""
 "Enable to overwrite existing tag metadata with data found from MusicBrainz. "
 "If disabled, only blank tag properties will be filled."
@@ -773,12 +773,12 @@ msgstr "Toplam parça sayısını buraya girin"
 msgid "Enter year here"
 msgstr "Yılı buraya girin"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1222
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:426 ../../../Models/MusicFile.cs:883
-#: ../../../Models/MusicFile.cs:1048
+#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
+#: ../../../Models/MusicFile.cs:1061
 msgid "ERROR"
 msgstr "HATA"
 
@@ -816,11 +816,11 @@ msgstr "Albüm Ön Kapağını Dışa Aktar"
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:1131
+#: ../../../Controllers/MainWindowController.cs:1132
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:1115
+#: ../../../Controllers/MainWindowController.cs:1116
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
@@ -837,11 +837,11 @@ msgstr "MusicBrainz Aramaları Başarısız Oldu"
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:1136
+#: ../../../Controllers/MainWindowController.cs:1137
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:1120
+#: ../../../Controllers/MainWindowController.cs:1121
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
@@ -880,7 +880,7 @@ msgid "File Properties"
 msgstr "Dosya Özellikleri"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1320
+#: ../../../Controllers/MainWindowController.cs:1321
 msgid "filename"
 msgstr "dosya adı"
 
@@ -926,9 +926,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1385
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:707
-#: ../../../Models/MusicFile.cs:822
+#: ../../../Controllers/MainWindowController.cs:1386
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
+#: ../../../Models/MusicFile.cs:835
 msgid "genre"
 msgstr "tür"
 
@@ -941,7 +941,7 @@ msgid "Genre"
 msgstr "Tür"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:76
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:157
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:173
 msgid "Get New API Key"
 msgstr "Yeni API Anahtarı Al"
 
@@ -1020,7 +1020,7 @@ msgstr "Albüm Arka Kapağı Ekle"
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:1019
+#: ../../../Controllers/MainWindowController.cs:1020
 msgid "Inserting album art..."
 msgstr "Albüm kapağı ekleniyor..."
 
@@ -1038,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Dil Kodu"
 
-#: ../../../Controllers/MainWindowController.cs:452
+#: ../../../Controllers/MainWindowController.cs:453
 msgid "Library was changed on disk."
 msgstr "Kitaplık diskte değiştirildi."
 
-#: ../../../Controllers/MainWindowController.cs:505
+#: ../../../Controllers/MainWindowController.cs:506
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../Controllers/MainWindowController.cs:491
-#: ../../../Controllers/MainWindowController.cs:1643
+#: ../../../Controllers/MainWindowController.cs:492
+#: ../../../Controllers/MainWindowController.cs:1645
 msgid "Loading music files from library..."
 msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 
@@ -1058,7 +1058,7 @@ msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 msgid "Lryics"
 msgstr "Şarkı Sözleri"
 
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:790
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
@@ -1123,7 +1123,7 @@ msgstr "Yeni Özel Özellik"
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:409
+#: ../../../Controllers/MainWindowController.cs:410
 msgid "New update available."
 msgstr "Yeni güncelleme var."
 
@@ -1140,7 +1140,7 @@ msgstr "Nicholas Logozzo"
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:1217
+#: ../../../Controllers/MainWindowController.cs:1218
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
@@ -1153,15 +1153,15 @@ msgstr "Hiçbir dosya seçilmedi"
 msgid "No files selected for removal."
 msgstr "Kaldırmak için hiçbir dosya seçilmedi."
 
-#: ../../../Controllers/MainWindowController.cs:1252
+#: ../../../Controllers/MainWindowController.cs:1253
 msgid "No lyrics were downloaded"
 msgstr "Hiçbir şarkı sözü indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:1228
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:528
+#: ../../../Controllers/MainWindowController.cs:529
 msgid "No music files are selected."
 msgstr "Hiçbir müzik dosyası seçilmedi."
 
@@ -1170,11 +1170,11 @@ msgstr "Hiçbir müzik dosyası seçilmedi."
 msgid "No Music Files Found"
 msgstr "Hiçbir Müzik Dosyası Bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:532
+#: ../../../Controllers/MainWindowController.cs:533
 msgid "No music files in library."
 msgstr "Kitaplıkta müzik dosyası yok."
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1219
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
@@ -1183,7 +1183,7 @@ msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 msgid "No Selected Music Files"
 msgstr "Seçili Müzik Dosyası Yok"
 
-#: ../../../Controllers/MainWindowController.cs:1265
+#: ../../../Controllers/MainWindowController.cs:1266
 msgid "No user api key configured."
 msgstr "Hiçbir kullanıcı anahtarı yapılandırılmadı."
 
@@ -1272,17 +1272,17 @@ msgid "Open Playlist"
 msgstr "Çalma Listesi Aç"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:66
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
 msgid "Overwrite Album Art With MusicBrainz"
 msgstr "MusicBrainz ile Albüm Kapağının Üzerine Yaz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:70
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:131
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:147
 msgid "Overwrite Lyrics From Web Service"
 msgstr "Web Hizmetinden Şarkı Sözlerinin Üzerine Yaz"
 
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:62
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:99
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:115
 msgid "Overwrite Tag With MusicBrainz"
 msgstr "MusicBrainz ile Etiketin Üzerine Yaz"
 
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
-#: ../../../Controllers/MainWindowController.cs:537
+#: ../../../Controllers/MainWindowController.cs:538
 msgid "Playlist file created successfully."
 msgstr "Çalma listesi oluşturuldu."
 
@@ -1318,7 +1318,7 @@ msgstr "Çalma listesi oluşturuldu."
 msgid "Playlist Mode"
 msgstr "Çalma Listesi Kipi"
 
-#: ../../../Controllers/MainWindowController.cs:524
+#: ../../../Controllers/MainWindowController.cs:525
 msgid "Playlist path can not be empty."
 msgstr "Çalma listesi yolu boş olamaz."
 
@@ -1344,9 +1344,9 @@ msgid "Property Name"
 msgstr "Özellik Adı"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1446
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:747
-#: ../../../Models/MusicFile.cs:850
+#: ../../../Controllers/MainWindowController.cs:1447
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
+#: ../../../Models/MusicFile.cs:863
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -1362,9 +1362,9 @@ msgid "Publishing Date"
 msgstr "Yayımcı"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1450
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:751
-#: ../../../Models/MusicFile.cs:854
+#: ../../../Controllers/MainWindowController.cs:1451
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
+#: ../../../Models/MusicFile.cs:867
 #, fuzzy
 msgid "publishingdate"
 msgstr "yayımcı"
@@ -1409,7 +1409,7 @@ msgstr "Çalma Listesinden Kaldır"
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
-#: ../../../Controllers/MainWindowController.cs:1063
+#: ../../../Controllers/MainWindowController.cs:1064
 msgid "Removing album art..."
 msgstr "Albüm kapağı kaldırılıyor..."
 
@@ -1435,8 +1435,8 @@ msgstr "Etiketi Kaydet"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Etiketi Kaydet (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:794
-#: ../../../Controllers/MainWindowController.cs:837
+#: ../../../Controllers/MainWindowController.cs:795
+#: ../../../Controllers/MainWindowController.cs:838
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
@@ -1502,11 +1502,11 @@ msgstr "Gönder"
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../Controllers/MainWindowController.cs:1268
+#: ../../../Controllers/MainWindowController.cs:1269
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1221
 msgid "This file does not have a valid fingerprint"
 msgstr "Bu dosyanın geçerli bir parmak izi yok"
 
@@ -1607,9 +1607,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1324
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:667
-#: ../../../Models/MusicFile.cs:794
+#: ../../../Controllers/MainWindowController.cs:1325
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
+#: ../../../Models/MusicFile.cs:807
 msgid "title"
 msgstr "başlık"
 
@@ -1627,9 +1627,9 @@ msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:687
-#: ../../../Models/MusicFile.cs:810
+#: ../../../Controllers/MainWindowController.cs:1352
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
+#: ../../../Models/MusicFile.cs:823
 msgid "track"
 msgstr "parça"
 
@@ -1642,9 +1642,9 @@ msgid "Track"
 msgstr "Parça"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1366
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:695
-#: ../../../Models/MusicFile.cs:814
+#: ../../../Controllers/MainWindowController.cs:1367
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
+#: ../../../Models/MusicFile.cs:827
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -1667,16 +1667,16 @@ msgstr "Tür"
 msgid "Type ! for advanced search"
 msgstr "gelişmiş arama için ! yazın"
 
-#: ../../../Controllers/MainWindowController.cs:561
+#: ../../../Controllers/MainWindowController.cs:562
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Dosya çalma listesine eklenemiyor. Dosya zaten çalma listesinde olabilir."
 
-#: ../../../Controllers/MainWindowController.cs:541
+#: ../../../Controllers/MainWindowController.cs:542
 msgid "Unable to create playlist."
 msgstr "Çalma listesi oluşturulamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:426
+#: ../../../Controllers/MainWindowController.cs:427
 msgid "Unable to download and install update."
 msgstr "Güncellemeler indirilip kurulamadı."
 
@@ -1690,29 +1690,29 @@ msgstr "LRC'ye dışa aktarılamıyor."
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:1015
+#: ../../../Controllers/MainWindowController.cs:1016
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:576
+#: ../../../Controllers/MainWindowController.cs:577
 msgid "Unable to remove some files from playlist."
 msgstr "Kimi dosyalar çalma listesinden kaldırılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:857
+#: ../../../Controllers/MainWindowController.cs:858
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:815
+#: ../../../Controllers/MainWindowController.cs:816
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:1271
+#: ../../../Controllers/MainWindowController.cs:1272
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:1621
+#: ../../../Controllers/MainWindowController.cs:1622
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1747,7 +1747,7 @@ msgstr "Kullanıcı Arayüzü"
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:149
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:61
-#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:112
 #: NickvisionTagger.GNOME/Blueprints/window.blp:69
 msgid "Web Services"
 msgstr "Web Servisleri"
@@ -1788,9 +1788,9 @@ msgstr ""
 "Aksi takdirde göreli yol yerine tam yol kullanılacaktır."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1336
-#: ../../../Models/MusicFile.cs:73 ../../../Models/MusicFile.cs:679
-#: ../../../Models/MusicFile.cs:806
+#: ../../../Controllers/MainWindowController.cs:1337
+#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
+#: ../../../Models/MusicFile.cs:819
 msgid "year"
 msgstr "yıl"
 
@@ -1845,6 +1845,14 @@ msgstr "Son Açılan Kitaplığı Hatırla"
 #: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:49
 msgid "Include Subfolders"
 msgstr "Alt Klasörleri Dahil Et"
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:95
+msgid "Limit File Name Characters"
+msgstr ""
+
+#: NickvisionTagger.GNOME/Blueprints/preferences_dialog.blp:96
+msgid "Restricts characters in file names to only those supported by Windows."
+msgstr ""
 
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:13
 msgctxt "Shortcut"

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-19 21:31-0400\n"
+"POT-Creation-Date: 2023-10-20 22:12-0400\n"
 "PO-Revision-Date: 2023-10-12 17:15+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -24,8 +24,8 @@ msgstr ""
 msgid "{0} • {1}"
 msgstr "{0}  /  {1}"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1484
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1515
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1493
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1524
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1378
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1428
 #, csharp-format
@@ -61,34 +61,24 @@ msgstr "%title%- %artist%"
 msgid "%track%- %title%"
 msgstr "%track%- %title%"
 
-#: ../../../Controllers/MainWindowController.cs:597
-#: ../../../Controllers/MainWindowController.cs:608
-#: ../../../Controllers/MainWindowController.cs:613
+#: ../../../Controllers/MainWindowController.cs:607
 #: ../../../Controllers/MainWindowController.cs:618
 #: ../../../Controllers/MainWindowController.cs:623
-#: ../../../Controllers/MainWindowController.cs:635
-#: ../../../Controllers/MainWindowController.cs:647
-#: ../../../Controllers/MainWindowController.cs:659
-#: ../../../Controllers/MainWindowController.cs:664
+#: ../../../Controllers/MainWindowController.cs:628
+#: ../../../Controllers/MainWindowController.cs:633
+#: ../../../Controllers/MainWindowController.cs:645
+#: ../../../Controllers/MainWindowController.cs:657
 #: ../../../Controllers/MainWindowController.cs:669
 #: ../../../Controllers/MainWindowController.cs:674
 #: ../../../Controllers/MainWindowController.cs:679
-#: ../../../Controllers/MainWindowController.cs:691
-#: ../../../Controllers/MainWindowController.cs:696
-#: ../../../Controllers/MainWindowController.cs:708
-#: ../../../Controllers/MainWindowController.cs:720
-#: ../../../Controllers/MainWindowController.cs:725
-#: ../../../Controllers/MainWindowController.cs:741
-#: ../../../Controllers/MainWindowController.cs:1812
-#: ../../../Controllers/MainWindowController.cs:1813
-#: ../../../Controllers/MainWindowController.cs:1814
-#: ../../../Controllers/MainWindowController.cs:1815
-#: ../../../Controllers/MainWindowController.cs:1816
-#: ../../../Controllers/MainWindowController.cs:1817
-#: ../../../Controllers/MainWindowController.cs:1818
-#: ../../../Controllers/MainWindowController.cs:1819
-#: ../../../Controllers/MainWindowController.cs:1820
-#: ../../../Controllers/MainWindowController.cs:1821
+#: ../../../Controllers/MainWindowController.cs:684
+#: ../../../Controllers/MainWindowController.cs:689
+#: ../../../Controllers/MainWindowController.cs:701
+#: ../../../Controllers/MainWindowController.cs:706
+#: ../../../Controllers/MainWindowController.cs:718
+#: ../../../Controllers/MainWindowController.cs:730
+#: ../../../Controllers/MainWindowController.cs:735
+#: ../../../Controllers/MainWindowController.cs:751
 #: ../../../Controllers/MainWindowController.cs:1822
 #: ../../../Controllers/MainWindowController.cs:1823
 #: ../../../Controllers/MainWindowController.cs:1824
@@ -96,9 +86,19 @@ msgstr "%track%- %title%"
 #: ../../../Controllers/MainWindowController.cs:1826
 #: ../../../Controllers/MainWindowController.cs:1827
 #: ../../../Controllers/MainWindowController.cs:1828
+#: ../../../Controllers/MainWindowController.cs:1829
+#: ../../../Controllers/MainWindowController.cs:1830
+#: ../../../Controllers/MainWindowController.cs:1831
 #: ../../../Controllers/MainWindowController.cs:1832
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1545
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1548
+#: ../../../Controllers/MainWindowController.cs:1833
+#: ../../../Controllers/MainWindowController.cs:1834
+#: ../../../Controllers/MainWindowController.cs:1835
+#: ../../../Controllers/MainWindowController.cs:1836
+#: ../../../Controllers/MainWindowController.cs:1837
+#: ../../../Controllers/MainWindowController.cs:1838
+#: ../../../Controllers/MainWindowController.cs:1842
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1554
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1557
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1450
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1542
@@ -114,7 +114,7 @@ msgstr "0 MiB"
 msgid "About {0}"
 msgstr "{0} Hakkında"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid ""
 "AcoustId can associate a song's fingerprint with a MusicBrainz Recording Id "
@@ -140,7 +140,7 @@ msgid "AcoustId User API Key"
 msgstr "AcoustId Kullanıcı API Anahtarı"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
@@ -172,9 +172,9 @@ msgid "Advanced Search Info"
 msgstr "Gelişmiş Arama Bilgisi"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1333
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:688
-#: ../../../Models/MusicFile.cs:815
+#: ../../../Controllers/MainWindowController.cs:1343
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:687
+#: ../../../Models/MusicFile.cs:814
 msgid "album"
 msgstr "album"
 
@@ -197,9 +197,9 @@ msgid "Album Artist"
 msgstr "Albüm Sanatçısı"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1382
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:716
-#: ../../../Models/MusicFile.cs:831
+#: ../../../Controllers/MainWindowController.cs:1392
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:715
+#: ../../../Models/MusicFile.cs:830
 msgid "albumartist"
 msgstr "albumartist"
 
@@ -209,8 +209,8 @@ msgstr "albumartist"
 msgid "All files"
 msgstr "Tüm Dosyalar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:737
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:852
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:742
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:857
 msgid "All Supported Files"
 msgstr "Tüm Desteklenen Dosyalar"
 
@@ -218,18 +218,18 @@ msgstr "Tüm Desteklenen Dosyalar"
 msgid "An application restart is required to change the theme."
 msgstr "Temayı değiştirmek için uygulamanın yeniden başlatılması gerekir."
 
-#: ../../../Controllers/MainWindowController.cs:1220
+#: ../../../Controllers/MainWindowController.cs:1230
 msgid "An invalid RecordingId was provided to MusicBrainz"
 msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:674
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:780
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:820
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:888
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:960
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1183
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1241
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1288
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:40
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:52
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:301
@@ -246,14 +246,14 @@ msgstr "Geçersiz bir kayıt kimliği MüzikBrainz'e verildi"
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:299
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:573
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:608
@@ -267,9 +267,9 @@ msgid "Apply Changes?"
 msgstr "Değişiklikler Uygulansın Mı?"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1329
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:684
-#: ../../../Models/MusicFile.cs:811
+#: ../../../Controllers/MainWindowController.cs:1339
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:683
+#: ../../../Models/MusicFile.cs:810
 msgid "artist"
 msgstr "sanatçı"
 
@@ -290,8 +290,8 @@ msgid "B"
 msgstr "B"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:138
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -305,40 +305,40 @@ msgid "Beats Per Minute"
 msgstr "Dakika Başına Vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1394
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:728
-#: ../../../Models/MusicFile.cs:843
+#: ../../../Controllers/MainWindowController.cs:1404
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:842
 msgid "bpm"
 msgstr "bpm"
 
-#: ../../../Controllers/MainWindowController.cs:1694
-#: ../../../Controllers/MainWindowController.cs:1700
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1769
+#: ../../../Controllers/MainWindowController.cs:1704
+#: ../../../Controllers/MainWindowController.cs:1710
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1798
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:221
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1565
 msgid "Calculating..."
 msgstr "Hesaplanıyor..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:664
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:770
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:810
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:950
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1173
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1231
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1278
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:669
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:775
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:815
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:883
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:955
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1178
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1236
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1283
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
@@ -382,9 +382,9 @@ msgid "Close Library"
 msgstr "Kitaplığı Kapat"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1390
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:724
-#: ../../../Models/MusicFile.cs:839
+#: ../../../Controllers/MainWindowController.cs:1400
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:723
+#: ../../../Models/MusicFile.cs:838
 msgid "comment"
 msgstr "yorum"
 
@@ -394,9 +394,9 @@ msgid "Comment"
 msgstr "Yorum"
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1409
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:736
-#: ../../../Models/MusicFile.cs:847
+#: ../../../Controllers/MainWindowController.cs:1419
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:846
 msgid "composer"
 msgstr "besteci"
 
@@ -414,8 +414,8 @@ msgstr "Yapılandır"
 msgid "Contributors on GitHub ❤️"
 msgstr "GitHub Katkıcıları ❤️"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:146
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
@@ -423,25 +423,25 @@ msgstr "GitHub Katkıcıları ❤️"
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../../../Controllers/MainWindowController.cs:964
+#: ../../../Controllers/MainWindowController.cs:974
 #, csharp-format
 msgid "Converted {0} file name to tag successfully"
 msgid_plural "Converted {0} file names to tags successfully"
 msgstr[0] "{0} dosya adı etikete dönüştürüldü"
 msgstr[1] "{0} dosya adı etikete dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:998
+#: ../../../Controllers/MainWindowController.cs:1008
 #, csharp-format
 msgid "Converted {0} tag to file name successfully"
 msgid_plural "Converted {0} tags to file names successfully"
 msgstr[0] "{0} etiket dosya adına dönüştürüldü"
 msgstr[1] "{0} etiket dosya adına dönüştürüldü"
 
-#: ../../../Controllers/MainWindowController.cs:943
+#: ../../../Controllers/MainWindowController.cs:953
 msgid "Converting file names to tags..."
 msgstr "Dosya adları etikete dönüştürülüyor..."
 
-#: ../../../Controllers/MainWindowController.cs:977
+#: ../../../Controllers/MainWindowController.cs:987
 msgid "Converting tags to file names..."
 msgstr "Etiketler dosya adlarına dönüştürülüyor..."
 
@@ -475,7 +475,7 @@ msgid "Credits"
 msgstr "Hazırlayanlar"
 
 #: ../../../Controllers/MainWindowController.cs:185
-#: ../../../Controllers/MainWindowController.cs:1466
+#: ../../../Controllers/MainWindowController.cs:1476
 msgid "custom"
 msgstr "özel"
 
@@ -513,14 +513,14 @@ msgstr "Etiketi Sil"
 msgid "Delete Tag (Shift+Delete)"
 msgstr "Etiketi Sil (Shift+Delete)"
 
-#: ../../../Controllers/MainWindowController.cs:910
+#: ../../../Controllers/MainWindowController.cs:920
 msgid "Deleting tags..."
 msgstr "Etiketler siliniyor..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1413
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:740
-#: ../../../Models/MusicFile.cs:851
+#: ../../../Controllers/MainWindowController.cs:1423
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:850
 msgid "description"
 msgstr "açıklama"
 
@@ -563,14 +563,14 @@ msgstr ""
 msgid "Disc"
 msgstr "Gözden Çıkar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:672
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:778
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:818
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:886
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:958
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1181
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1239
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1286
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:302
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:576
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:611
@@ -591,21 +591,21 @@ msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar"
 msgid "Discard Unapplied Changed (Ctrl+Z)"
 msgstr "Uygulanmamış Değişiklikleri Gözden Çıkar (Ctrl+Z)"
 
-#: ../../../Controllers/MainWindowController.cs:878
+#: ../../../Controllers/MainWindowController.cs:888
 msgid "Discarding tags..."
 msgstr "Etiketler gözden çıkarılıyor..."
 
 #: ../../../Controllers/MainWindowController.cs:183
-#: ../../../Controllers/MainWindowController.cs:1417
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:744
-#: ../../../Models/MusicFile.cs:855
+#: ../../../Controllers/MainWindowController.cs:1427
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:854
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1432
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:752
-#: ../../../Models/MusicFile.cs:859
+#: ../../../Controllers/MainWindowController.cs:1442
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:751
+#: ../../../Models/MusicFile.cs:858
 #, fuzzy
 msgid "disctotal"
 msgstr "toplam parça"
@@ -634,21 +634,21 @@ msgstr "MusicBrainz Üst Verilerini İndir"
 msgid "Download MusicBrainz Metadata (Ctrl+M)"
 msgstr "MusicBrainz Üst Verilerini İndir (Ctrl+M)"
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 #, csharp-format
 msgid "Downloaded lyrics for {0} files successfully"
 msgstr "{0} dosya için şarkı sözleri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 #, csharp-format
 msgid "Downloaded metadata for {0} files successfully"
 msgstr "{0} dosya için üst veri indirildi"
 
-#: ../../../Controllers/MainWindowController.cs:1239
+#: ../../../Controllers/MainWindowController.cs:1249
 msgid "Downloading lyrics..."
 msgstr "Şarkı sözleri indiriliyor..."
 
-#: ../../../Controllers/MainWindowController.cs:1189
+#: ../../../Controllers/MainWindowController.cs:1199
 msgid "Downloading MusicBrainz metadata..."
 msgstr "MusicBrainz üst verileri indiriliyor..."
 
@@ -773,12 +773,12 @@ msgstr "Toplam parça sayısını buraya girin"
 msgid "Enter year here"
 msgstr "Yılı buraya girin"
 
-#: ../../../Controllers/MainWindowController.cs:1222
+#: ../../../Controllers/MainWindowController.cs:1232
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:439 ../../../Models/MusicFile.cs:896
-#: ../../../Models/MusicFile.cs:1061
+#: ../../../Models/MusicFile.cs:438 ../../../Models/MusicFile.cs:895
+#: ../../../Models/MusicFile.cs:1060
 msgid "ERROR"
 msgstr "HATA"
 
@@ -800,12 +800,12 @@ msgstr "Çık"
 msgid "Export"
 msgstr "Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:110
 msgid "Export Back Album Art"
 msgstr "Albüm Arka Kapağını Dışa Aktar"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1100
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1105
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:90
 msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
@@ -816,11 +816,11 @@ msgstr "Albüm Ön Kapağını Dışa Aktar"
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
 
-#: ../../../Controllers/MainWindowController.cs:1132
+#: ../../../Controllers/MainWindowController.cs:1142
 msgid "Exported back album art to file successfully"
 msgstr "Albüm arka kapağı dosyaya dışa aktardı"
 
-#: ../../../Controllers/MainWindowController.cs:1116
+#: ../../../Controllers/MainWindowController.cs:1126
 msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
@@ -833,15 +833,15 @@ msgstr "Dışa aktarıldı: {0}"
 msgid "Failed MusicBrainz Lookup"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:604
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:609
 msgid "Failed MusicBrainz Lookups"
 msgstr "MusicBrainz Aramaları Başarısız Oldu"
 
-#: ../../../Controllers/MainWindowController.cs:1137
+#: ../../../Controllers/MainWindowController.cs:1147
 msgid "Failed to export back album art to a file"
 msgstr "Albüm arka kapağı dosyaya dışa aktarılamadı"
 
-#: ../../../Controllers/MainWindowController.cs:1121
+#: ../../../Controllers/MainWindowController.cs:1131
 msgid "Failed to export front album art to a file"
 msgstr "Albüm ön kapağı dosyaya dışa aktarılamadı"
 
@@ -857,7 +857,7 @@ msgstr "Dosya"
 msgid "File Name"
 msgstr "Dosya Adı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:147
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: NickvisionTagger.GNOME/Blueprints/window.blp:64
@@ -880,7 +880,7 @@ msgid "File Properties"
 msgstr "Dosya Özellikleri"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1321
+#: ../../../Controllers/MainWindowController.cs:1331
 msgid "filename"
 msgstr "dosya adı"
 
@@ -889,12 +889,12 @@ msgstr "dosya adı"
 msgid "Fingerprint"
 msgstr "Parmak izi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1786
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1815
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1717
 msgid "Fingerprint was copied to clipboard."
 msgstr "Parmak izi panoya kopyalandı."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Folder Mode"
 msgstr "Klasör Kipi"
@@ -904,16 +904,16 @@ msgstr "Klasör Kipi"
 msgid "Format"
 msgstr "Biçim"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Format String"
 msgstr "Biçimlendirme Dizgesi"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/AlbumArtInfoDialog.cs:32
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:188
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1054
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:193
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1059
 #: ../../../../NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs:21
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:133
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1482
@@ -926,9 +926,9 @@ msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:182
-#: ../../../Controllers/MainWindowController.cs:1386
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:720
-#: ../../../Models/MusicFile.cs:835
+#: ../../../Controllers/MainWindowController.cs:1396
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:834
 msgid "genre"
 msgstr "tür"
 
@@ -949,7 +949,7 @@ msgstr "Yeni API Anahtarı Al"
 msgid "GiB"
 msgstr "GiB"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1391
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1396
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:156
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
@@ -960,9 +960,9 @@ msgstr "GitHub Deposu"
 msgid "Height"
 msgstr "Açık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:591
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:596
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:29
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:449
@@ -990,7 +990,7 @@ msgstr "LRC'den İçe Aktar"
 msgid "Include Only Selected Files"
 msgstr "Yalnızca Seçili Dosyaları İçer"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:601
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:606
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:137
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:142
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:227
@@ -1010,17 +1010,17 @@ msgstr "Bilgi"
 msgid "Insert"
 msgstr "Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:100
 msgid "Insert Back Album Art"
 msgstr "Albüm Arka Kapağı Ekle"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1065
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1070
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:80
 msgid "Insert Front Album Art"
 msgstr "Albüm Ön Kapağı Ekle"
 
-#: ../../../Controllers/MainWindowController.cs:1020
+#: ../../../Controllers/MainWindowController.cs:1030
 msgid "Inserting album art..."
 msgstr "Albüm kapağı ekleniyor..."
 
@@ -1038,19 +1038,19 @@ msgstr "KiB"
 msgid "Language Code"
 msgstr "Dil Kodu"
 
-#: ../../../Controllers/MainWindowController.cs:453
+#: ../../../Controllers/MainWindowController.cs:463
 msgid "Library was changed on disk."
 msgstr "Kitaplık diskte değiştirildi."
 
-#: ../../../Controllers/MainWindowController.cs:506
+#: ../../../Controllers/MainWindowController.cs:516
 #, csharp-format
 msgid "Loaded {0} music file."
 msgid_plural "Loaded {0} music files."
 msgstr[0] "{0} müzik dosyası yüklendi."
 msgstr[1] "{0} müzik dosyası yüklendi."
 
-#: ../../../Controllers/MainWindowController.cs:492
-#: ../../../Controllers/MainWindowController.cs:1645
+#: ../../../Controllers/MainWindowController.cs:502
+#: ../../../Controllers/MainWindowController.cs:1655
 msgid "Loading music files from library..."
 msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 
@@ -1058,7 +1058,7 @@ msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 msgid "Lryics"
 msgstr "Şarkı Sözleri"
 
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:803
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:802
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
@@ -1072,6 +1072,10 @@ msgstr "Şarkı Sözleri"
 #: NickvisionTagger.GNOME/Blueprints/window.blp:449
 msgid "Main Properties"
 msgstr "Ana Özellikler"
+
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1424
+msgid "Making everything pretty..."
+msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:131
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:115
@@ -1108,12 +1112,12 @@ msgstr "Müzik Dosyası"
 msgid "Music Library"
 msgstr "Müzik Kitaplığı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "MusicBrainz Recording Id"
 msgstr "MusicBrainz Kayıt Kimliği"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
@@ -1123,7 +1127,7 @@ msgstr "Yeni Özel Özellik"
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
-#: ../../../Controllers/MainWindowController.cs:410
+#: ../../../Controllers/MainWindowController.cs:420
 msgid "New update available."
 msgstr "Yeni güncelleme var."
 
@@ -1132,15 +1136,15 @@ msgstr "Yeni güncelleme var."
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:870
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:937
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:875
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:942
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:843
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:900
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:122
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../Controllers/MainWindowController.cs:1218
+#: ../../../Controllers/MainWindowController.cs:1228
 msgid "No AcoustId entry found for the file's fingerprint"
 msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 
@@ -1148,20 +1152,20 @@ msgstr "Dosyanın parmak izi için AcoustId girdisi bulunamadı"
 msgid "No file selected"
 msgstr "Hiçbir dosya seçilmedi"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:931
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:936
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:891
 msgid "No files selected for removal."
 msgstr "Kaldırmak için hiçbir dosya seçilmedi."
 
-#: ../../../Controllers/MainWindowController.cs:1253
+#: ../../../Controllers/MainWindowController.cs:1263
 msgid "No lyrics were downloaded"
 msgstr "Hiçbir şarkı sözü indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:1229
+#: ../../../Controllers/MainWindowController.cs:1239
 msgid "No metadata was downloaded"
 msgstr "Hiçbir üst veri indirilmedi"
 
-#: ../../../Controllers/MainWindowController.cs:529
+#: ../../../Controllers/MainWindowController.cs:539
 msgid "No music files are selected."
 msgstr "Hiçbir müzik dosyası seçilmedi."
 
@@ -1170,11 +1174,11 @@ msgstr "Hiçbir müzik dosyası seçilmedi."
 msgid "No Music Files Found"
 msgstr "Hiçbir Müzik Dosyası Bulunamadı"
 
-#: ../../../Controllers/MainWindowController.cs:533
+#: ../../../Controllers/MainWindowController.cs:543
 msgid "No music files in library."
 msgstr "Kitaplıkta müzik dosyası yok."
 
-#: ../../../Controllers/MainWindowController.cs:1219
+#: ../../../Controllers/MainWindowController.cs:1229
 msgid "No MusicBrainz RecordingId was provided for the AcoustId entry"
 msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 
@@ -1183,7 +1187,7 @@ msgstr "AcoustId girdisi için MusicBrainz kayıt kimliği sağlanmadı"
 msgid "No Selected Music Files"
 msgstr "Seçili Müzik Dosyası Yok"
 
-#: ../../../Controllers/MainWindowController.cs:1266
+#: ../../../Controllers/MainWindowController.cs:1276
 msgid "No user api key configured."
 msgstr "Hiçbir kullanıcı anahtarı yapılandırılmadı."
 
@@ -1208,7 +1212,7 @@ msgstr "Kapalı"
 msgid "Offset (in milliseconds)"
 msgstr "Ofset (milisaniye cinsinden)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1215
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1220
 #: ../../../../NickvisionTagger.WinUI/Controls/AboutDialog.xaml.cs:27
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:28
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:487
@@ -1228,7 +1232,7 @@ msgstr "Tamam"
 msgid "On"
 msgstr "Açık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1210
 msgid ""
 "Only one file can be submitted to AcoustID at a time. Please select only one "
@@ -1237,7 +1241,7 @@ msgstr ""
 "AcoustIDʼye aynı anda yalnızca bir dosya gönderilebilir. Lütfen yalnızca bir "
 "dosya seçip tekrar deneyin."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:610
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:615
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:504
 msgid "Open"
 msgstr "Aç"
@@ -1248,7 +1252,7 @@ msgid "Open a library with music to get started"
 msgstr "Başlamak için müzik içeren bir kitaplık açın"
 
 #: ../../../../NickvisionTagger.GNOME/Controls/CorruptedFilesDialog.cs:46
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:719
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:724
 #: ../../../../NickvisionTagger.WinUI/Controls/CorruptedFilesDialog.xaml.cs:43
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:107
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:162
@@ -1258,11 +1262,11 @@ msgstr "Başlamak için müzik içeren bir kitaplık açın"
 msgid "Open Folder"
 msgstr "Klasör Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:849
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:854
 msgid "Open Music File"
 msgstr "Müzik Dosyası Aç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:734
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:739
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:108
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:163
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:21
@@ -1296,8 +1300,8 @@ msgstr "Yol"
 msgid "Path (Empty)"
 msgstr "Yol (Boş)"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1543
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1746
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1552
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1775
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:214
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1451
 msgid "Pick a date"
@@ -1309,21 +1313,21 @@ msgstr ""
 msgid "Playlist"
 msgstr "Çalma Listesi"
 
-#: ../../../Controllers/MainWindowController.cs:538
+#: ../../../Controllers/MainWindowController.cs:548
 msgid "Playlist file created successfully."
 msgstr "Çalma listesi oluşturuldu."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1463
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1472
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1376
 msgid "Playlist Mode"
 msgstr "Çalma Listesi Kipi"
 
-#: ../../../Controllers/MainWindowController.cs:525
+#: ../../../Controllers/MainWindowController.cs:535
 msgid "Playlist path can not be empty."
 msgstr "Çalma listesi yolu boş olamaz."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1014
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1019
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1123
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 msgid "Please select a format string."
@@ -1338,15 +1342,15 @@ msgstr "Değişiklik Zaman Damgasını Koru"
 msgid "PREVIEW"
 msgstr "ÖN İZLEME"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1148
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1153
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1105
 msgid "Property Name"
 msgstr "Özellik Adı"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1447
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:760
-#: ../../../Models/MusicFile.cs:863
+#: ../../../Controllers/MainWindowController.cs:1457
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:862
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -1362,14 +1366,14 @@ msgid "Publishing Date"
 msgstr "Yayımcı"
 
 #: ../../../Controllers/MainWindowController.cs:184
-#: ../../../Controllers/MainWindowController.cs:1451
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:764
-#: ../../../Models/MusicFile.cs:867
+#: ../../../Controllers/MainWindowController.cs:1461
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:866
 #, fuzzy
 msgid "publishingdate"
 msgstr "yayımcı"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:581
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:586
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:438
 msgid "Reload"
 msgstr "Yeniden Yükle"
@@ -1389,12 +1393,12 @@ msgstr "Kitaplığı Yeniden Yükle"
 msgid "Remove"
 msgstr "Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1603
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1613
 #: ../../../../NickvisionTagger.WinUI/Controls/CustomPropertyRow.xaml.cs:22
 msgid "Remove Custom Property"
 msgstr "Özel Özelliği Kaldır"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:897
 msgid "Remove Files?"
 msgstr "Dosyalar Kaldırılsın Mı?"
@@ -1409,7 +1413,7 @@ msgstr "Çalma Listesinden Kaldır"
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
-#: ../../../Controllers/MainWindowController.cs:1064
+#: ../../../Controllers/MainWindowController.cs:1074
 msgid "Removing album art..."
 msgstr "Albüm kapağı kaldırılıyor..."
 
@@ -1435,8 +1439,8 @@ msgstr "Etiketi Kaydet"
 msgid "Save Tag (Ctrl+S)"
 msgstr "Etiketi Kaydet (Ctrl+S)"
 
-#: ../../../Controllers/MainWindowController.cs:795
-#: ../../../Controllers/MainWindowController.cs:838
+#: ../../../Controllers/MainWindowController.cs:805
+#: ../../../Controllers/MainWindowController.cs:848
 msgid "Saving tags..."
 msgstr "Etiketler kaydediliyor..."
 
@@ -1459,14 +1463,14 @@ msgstr "Ayarlar"
 msgid "Show Extras Pane"
 msgstr "İlaveler Panelini Göster"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:662
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:768
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:808
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:876
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:948
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1171
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1229
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1276
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:667
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:773
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:813
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:881
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:953
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1176
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1234
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1281
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:300
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:574
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:609
@@ -1489,12 +1493,12 @@ msgstr ""
 msgid "Sort Files By"
 msgstr "Dosyaları Sırala"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 msgid "Submit"
 msgstr "Gönder"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1222
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1227
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:152
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1218
 #: NickvisionTagger.GNOME/Blueprints/shortcuts_dialog.blp:134
@@ -1502,15 +1506,15 @@ msgstr "Gönder"
 msgid "Submit to AcoustId"
 msgstr "AcoustIdʼye Gönder"
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Submitted metadata to AcoustId successfully"
 msgstr "AcoustId'ye üst veriler başarıyla gönderildi"
 
-#: ../../../Controllers/MainWindowController.cs:1269
+#: ../../../Controllers/MainWindowController.cs:1279
 msgid "Submitting data to AcoustId..."
 msgstr "AcoustId'ye veriler gönderiliyor..."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:143
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:223
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
@@ -1521,7 +1525,7 @@ msgstr "AcoustId'ye veriler gönderiliyor..."
 msgid "Switch to Back Cover"
 msgstr "Arka Kapağa Geç"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1053
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1058
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1266
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1267
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1595
@@ -1538,7 +1542,7 @@ msgstr "Eşitlenmiş"
 msgid "Tag"
 msgstr "Etiket"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1033
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1038
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:148
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1141
 #: NickvisionTagger.GNOME/Blueprints/window.blp:65
@@ -1571,7 +1575,7 @@ msgid ""
 "Tagger's documentation and support channels are accessible via the Help menu."
 msgstr ""
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:935
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:898
 msgid ""
 "The selected files will not be deleted from disk but will be removed from "
@@ -1584,7 +1588,7 @@ msgstr ""
 msgid "Theme"
 msgstr "Tema"
 
-#: ../../../Controllers/MainWindowController.cs:1221
+#: ../../../Controllers/MainWindowController.cs:1231
 msgid "This file does not have a valid fingerprint"
 msgstr "Bu dosyanın geçerli bir parmak izi yok"
 
@@ -1607,9 +1611,9 @@ msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:180
-#: ../../../Controllers/MainWindowController.cs:1325
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:680
-#: ../../../Models/MusicFile.cs:807
+#: ../../../Controllers/MainWindowController.cs:1335
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:679
+#: ../../../Models/MusicFile.cs:806
 msgid "title"
 msgstr "başlık"
 
@@ -1621,15 +1625,15 @@ msgstr "başlık"
 msgid "Title"
 msgstr "Başlık"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1213
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1218
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1209
 msgid "Too Many Files Selected"
 msgstr "Çok Fazla Dosya Seçildi"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1352
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:700
-#: ../../../Models/MusicFile.cs:823
+#: ../../../Controllers/MainWindowController.cs:1362
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:822
 msgid "track"
 msgstr "parça"
 
@@ -1642,9 +1646,9 @@ msgid "Track"
 msgstr "Parça"
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1367
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:708
-#: ../../../Models/MusicFile.cs:827
+#: ../../../Controllers/MainWindowController.cs:1377
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:826
 msgid "tracktotal"
 msgstr "toplam parça"
 
@@ -1667,16 +1671,16 @@ msgstr "Tür"
 msgid "Type ! for advanced search"
 msgstr "gelişmiş arama için ! yazın"
 
-#: ../../../Controllers/MainWindowController.cs:562
+#: ../../../Controllers/MainWindowController.cs:572
 msgid "Unable to add file to playlist. File may already exist in playlist."
 msgstr ""
 "Dosya çalma listesine eklenemiyor. Dosya zaten çalma listesinde olabilir."
 
-#: ../../../Controllers/MainWindowController.cs:542
+#: ../../../Controllers/MainWindowController.cs:552
 msgid "Unable to create playlist."
 msgstr "Çalma listesi oluşturulamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:427
+#: ../../../Controllers/MainWindowController.cs:437
 msgid "Unable to download and install update."
 msgstr "Güncellemeler indirilip kurulamadı."
 
@@ -1690,29 +1694,29 @@ msgstr "LRC'ye dışa aktarılamıyor."
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:1016
+#: ../../../Controllers/MainWindowController.cs:1026
 msgid "Unable to load image file"
 msgstr "Resim dosyası yüklenemedi"
 
-#: ../../../Controllers/MainWindowController.cs:577
+#: ../../../Controllers/MainWindowController.cs:587
 msgid "Unable to remove some files from playlist."
 msgstr "Kimi dosyalar çalma listesinden kaldırılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:858
+#: ../../../Controllers/MainWindowController.cs:868
 #, csharp-format
 msgid "Unable to save {0}"
 msgstr "{0} kaydedilemedi"
 
-#: ../../../Controllers/MainWindowController.cs:816
+#: ../../../Controllers/MainWindowController.cs:826
 #, csharp-format
 msgid "Unable to save {0}."
 msgstr "{0} kaydedilemedi."
 
-#: ../../../Controllers/MainWindowController.cs:1272
+#: ../../../Controllers/MainWindowController.cs:1282
 msgid "Unable to submit to AcoustId. Check API key"
 msgstr "AcoustIdʼye gönderilemiyor. API anahtarını denetleyin"
 
-#: ../../../Controllers/MainWindowController.cs:1622
+#: ../../../Controllers/MainWindowController.cs:1632
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1735,7 +1739,7 @@ msgstr "LRC şarkı sözlerini kullan"
 msgid "Use Relative Paths"
 msgstr "Göreli Yolları Kullan"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:840
 msgid "Use Relative Paths?"
 msgstr "Göreli Yollar Kullanılsın Mı?"
@@ -1776,7 +1780,7 @@ msgstr ""
 "misiniz?\n"
 "Kaydedilmemiş tüm çalışmalar kaybolacaktır."
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:868
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:841
 msgid ""
 "Would you like to save the added file to the playlist using it's relative "
@@ -1788,9 +1792,9 @@ msgstr ""
 "Aksi takdirde göreli yol yerine tam yol kullanılacaktır."
 
 #: ../../../Controllers/MainWindowController.cs:181
-#: ../../../Controllers/MainWindowController.cs:1337
-#: ../../../Models/MusicFile.cs:79 ../../../Models/MusicFile.cs:692
-#: ../../../Models/MusicFile.cs:819
+#: ../../../Controllers/MainWindowController.cs:1347
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:691
+#: ../../../Models/MusicFile.cs:818
 msgid "year"
 msgstr "yıl"
 
@@ -1802,8 +1806,8 @@ msgstr "yıl"
 msgid "Year"
 msgstr "Yıl"
 
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:873
-#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:940
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:878
+#: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:945
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:842
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:899
 #: ../../../../NickvisionTagger.WinUI/Views/SettingsDialog.xaml.cs:121

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -45,6 +45,7 @@
         <p>- Added the option to use relative paths when creating a playlist. This means that Tagger also now supports opening playlists with relative paths</p>
         <p>- Added the Disc Number, Disc Total, and Publishing Date fields to additional properties</p>
         <p>- Added information dialog for album art</p>
+        <p>- Added an option in Preferences to limit file name characters to those only supported by Windows</p>
         <p>- Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary</p>
         <p>- Tagger will now display front album art within a music file row itself if available</p>
         <p>- Fixed an issue where downloaded lyrics would sometimes contain html encoded characters</p>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -47,6 +47,7 @@
         <p>- Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary</p>
         <p>- Tagger will now display front album art within a music file row itself if available</p>
         <p>- Fixed an issue where downloaded lyrics would sometimes contain html encoded characters</p>
+        <p>- Fixed an issue where file names containing the ""<"" character caused the music file row to not display</p>
         <p>- Improved create playlist dialog ux</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -43,11 +43,12 @@
       <description translatable="no">
         <p>- Tagger is now available for Windows using Windows App SDK and WinUI 3</p>
         <p>- Added the option to use relative paths when creating a playlist. This means that Tagger also now supports opening playlists with relative paths</p>
-        <p>- Added the PublishingDate field to additional properties</p>
+        <p>- Added the Disc Number, Disc Total, and Publishing Date fields to additional properties</p>
+        <p>- Added information dialog for album art</p>
         <p>- Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary</p>
         <p>- Tagger will now display front album art within a music file row itself if available</p>
         <p>- Fixed an issue where downloaded lyrics would sometimes contain html encoded characters</p>
-        <p>- Fixed an issue where file names containing the ""<"" character caused the music file row to not display</p>
+        <p>- Fixed an issue where file names containing the less than character caused the music file row to not display</p>
         <p>- Improved create playlist dialog ux</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>

--- a/NickvisionTagger.WinUI/App.xaml.cs
+++ b/NickvisionTagger.WinUI/App.xaml.cs
@@ -25,7 +25,8 @@ public partial class App : Application
         _controller.AppInfo.Changelog =
             @"- Tagger is now available for Windows using Windows App SDK and WinUI 3
 - Added the option to use relative paths when creating a playlist. This means that Tagger also now supports opening playlists with relative paths
-- Added the PublishingDate field to additional properties
+- Added the Disc Number, Disc Total, and Publishing Date fields to additional properties
+- Added information dialog for album art
 - Tagger will now watch a music folder library for changes on disk and prompt the user to reload if necessary
 - Tagger will now display front album art within a music file row itself if available
 - Fixed an issue where downloaded lyrics would sometimes contain html encoded characters

--- a/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml
+++ b/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="NickvisionTagger.WinUI.Controls.AlbumArtInfoDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:NickvisionTagger.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:wct="using:CommunityToolkit.WinUI.Controls"
+    mc:Ignorable="d" Style="{StaticResource DefaultContentDialogStyle}"
+    DefaultButton="Close">
+
+    <ScrollViewer x:Name="ScrollViewer" VerticalScrollBarVisibility="Auto" MinWidth="500" SizeChanged="ScrollViewer_SizeChanged">
+        <StackPanel x:Name="StackPanel" Orientation="Vertical" Spacing="6">
+            <wct:SettingsCard x:Name="CardMimeType">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE97C;"/>
+                </wct:SettingsCard.HeaderIcon>
+
+                <TextBlock x:Name="LblMimeType"/>
+            </wct:SettingsCard>
+
+            <wct:SettingsCard x:Name="CardWidth">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED5E;"/>
+                </wct:SettingsCard.HeaderIcon>
+
+                <TextBlock x:Name="LblWidth"/>
+            </wct:SettingsCard>
+
+            <wct:SettingsCard x:Name="CardHeight">
+                <wct:SettingsCard.HeaderIcon>
+                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED5E;"/>
+                </wct:SettingsCard.HeaderIcon>
+
+                <TextBlock x:Name="LblHeight"/>
+            </wct:SettingsCard>
+        </StackPanel>
+    </ScrollViewer>
+</ContentDialog>

--- a/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
@@ -5,8 +5,15 @@ using static Nickvision.Aura.Localization.Gettext;
 
 namespace NickvisionTagger.WinUI.Controls;
 
+/// <summary>
+/// A dialog for showing album art info
+/// </summary>
 public sealed partial class AlbumArtInfoDialog : ContentDialog
 {
+    /// <summary>
+    /// Constructs a AlbumArtInfoDialog
+    /// </summary>
+    /// <param name="art">AlbumArt</param>
     public AlbumArtInfoDialog(AlbumArt art)
     {
         InitializeComponent();

--- a/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
@@ -18,8 +18,8 @@ public sealed partial class AlbumArtInfoDialog : ContentDialog
         CardHeight.Header = _("Height");
         //Load
         LblMimeType.Text = art.MimeType;
-        LblWidth.Text = art.Width.ToString();
-        LblHeight.Text = art.Height.ToString();
+        LblWidth.Text = _("{0} pixels", art.Width);
+        LblHeight.Text = _("{0} pixels", art.Height);
     }
 
     /// <summary>

--- a/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/AlbumArtInfoDialog.xaml.cs
@@ -1,0 +1,31 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using NickvisionTagger.Shared.Models;
+using static Nickvision.Aura.Localization.Gettext;
+
+namespace NickvisionTagger.WinUI.Controls;
+
+public sealed partial class AlbumArtInfoDialog : ContentDialog
+{
+    public AlbumArtInfoDialog(AlbumArt art)
+    {
+        InitializeComponent();
+        //Localize Strings
+        Title = art.Type == AlbumArtType.Front ? _("Front") : _("Back");
+        CloseButtonText = _("Close");
+        CardMimeType.Header = _("Mime Type");
+        CardWidth.Header = _("Width");
+        CardHeight.Header = _("Height");
+        //Load
+        LblMimeType.Text = art.MimeType;
+        LblWidth.Text = art.Width.ToString();
+        LblHeight.Text = art.Height.ToString();
+    }
+
+    /// <summary>
+    /// Occurs when the ScrollViewer's size is changed
+    /// </summary>
+    /// <param name="sender">object</param>
+    /// <param name="e">SizeChangedEventArgs</param>
+    private void ScrollViewer_SizeChanged(object sender, SizeChangedEventArgs e) => StackPanel.Margin = new Thickness(0, 0, ScrollViewer.ComputedVerticalScrollBarVisibility == Visibility.Visible ? 14 : 0, 0);
+}

--- a/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
@@ -13,7 +13,7 @@ namespace NickvisionTagger.WinUI.Controls;
 /// </summary>
 public sealed partial class MusicFileRow : UserControl
 {
-    private byte[] _art;
+    private AlbumArt _art;
 
     /// <summary>
     /// Constructs a MusicFileRow
@@ -22,7 +22,7 @@ public sealed partial class MusicFileRow : UserControl
     public MusicFileRow(MusicFile musicFile)
     {
         InitializeComponent();
-        _art = Array.Empty<byte>();
+        _art = new AlbumArt(Array.Empty<byte>(), AlbumArtType.Front);
         ArtViewStack.CurrentPageName = "NoArt";
         ShowUnsaveIcon = false;
         Update(musicFile);
@@ -65,22 +65,22 @@ public sealed partial class MusicFileRow : UserControl
     /// <summary>
     /// The album art of the row
     /// </summary>
-    public byte[] Art
+    public AlbumArt Art
     {
         get => _art;
 
         set
         {
-            if (_art.SequenceEqual(value))
+            if (_art == value)
             {
                 return;
             }
             _art = value;
-            if (_art.Length > 0)
+            if (!_art.IsEmpty)
             {
                 using var ms = new InMemoryRandomAccessStream();
                 using var writer = new DataWriter(ms.GetOutputStreamAt(0));
-                writer.WriteBytes(_art);
+                writer.WriteBytes(_art.Image);
                 writer.StoreAsync().GetResults();
                 var image = new BitmapImage();
                 image.SetSource(ms);

--- a/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using NickvisionTagger.Shared.Models;
 using System;
-using System.Linq;
 using Windows.Storage.Streams;
 
 namespace NickvisionTagger.WinUI.Controls;

--- a/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/MusicFileRow.xaml.cs
@@ -79,7 +79,7 @@ public sealed partial class MusicFileRow : UserControl
             {
                 using var ms = new InMemoryRandomAccessStream();
                 using var writer = new DataWriter(ms.GetOutputStreamAt(0));
-                writer.WriteBytes(_art.Image);
+                writer.WriteBytes(_art.Icon);
                 writer.StoreAsync().GetResults();
                 var image = new BitmapImage();
                 image.SetSource(ms);

--- a/NickvisionTagger.WinUI/Views/MainWindow.xaml
+++ b/NickvisionTagger.WinUI/Views/MainWindow.xaml
@@ -246,6 +246,12 @@
                                         <KeyboardAccelerator Modifiers="Control" Key="E"/>
                                     </MenuFlyoutItem.KeyboardAccelerators>
                                 </MenuFlyoutItem>
+
+                                <MenuFlyoutItem x:Name="MenuAlbumArtFrontInfo" Click="AlbumArtInfo">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE946;"/>
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
 
                             <MenuFlyoutSubItem x:Name="MenuAlbumArtBack">
@@ -281,6 +287,12 @@
                                     <MenuFlyoutItem.KeyboardAccelerators>
                                         <KeyboardAccelerator Modifiers="Control,Shift" Key="E"/>
                                     </MenuFlyoutItem.KeyboardAccelerators>
+                                </MenuFlyoutItem>
+
+                                <MenuFlyoutItem x:Name="MenuAlbumArtBackInfo" Click="AlbumArtInfo">
+                                    <MenuFlyoutItem.Icon>
+                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE946;"/>
+                                    </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                             </MenuFlyoutSubItem>
 
@@ -761,7 +773,7 @@
 
                                                                         <TextBlock x:Name="LblDurationFileSize" HorizontalAlignment="Center" Style="{ThemeResource NavigationViewItemHeaderTextStyle}" FontSize="16" Foreground="Gray"/>
 
-                                                                        <Button x:Name="BtnAlbumArtSwitch" HorizontalAlignment="Stretch" Margin="0,12,0,0" Height="40" Click="SwitchAlbumArt">
+                                                                        <Button x:Name="BtnAlbumArtSwitch" HorizontalAlignment="Stretch" Margin="0,12,0,0" Click="SwitchAlbumArt">
                                                                             <Button.Content>
                                                                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                                                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE13C;"/>
@@ -771,7 +783,7 @@
                                                                             </Button.Content>
                                                                         </Button>
 
-                                                                        <Button x:Name="BtnAlbumArtInsert" HorizontalAlignment="Stretch" Height="40" Click="InsertAlbumArt">
+                                                                        <Button x:Name="BtnAlbumArtInsert" HorizontalAlignment="Stretch" Click="InsertAlbumArt">
                                                                             <Button.Content>
                                                                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                                                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE710;"/>
@@ -781,7 +793,7 @@
                                                                             </Button.Content>
                                                                         </Button>
 
-                                                                        <Button x:Name="BtnAlbumArtRemove" HorizontalAlignment="Stretch" Height="40" Click="RemoveAlbumArt">
+                                                                        <Button x:Name="BtnAlbumArtRemove" HorizontalAlignment="Stretch" Click="RemoveAlbumArt">
                                                                             <Button.Content>
                                                                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                                                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE108;"/>
@@ -791,12 +803,22 @@
                                                                             </Button.Content>
                                                                         </Button>
 
-                                                                        <Button x:Name="BtnAlbumArtExport" HorizontalAlignment="Stretch" Height="40" Click="ExportAlbumArt">
+                                                                        <Button x:Name="BtnAlbumArtExport" HorizontalAlignment="Stretch" Click="ExportAlbumArt">
                                                                             <Button.Content>
                                                                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                                                                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE118;"/>
 
                                                                                     <TextBlock x:Name="LblBtnAlbumArtExport"/>
+                                                                                </StackPanel>
+                                                                            </Button.Content>
+                                                                        </Button>
+
+                                                                        <Button x:Name="BtnAlbumArtInfo" HorizontalAlignment="Stretch" Click="AlbumArtInfo">
+                                                                            <Button.Content>
+                                                                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                                                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE946;"/>
+
+                                                                                    <TextBlock x:Name="LblBtnAlbumArtInfo"/>
                                                                                 </StackPanel>
                                                                             </Button.Content>
                                                                         </Button>

--- a/NickvisionTagger.WinUI/Views/MainWindow.xaml
+++ b/NickvisionTagger.WinUI/Views/MainWindow.xaml
@@ -676,6 +676,16 @@
                                                                             <TextBox x:Name="TxtDescription" MinWidth="300" MaxWidth="400" TextChanged="TagPropertyChanged"/>
                                                                         </wct:SettingsCard>
 
+                                                                        <wct:SettingsCard x:Name="CardDisc">
+                                                                            <StackPanel Orientation="Horizontal" Spacing="12">
+                                                                                <TextBox x:Name="TxtDiscNumber" MinWidth="150" TextChanged="TagPropertyChanged"/>
+
+                                                                                <TextBlock VerticalAlignment="Center" Text="/"/>
+
+                                                                                <TextBox x:Name="TxtDiscTotal" MinWidth="150" TextChanged="TagPropertyChanged"/>
+                                                                            </StackPanel>
+                                                                        </wct:SettingsCard>
+
                                                                         <wct:SettingsCard x:Name="CardPublisher">
                                                                             <TextBox x:Name="TxtPublisher" MinWidth="300" MaxWidth="400" TextChanged="TagPropertyChanged"/>
                                                                         </wct:SettingsCard>

--- a/NickvisionTagger.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTagger.WinUI/Views/MainWindow.xaml.cs
@@ -1088,13 +1088,8 @@ public sealed partial class MainWindow : Window
         {
             type = AlbumArtType.Back;
         }
-        var art = _controller.GetFirstAlbumArt(type);
-        var dialog = new ContentDialog()
+        var dialog = new AlbumArtInfoDialog(_controller.GetFirstAlbumArt(type))
         {
-            Title = type == AlbumArtType.Front ? _("Front") : _("Back"),
-            Content = $"{_("Mime Type:")} {art.MimeType}\n\n{_("Width:")} {art.Width}\n\n{_("Height:")} {art.Height}",
-            CloseButtonText = _("Close"),
-            DefaultButton = ContentDialogButton.Close,
             XamlRoot = MainGrid.XamlRoot
         };
         await dialog.ShowAsync();

--- a/NickvisionTagger.WinUI/Views/MainWindow.xaml.cs
+++ b/NickvisionTagger.WinUI/Views/MainWindow.xaml.cs
@@ -203,6 +203,9 @@ public sealed partial class MainWindow : Window
         TxtComposer.PlaceholderText = _("Enter composer here");
         CardDescription.Header = _("Description");
         TxtDescription.PlaceholderText = _("Enter description here");
+        CardDisc.Header = _("Disc");
+        TxtDiscNumber.PlaceholderText = _("Enter disc number here");
+        TxtDiscTotal.PlaceholderText = _("Enter disc total here");
         CardPublisher.Header = _("Publisher");
         TxtPublisher.PlaceholderText = _("Enter publisher here");
         CardPublishingDate.Header = _("Publishing Date");
@@ -1415,6 +1418,8 @@ public sealed partial class MainWindow : Window
         TxtBPM.Text = _controller.SelectedPropertyMap.BeatsPerMinute;
         TxtComposer.Text = _controller.SelectedPropertyMap.Composer;
         TxtDescription.Text = _controller.SelectedPropertyMap.Description;
+        TxtDiscNumber.Text = _controller.SelectedPropertyMap.DiscNumber;
+        TxtDiscTotal.Text = _controller.SelectedPropertyMap.DiscTotal;
         TxtPublisher.Text = _controller.SelectedPropertyMap.Publisher;
         DatePublishingDate.Date = string.IsNullOrEmpty(_controller.SelectedPropertyMap.PublishingDate) ? null : (_controller.SelectedPropertyMap.PublishingDate == _("<keep>") ? null : DateTimeOffset.Parse(_controller.SelectedPropertyMap.PublishingDate));
         DatePublishingDate.PlaceholderText = _controller.SelectedPropertyMap.PublishingDate == _("<keep>") ? _("<keep>") : _("Pick a date");
@@ -1502,6 +1507,8 @@ public sealed partial class MainWindow : Window
                 BeatsPerMinute = TxtBPM.Text,
                 Composer = TxtComposer.Text,
                 Description = TxtDescription.Text,
+                DiscNumber = TxtDiscNumber.Text,
+                DiscTotal = TxtDiscTotal.Text,
                 Publisher = TxtPublisher.Text,
                 PublishingDate = DatePublishingDate.PlaceholderText == _("<keep>") ? _("<keep>") : (DatePublishingDate.Date?.Date.ToShortDateString() ?? ""),
             };


### PR DESCRIPTION
Fixes #365
Fixes #366 
 - **NOTE:** With the implementation of this feature, I've introduced a new `AlbumArt` model. 
    - This abstracts the previously used `byte[]` for `FrontAlbumArt` and `BackAlbumArt` into a full object which contains and exposes the underlying `byte[]` for the image, but also contains properties for an image's `Width`, `Height`, `MimeType` and `AlbumArtType`. 
    - The `Width` and `Height` are processed and provided by the `ImageSharp` library. 
    - `MimeType` is provided by `ATL.PictureInfo`. 
    - An `ATL.PictureInfo` representation of the `AlbumArt` object is also accessible via the object's `ATLPictureInfo` property which manages and exposes this ATL object to prevent having to create it more times than needed when actually setting `ATL.Track`'s picture.

Fixes #370
Fixes #372 

*Screenshots for new feature designs can be seen on individual issues themselves*