### PR TITLE
Fixes + Tweaks

### DIFF
--- a/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
+++ b/NickvisionTagger.GNOME/NickvisionTagger.GNOME.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GirCore.Adw-1" Version="0.4.0" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <PackageReference Include="Nickvision.GirExt" Version="2023.7.3" />
   </ItemGroup>
 

--- a/NickvisionTagger.GNOME/Program.cs
+++ b/NickvisionTagger.GNOME/Program.cs
@@ -33,10 +33,7 @@ public partial class Program
         _mainWindow = null;
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
-            @"* Added the ability to specify ""/"" in a Tag to File Name format string to move files to a new directory when renaming files
-              * Tagger now has the ability to fix corrupted file right from within the app
-              * Tagger will now display files with corrupted album art as corrupted files
-              * Fixed an issue where some custom properties for vorbis and wav files could not be removed
+            @"* Fixed an issue where specifying the directory separator in Tag to File Name when Limit Filename Characters was enabled caused new directories to not be made
               * Updated translations (Thanks everyone on Weblate!)";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.tagger.gresource"))

--- a/NickvisionTagger.GNOME/nuget-sources.json
+++ b/NickvisionTagger.GNOME/nuget-sources.json
@@ -211,10 +211,10 @@
   },
   {
     "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.10.2/nickvision.aura.2023.10.2.nupkg",
-    "sha512": "830ab163b59643b28673b5f816dd1274d22182ec4c010d929fb6498d43c254279dca8dab27913ac7a323a15a1a766ce24e8f81d4b0fab6660b58ff5a26e15a40",
+    "url": "https://api.nuget.org/v3-flatcontainer/nickvision.aura/2023.11.0/nickvision.aura.2023.11.0.nupkg",
+    "sha512": "7788d1565cfe5670bd993e91d994d077ed1ebe97f5f2d3d190857328778920a13a0deb9ce0b20ee77f2b3f74887456f05f903b838489b6cb1fbabf531de13041",
     "dest": "nuget-sources",
-    "dest-filename": "nickvision.aura.2023.10.2.nupkg"
+    "dest-filename": "nickvision.aura.2023.11.0.nupkg"
   },
   {
     "type": "file",

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -416,17 +416,14 @@ public class MainWindowController : IDisposable
     /// </summary>
     public async Task CheckForUpdatesAsync()
     {
-        if (!AppInfo.IsDevVersion)
+        if (_updater == null)
         {
-            if (_updater == null)
-            {
-                _updater = await Updater.NewAsync();
-            }
-            var version = await _updater!.GetCurrentStableVersionAsync();
-            if (version != null && version > new System.Version(AppInfo.Version))
-            {
-                NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("New update available."), NotificationSeverity.Success, "update"));
-            }
+            _updater = await Updater.NewAsync();
+        }
+        var version = await _updater!.GetCurrentStableVersionAsync();
+        if (version != null && (!AppInfo.IsDevVersion ? version > new System.Version(AppInfo.Version) : version >= new System.Version(AppInfo.Version.Remove(AppInfo.Version.IndexOf('-')))))
+        {
+            NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("New update available."), NotificationSeverity.Success, "update"));
         }
     }
 

--- a/NickvisionTagger.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTagger.Shared/Controllers/MainWindowController.cs
@@ -164,7 +164,7 @@ public class MainWindowController : IDisposable
         }
         Aura.Active.SetConfig<Configuration>("config");
         Configuration.Current.Saved += ConfigurationSaved;
-        AppInfo.Version = "2023.11.1";
+        AppInfo.Version = "2023.11.2-next";
         AppInfo.ShortName = _("Tagger");
         AppInfo.Description = _("Tag your music");
         AppInfo.SourceRepo = new Uri("https://github.com/NickvisionApps/Tagger");

--- a/NickvisionTagger.Shared/Docs/html/cs/corrupted.html
+++ b/NickvisionTagger.Shared/Docs/html/cs/corrupted.html
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="contents pagewide">
 <p class="p">Tato stránka vysvětluje hudební soubory s poškozenými daty.</p>
 <p class="p">Pokud <span class="app">Označovač</span> nedokáže přečíst soubor, bude ignorován a bude zobrazen dialog se seznamem poškozených souborů, které následně můžete spravovat a opravit.</p>
-<p class="p">This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p class="p">Tento dialog vám nabídne možnost nechat aplikaci spustit příslušný příkaz a pokusit se opravit poškozený soubor.</p>
 </div>
 <section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Neplatná data</span></h2></div>
@@ -64,9 +64,9 @@ document.addEventListener('DOMContentLoaded', function() {
 </div>
 </div></div>
 </div></section><section id=""><div class="inner">
-<div class="hgroup pagewide"><h2 class="title"><span class="title">Invalid Album Art</span></h2></div>
+<div class="hgroup pagewide"><h2 class="title"><span class="title">Neplatný obal alba</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+<p class="p">Neplatný nebo poškozený formát vloženého obalu alba může způsobit problémy při zobrazování hudebních souborů v aplikaci Označovač.</p>
 <div class="note note-advanced" title="Pokročilé">
 <svg height="24" width="24" version="1.1">
  <g>
@@ -82,8 +82,8 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
 </svg><div class="inner"><div class="region"><div class="contents">
-<p class="p">FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
-<div class="code"><pre class="contents"><code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code></pre></div>
+<p class="p">Pro opravení problémů s obalem alba lze použít FFmpeg. Spusťte následující příkaz pro odebrání data o obalu alba ze souboru:</p>
+<div class="code"><pre class="contents"><code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i vstup.mp3 vystup.mp3</code></pre></div>
 <p class="p">kde je <span class="code">vstup.mp3</span> cesta k poškozenému souboru a <span class="code">výstup.mp3</span> cesta k exportovanému opětovně kódovanému souboru.</p>
 </div></div></div>
 </div>

--- a/NickvisionTagger.Shared/Docs/html/es/corrupted.html
+++ b/NickvisionTagger.Shared/Docs/html/es/corrupted.html
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="contents pagewide">
 <p class="p">En esta página se explican los archivos de música con datos dañados.</p>
 <p class="p">Si <span class="app">Tagger</span> no puede leer un archivo, se ignorará y se mostrará un diálogo con una lista de los archivos dañados para que los gestione y corrija en consecuencia.</p>
-<p class="p">This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p class="p">Este cuadro de diálogo ofrecerá la opción de que Tagger ejecute el comando adecuado para intentar reparar el archivo dañado.</p>
 </div>
 <section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Datos no válidos</span></h2></div>
@@ -64,9 +64,9 @@ document.addEventListener('DOMContentLoaded', function() {
 </div>
 </div></div>
 </div></section><section id=""><div class="inner">
-<div class="hgroup pagewide"><h2 class="title"><span class="title">Invalid Album Art</span></h2></div>
+<div class="hgroup pagewide"><h2 class="title"><span class="title">Carátula del álbum no válida</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+<p class="p">Un formato de carátula no válido o dañado puede causar problemas en la visualización de los archivos de música en Tagger.</p>
 <div class="note note-advanced" title="Avanzada">
 <svg height="24" width="24" version="1.1">
  <g>
@@ -82,7 +82,7 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
 </svg><div class="inner"><div class="region"><div class="contents">
-<p class="p">FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
+<p class="p">FFmpeg puede utilizarse para solucionar problemas en las carátulas de los álbumes. Ejecute el siguiente comando para eliminar los datos de las carátulas de un archivo:</p>
 <div class="code"><pre class="contents"><code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code></pre></div>
 <p class="p">donde <span class="code">in.mp3</span> es la ruta del archivo dañado y <span class="code">out.mp3</span> es la ruta para exportar el archivo recodificado.</p>
 </div></div></div>

--- a/NickvisionTagger.Shared/Docs/html/ru/corrupted.html
+++ b/NickvisionTagger.Shared/Docs/html/ru/corrupted.html
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="contents pagewide">
 <p class="p">This page explains music files with corrupted data.</p>
 <p class="p">If <span class="app">Tagger</span> is unable to read a file, it will be ignored and a dialog will be displayed listing corrupted files for you to manage and fix accordingly.</p>
-<p class="p">This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p class="p">В этом окне будет предложена опция, при которой Tagger выполнит команду, которая, возможно, исправит повреждённый файл.</p>
 </div>
 <section id=""><div class="inner">
 <div class="hgroup pagewide"><h2 class="title"><span class="title">Invalid Data</span></h2></div>
@@ -64,9 +64,9 @@ document.addEventListener('DOMContentLoaded', function() {
 </div>
 </div></div>
 </div></section><section id=""><div class="inner">
-<div class="hgroup pagewide"><h2 class="title"><span class="title">Invalid Album Art</span></h2></div>
+<div class="hgroup pagewide"><h2 class="title"><span class="title">Неправильное изображение обложки</span></h2></div>
 <div class="region"><div class="contents pagewide">
-<p class="p">An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+<p class="p">Неправильное или повреждённое встроенное изображение обложки альбома может создавать проблемы при отображении музыки в Tagger.</p>
 <div class="note note-advanced" title="Подробности">
 <svg height="24" width="24" version="1.1">
  <g>
@@ -82,8 +82,8 @@ document.addEventListener('DOMContentLoaded', function() {
   <path class="yelp-svg-fill" d="m11.072 11.757-3.3146 1.9-1.4143-1.414 1.7457-3.1602z"></path>
  </g>
 </svg><div class="inner"><div class="region"><div class="contents">
-<p class="p">FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
-<div class="code"><pre class="contents"><code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code></pre></div>
+<p class="p">Вы можете использовать FFmpeg для исправления проблемных обложек. Выполните следующую команду для удаления обложки из файла:</p>
+<div class="code"><pre class="contents"><code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i исходный.mp3 новый.mp3</code></pre></div>
 <p class="p">
             where <span class="code">in.mp3</span> is the file path of the corrupted file and <span class="code">out.mp3</span> is the path to export the re-encoded file.
         </p>

--- a/NickvisionTagger.Shared/Docs/yelp/cs/corrupted.page
+++ b/NickvisionTagger.Shared/Docs/yelp/cs/corrupted.page
@@ -23,7 +23,7 @@
 <title>Poškozené soubory</title>
 <p>Tato stránka vysvětluje hudební soubory s poškozenými daty.</p>
 <p>Pokud <app>Označovač</app> nedokáže přečíst soubor, bude ignorován a bude zobrazen dialog se seznamem poškozených souborů, které následně můžete spravovat a opravit.</p>
-<p>This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p>Tento dialog vám nabídne možnost nechat aplikaci spustit příslušný příkaz a pokusit se opravit poškozený soubor.</p>
 <section>
     <title>Neplatná data</title>
     <p>Neplatná hlavička značky nebo nevyžádaná data v souboru mohou způsobit problémy při čtení informací o souboru a dokonce i problémy s přehráváním. Některé webové stránky přidávají do souborů další nevyžádaná data, která následně způsobují poškození.</p>
@@ -37,11 +37,11 @@
     </note>
 </section>
 <section>
-    <title>Invalid Album Art</title>
-    <p>An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+    <title>Neplatný obal alba</title>
+    <p>Neplatný nebo poškozený formát vloženého obalu alba může způsobit problémy při zobrazování hudebních souborů v aplikaci Označovač.</p>
     <note style="advanced">
-        <p>FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
-        <code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code>
+        <p>Pro opravení problémů s obalem alba lze použít FFmpeg. Spusťte následující příkaz pro odebrání data o obalu alba ze souboru:</p>
+        <code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i vstup.mp3 vystup.mp3</code>
         <p>kde je <code>vstup.mp3</code> cesta k poškozenému souboru a <code>výstup.mp3</code> cesta k exportovanému opětovně kódovanému souboru.</p>
     </note>
 </section>

--- a/NickvisionTagger.Shared/Docs/yelp/es/corrupted.page
+++ b/NickvisionTagger.Shared/Docs/yelp/es/corrupted.page
@@ -23,7 +23,7 @@
 <title>Archivos dañados</title>
 <p>En esta página se explican los archivos de música con datos dañados.</p>
 <p>Si <app>Tagger</app> no puede leer un archivo, se ignorará y se mostrará un diálogo con una lista de los archivos dañados para que los gestione y corrija en consecuencia.</p>
-<p>This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p>Este cuadro de diálogo ofrecerá la opción de que Tagger ejecute el comando adecuado para intentar reparar el archivo dañado.</p>
 <section>
     <title>Datos no válidos</title>
     <p>Un encabezado de etiqueta no válido o datos basura en un archivo pueden causar problemas al leer la información sobre un archivo e incluso causar problemas de reproducción. Algunas páginas web añaden datos basura a los archivos, lo que a su vez provoca su corrupción.</p>
@@ -37,10 +37,10 @@
     </note>
 </section>
 <section>
-    <title>Invalid Album Art</title>
-    <p>An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+    <title>Carátula del álbum no válida</title>
+    <p>Un formato de carátula no válido o dañado puede causar problemas en la visualización de los archivos de música en Tagger.</p>
     <note style="advanced">
-        <p>FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
+        <p>FFmpeg puede utilizarse para solucionar problemas en las carátulas de los álbumes. Ejecute el siguiente comando para eliminar los datos de las carátulas de un archivo:</p>
         <code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code>
         <p>donde <code>in.mp3</code> es la ruta del archivo dañado y <code>out.mp3</code> es la ruta para exportar el archivo recodificado.</p>
     </note>

--- a/NickvisionTagger.Shared/Docs/yelp/ru/corrupted.page
+++ b/NickvisionTagger.Shared/Docs/yelp/ru/corrupted.page
@@ -29,7 +29,7 @@
 <title>Повреждённые файлы</title>
 <p>This page explains music files with corrupted data.</p>
 <p>If <app>Tagger</app> is unable to read a file, it will be ignored and a dialog will be displayed listing corrupted files for you to manage and fix accordingly.</p>
-<p>This dialog will offer the option to have Tagger run the appropriate command to try and fix the corrupted file.</p>
+<p>В этом окне будет предложена опция, при которой Tagger выполнит команду, которая, возможно, исправит повреждённый файл.</p>
 <section>
     <title>Invalid Data</title>
     <p>An invalid tag header or junk data in a file can cause issues when reading information about a file and even cause playback issues. Some websites add extra junk data in files which in turn causes corruption.</p>
@@ -43,11 +43,11 @@
     </note>
 </section>
 <section>
-    <title>Invalid Album Art</title>
-    <p>An invalid or corrupted embedded album art format can cause issues in displaying music files in Tagger.</p>
+    <title>Неправильное изображение обложки</title>
+    <p>Неправильное или повреждённое встроенное изображение обложки альбома может создавать проблемы при отображении музыки в Tagger.</p>
     <note style="advanced">
-        <p>FFmpeg can be used to fix album art issues. Run the following command to remove album art data from a file:</p>
-        <code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i in.mp3 out.mp3</code>
+        <p>Вы можете использовать FFmpeg для исправления проблемных обложек. Выполните следующую команду для удаления обложки из файла:</p>
+        <code>ffmpeg -map 0:a -c:a copy -map_metadata -1 -i исходный.mp3 новый.mp3</code>
         <p>
             where <code>in.mp3</code> is the file path of the corrupted file and <code>out.mp3</code> is the path to export the re-encoded file.
         </p>

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -887,10 +887,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 {
                     replace = PublishingDate == DateTime.MinValue ? "" : PublishingDate.ToShortDateString();
                 }
-                if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && LimitFilenameCharacters)
-                {
-                    replace = replace.Replace('/', '_');
-                }
+                replace = replace.Replace(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\\' : '/', '_');
                 formatString = formatString.Replace(match.Value, replace);
             }
             else if (customProps.Contains(value))

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -545,13 +545,13 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 Directory.CreateDirectory(System.IO.Path.GetDirectoryName(newPath)!);
                 if(File.Exists(newPath))
                 {
-                    newPath = newPath.Remove(newPath.IndexOf(_dotExtension)) + $" (1){_dotExtension}";
-                }
-                var i = 2;
-                while (File.Exists(newPath))
-                {
-                    newPath = newPath.Remove(newPath.IndexOf($" ({i - 1})")) + $" ({i}){_dotExtension}";
-                    i++;
+                    newPath = newPath.Remove(newPath.IndexOf(_dotExtension));
+                    var i = 1;
+                    while(File.Exists($"{newPath} ({i}){_dotExtension}"))
+                    {
+                        i++;
+                    }
+                    newPath += $" ({i}){_dotExtension}";
                 }
                 File.Move(Path, newPath);
                 Path = newPath;

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -79,7 +79,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
     static MusicFile()
     {
         _validProperties = new string[] { "title", _("title"), "artist", _("artist"), "album", _("album"), "year", _("year"), "track", _("track"), "tracktotal", _("tracktotal"), "albumartist", _("albumartist"), "genre", _("genre"), "comment", _("comment"), "beatsperminute", _("beatsperminute"), "bpm", _("bpm"), "composer", _("composer"), "description", _("description"), "discnumber", _("discnumber"), "disctotal", _("disctotal"), "publisher", _("publisher"), "publishingdate", _("publishingdate"), "lyrics", _("lyrics") };
-        _invalidWindowsFilenameCharacters = new List<char>() { '"', '<', '>', ':', '\\', '/', '|', '?', '*' };
+        _invalidWindowsFilenameCharacters = new List<char>() { '"', '<', '>', ':', '\\', '|', '?', '*' };
         _invalidSystemFilenameCharacters = System.IO.Path.GetInvalidPathChars().Union(System.IO.Path.GetInvalidFileNameChars()).ToList();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -87,8 +87,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         }
         else
         {
-            _invalidSystemFilenameCharacters.Remove('/');
-            _invalidWindowsFilenameCharacters.Remove('/');
+            _invalidSystemFilenameCharacters.Remove(System.IO.Path.DirectorySeparatorChar);
         }
         SortFilesBy = SortBy.Path;
         LimitFilenameCharacters = false;
@@ -543,11 +542,11 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
             {
                 var newPath = $"{System.IO.Path.GetDirectoryName(Path)}{System.IO.Path.DirectorySeparatorChar}{Filename}";
                 Directory.CreateDirectory(System.IO.Path.GetDirectoryName(newPath)!);
-                if(File.Exists(newPath))
+                if (File.Exists(newPath))
                 {
                     newPath = newPath.Remove(newPath.IndexOf(_dotExtension));
                     var i = 1;
-                    while(File.Exists($"{newPath} ({i}){_dotExtension}"))
+                    while (File.Exists($"{newPath} ({i}){_dotExtension}"))
                     {
                         i++;
                     }
@@ -887,7 +886,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 {
                     replace = PublishingDate == DateTime.MinValue ? "" : PublishingDate.ToShortDateString();
                 }
-                replace = replace.Replace(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\\' : '/', '_');
+                replace = replace.Replace(System.IO.Path.DirectorySeparatorChar, '_');
                 formatString = formatString.Replace(match.Value, replace);
             }
             else if (customProps.Contains(value))

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -85,7 +85,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         {
             _invalidSystemFilenameCharacters.Remove('\\');
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else
         {
             _invalidSystemFilenameCharacters.Remove('/');
             _invalidWindowsFilenameCharacters.Remove('/');
@@ -886,6 +886,10 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
                 else if (value == "publishingdate" || value == _("publishingdate"))
                 {
                     replace = PublishingDate == DateTime.MinValue ? "" : PublishingDate.ToShortDateString();
+                }
+                if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && LimitFilenameCharacters)
+                {
+                    replace = replace.Replace('/', '_');
                 }
                 formatString = formatString.Replace(match.Value, replace);
             }

--- a/NickvisionTagger.Shared/Models/MusicFile.cs
+++ b/NickvisionTagger.Shared/Models/MusicFile.cs
@@ -88,6 +88,7 @@ public class MusicFile : IComparable<MusicFile>, IDisposable, IEquatable<MusicFi
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             _invalidSystemFilenameCharacters.Remove('/');
+            _invalidWindowsFilenameCharacters.Remove('/');
         }
         SortFilesBy = SortBy.Path;
         LimitFilenameCharacters = false;

--- a/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
+++ b/NickvisionTagger.Shared/NickvisionTagger.Shared.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     <PackageReference Include="AcoustID.NET" Version="1.3.3" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <PackageReference Include="z440.atl.core" Version="5.12.0" />
     <PackageReference Include="MetaBrainz.MusicBrainz" Version="5.0.1" />
     <PackageReference Include="MetaBrainz.MusicBrainz.CoverArt" Version="5.1.0" />

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-23 10:55+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -174,8 +174,8 @@ msgstr "Informace o pokročilém vyhledávání"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -199,8 +199,8 @@ msgstr "Umělec alba"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "umělecalba"
 
@@ -269,8 +269,8 @@ msgstr "Použít změny?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "umělec"
 
@@ -307,15 +307,15 @@ msgstr "Údery za minutu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -389,8 +389,8 @@ msgstr "Zavřít knihovnu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "komentář"
 
@@ -401,8 +401,8 @@ msgstr "Komentář"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "skladatel"
 
@@ -527,8 +527,8 @@ msgstr "Odstraňování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "popis"
 
@@ -606,15 +606,15 @@ msgstr "Zahazování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "číslodisku"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "celkemdisků"
 
@@ -780,8 +780,8 @@ msgstr "Sem zadejte rok"
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -942,8 +942,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "žánr"
 
@@ -1069,7 +1069,7 @@ msgstr[2] "Načteno {0} hudebních souborů."
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "texty"
 
@@ -1359,8 +1359,8 @@ msgstr "Název vlastnosti"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -1376,8 +1376,8 @@ msgstr "Datum vydání"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "datumvydání"
 
@@ -1418,6 +1418,7 @@ msgid "Remove from Playlist"
 msgstr "Odebrat z playlistu"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
@@ -1621,8 +1622,8 @@ msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "název"
 
@@ -1641,8 +1642,8 @@ msgstr "Vybráno příliš mnoho souborů"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "stopa"
 
@@ -1656,8 +1657,8 @@ msgstr "Stopa"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -1805,8 +1806,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "rok"
 

--- a/NickvisionTagger.Shared/Resources/po/cs.po
+++ b/NickvisionTagger.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-11-07 03:13+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -142,7 +142,7 @@ msgstr "Klíč API uživatele AcoustId"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -174,8 +174,8 @@ msgstr "Informace o pokročilém vyhledávání"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -199,13 +199,13 @@ msgstr "Umělec alba"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "umělecalba"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Všechny soubory"
@@ -269,8 +269,8 @@ msgstr "Použít změny?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "umělec"
 
@@ -307,15 +307,15 @@ msgstr "Údery za minutu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "úderyzaminutu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -342,7 +342,6 @@ msgstr "Vypočítávání..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -368,7 +367,7 @@ msgstr "Seznam změn"
 msgid "Check for Updates"
 msgstr "Zkontrolovat aktualizace"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Vymazat všechny texty"
@@ -389,8 +388,8 @@ msgstr "Zavřít knihovnu"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "komentář"
 
@@ -401,8 +400,8 @@ msgstr "Komentář"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "skladatel"
 
@@ -527,8 +526,8 @@ msgstr "Odstraňování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "popis"
 
@@ -606,15 +605,15 @@ msgstr "Zahazování značek..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "číslodisku"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "celkemdisků"
 
@@ -780,13 +779,13 @@ msgstr "Sem zadejte rok"
 msgid "Error"
 msgstr "Chyba"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "CHYBA"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Existující texty"
 
@@ -814,7 +813,7 @@ msgid "Export Front Album Art"
 msgstr "Exportovat přední obal alba"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Exportovat do LRC"
@@ -828,7 +827,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Přední obal alba úspěšně exportován do souboru"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Úspěšně exportováno do: {0}"
 
@@ -940,8 +939,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "žánr"
 
@@ -992,7 +991,7 @@ msgid "Hide Extras Pane"
 msgstr "Skrýt extra panel"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Importovat z LRC"
@@ -1037,7 +1036,7 @@ msgid "Inserting album art..."
 msgstr "Vkládání obalu alba..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Ponechat texty Označovače"
 
@@ -1067,7 +1066,7 @@ msgstr[2] "Načteno {0} hudebních souborů."
 msgid "Loading music files from library..."
 msgstr "Načítání hudebních souborů z knihovny..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "texty"
 
@@ -1132,7 +1131,6 @@ msgid "New Custom Property"
 msgstr "Nová vlastní vlastnost"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Nový synchronizovaný řádek"
 
@@ -1357,8 +1355,8 @@ msgstr "Název vlastnosti"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "vydavatel"
 
@@ -1374,8 +1372,8 @@ msgstr "Datum vydání"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "datumvydání"
 
@@ -1416,6 +1414,7 @@ msgid "Remove from Playlist"
 msgstr "Odebrat z playlistu"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Odebrat řádek"
 
@@ -1613,14 +1612,14 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Čas (hh:mm:ss nebo mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "název"
 
@@ -1639,8 +1638,8 @@ msgstr "Vybráno příliš mnoho souborů"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "stopa"
 
@@ -1654,8 +1653,8 @@ msgstr "Stopa"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "celkemstop"
 
@@ -1691,7 +1690,7 @@ msgid "Unable to download and install update."
 msgstr "Nepodařilo se stáhnout a nainstalovat aktualizaci."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "Nepodařilo se exportovat do souboru LRC."
 
@@ -1701,7 +1700,7 @@ msgid "Unable to fix file"
 msgstr "Nepodařilo se opravit soubor"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Nepodařilo se importovat soubor LRC."
 
@@ -1741,7 +1740,7 @@ msgid "Update"
 msgstr "Aktualizace"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Použít texty LRC"
 
@@ -1768,7 +1767,7 @@ msgid "Web Services"
 msgstr "Webové služby"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"
@@ -1802,8 +1801,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "rok"
 

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-10-30 05:03+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -143,7 +143,7 @@ msgstr "AcoustId Nutzer-API-Key"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -206,7 +206,7 @@ msgid "albumartist"
 msgstr "albumkünstler"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Alle Dateien"
@@ -343,7 +343,6 @@ msgstr "Berechne..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -369,7 +368,7 @@ msgstr "Änderungshistorie"
 msgid "Check for Updates"
 msgstr "Auf Updates prüfen"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Alle Songtexte entfernen"
@@ -781,13 +780,13 @@ msgstr "Jahr hier eintragen"
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "FEHLER"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Existierende Songtexte"
 
@@ -815,7 +814,7 @@ msgid "Export Front Album Art"
 msgstr "Vorderseite des Albumcovers exportieren"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Nach LRC Exportieren"
@@ -829,7 +828,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Vorderseite des Albumcovers erfolgreich zu Datei exportiert"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Erfolgreich exportiert nach: {0}"
 
@@ -995,7 +994,7 @@ msgid "Hide Extras Pane"
 msgstr "Extras-Bereich verstecken"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Von LRC importieren"
@@ -1040,7 +1039,7 @@ msgid "Inserting album art..."
 msgstr "Albumcover wird eingefügt..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Tagger's Songtexte behalten"
 
@@ -1134,7 +1133,6 @@ msgid "New Custom Property"
 msgstr "Neue Andere Eigenschaft"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Neuer Synchronisierter Text"
 
@@ -1617,7 +1615,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
@@ -1697,7 +1695,7 @@ msgid "Unable to download and install update."
 msgstr "Update konnte nicht heruntergeladen und installiert werden."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "Export nach LRC fehlgeschlagen."
 
@@ -1708,7 +1706,7 @@ msgid "Unable to fix file"
 msgstr "Konnte Bilddatei nicht laden"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Import von LRC fehlgeschlagen."
 
@@ -1748,7 +1746,7 @@ msgid "Update"
 msgstr "Update"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Lyrics aus LRC-Datei nutzen"
 
@@ -1775,7 +1773,7 @@ msgid "Web Services"
 msgstr "Web-Dienste"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/de.po
+++ b/NickvisionTagger.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-30 05:03+0000\n"
 "Last-Translator: Simon Hahne <simonhahne@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -175,8 +175,8 @@ msgstr "Info zur erweiterten Suche"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -200,8 +200,8 @@ msgstr "Album-Interpret"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "albumkünstler"
 
@@ -270,8 +270,8 @@ msgstr "Änderungen anwenden?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "künstler"
 
@@ -308,15 +308,15 @@ msgstr "Schläge pro Minute"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -390,8 +390,8 @@ msgstr "Bibliothek schließen"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "kommentar"
 
@@ -402,8 +402,8 @@ msgstr "Kommentar"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "Komponist"
 
@@ -528,8 +528,8 @@ msgstr "Tags werden gelöscht..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "Beschreibung"
 
@@ -607,15 +607,15 @@ msgstr "Tags werden verworfen..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "plattennummer"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "plattengesamt"
 
@@ -781,8 +781,8 @@ msgstr "Jahr hier eintragen"
 msgid "Error"
 msgstr "Fehler"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -943,8 +943,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "genre"
 
@@ -1069,7 +1069,7 @@ msgstr[1] "{0} Musikdateien geladen."
 msgid "Loading music files from library..."
 msgstr "Lade Musikdateien von Bibliothek..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "Songtext"
 
@@ -1359,8 +1359,8 @@ msgstr "Eigenschaft-Name"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "Herausgeber"
 
@@ -1376,8 +1376,8 @@ msgstr "Veröffentlichungsdatum"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "veröffentlichungsdatum"
 
@@ -1418,6 +1418,7 @@ msgid "Remove from Playlist"
 msgstr "Aus Wiedergabeliste entfernen"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Text Entfernen"
 
@@ -1622,8 +1623,8 @@ msgstr "Zeitstempel (hh:mm:ss oder mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "titel"
 
@@ -1642,8 +1643,8 @@ msgstr "Zu viele Dateien ausgewählt"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "nummer"
 
@@ -1657,8 +1658,8 @@ msgstr "Track"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "songanzahl"
 
@@ -1809,8 +1810,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "Jahr"
 

--- a/NickvisionTagger.Shared/Resources/po/enm.po
+++ b/NickvisionTagger.Shared/Resources/po/enm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -133,7 +133,7 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -196,7 +196,7 @@ msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr ""
@@ -333,7 +333,6 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -359,7 +358,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr ""
@@ -753,13 +752,13 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr ""
 
@@ -787,7 +786,7 @@ msgid "Export Front Album Art"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr ""
@@ -801,7 +800,7 @@ msgid "Exported front album art to file successfully"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -965,7 +964,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr ""
@@ -1010,7 +1009,7 @@ msgid "Inserting album art..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1104,7 +1103,6 @@ msgid "New Custom Property"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1578,7 +1576,7 @@ msgid "TiB"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
@@ -1656,7 +1654,7 @@ msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr ""
 
@@ -1666,7 +1664,7 @@ msgid "Unable to fix file"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr ""
 
@@ -1706,7 +1704,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr ""
 
@@ -1733,7 +1731,7 @@ msgid "Web Services"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/enm.po
+++ b/NickvisionTagger.Shared/Resources/po/enm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -165,8 +165,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr ""
 
@@ -190,8 +190,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr ""
 
@@ -260,8 +260,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr ""
 
@@ -298,15 +298,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr ""
 
@@ -380,8 +380,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr ""
 
@@ -392,8 +392,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr ""
 
@@ -516,8 +516,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr ""
 
@@ -584,15 +584,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr ""
 
@@ -753,8 +753,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr ""
 
@@ -913,8 +913,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr ""
 
@@ -1039,7 +1039,7 @@ msgstr[1] ""
 msgid "Loading music files from library..."
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr ""
 
@@ -1327,8 +1327,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr ""
 
@@ -1344,8 +1344,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr ""
 
@@ -1386,6 +1386,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr ""
 
@@ -1583,8 +1584,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr ""
 
@@ -1603,8 +1604,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr ""
 
@@ -1618,8 +1619,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr ""
 
@@ -1760,8 +1761,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-27 21:06+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -176,8 +176,8 @@ msgstr "Información de búsqueda avanzada"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "álbum"
 
@@ -201,8 +201,8 @@ msgstr "Artista del álbum"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "artistadelálbum"
 
@@ -271,8 +271,8 @@ msgstr "¿Aplicar cambios?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artista"
 
@@ -309,15 +309,15 @@ msgstr "Pulsaciones por minuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "ppm"
 
@@ -391,8 +391,8 @@ msgstr "Cerrar la biblioteca"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "comentario"
 
@@ -403,8 +403,8 @@ msgstr "Comentario"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "compositor"
 
@@ -529,8 +529,8 @@ msgstr "Borrando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "descripción"
 
@@ -608,15 +608,15 @@ msgstr "Descartando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "númerodeldisco"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "totaldeldisco"
 
@@ -785,8 +785,8 @@ msgstr "Introduzca aquí el año"
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -947,8 +947,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "género"
 
@@ -1073,7 +1073,7 @@ msgstr[1] "Cargados {0} archivos de música."
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "letras"
 
@@ -1365,8 +1365,8 @@ msgstr "Nombre de la propiedad"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "editor"
 
@@ -1382,8 +1382,8 @@ msgstr "Fecha de publicación"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "fechadepublicación"
 
@@ -1424,6 +1424,7 @@ msgid "Remove from Playlist"
 msgstr "Eliminar de la lista de reproducción"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
@@ -1630,8 +1631,8 @@ msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "título"
 
@@ -1650,8 +1651,8 @@ msgstr "Demasiados archivos seleccionados"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "pista"
 
@@ -1665,8 +1666,8 @@ msgstr "Pista"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -1817,8 +1818,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "año"
 

--- a/NickvisionTagger.Shared/Resources/po/es.po
+++ b/NickvisionTagger.Shared/Resources/po/es.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-11-07 03:13+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -143,7 +143,7 @@ msgstr "Clave API de usuario de AcoustId"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -175,8 +175,8 @@ msgstr "Información de búsqueda avanzada"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "álbum"
 
@@ -200,13 +200,13 @@ msgstr "Artista del álbum"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "artistadelálbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Todos los archivos"
@@ -270,8 +270,8 @@ msgstr "¿Aplicar cambios?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artista"
 
@@ -308,15 +308,15 @@ msgstr "Pulsaciones por minuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "pulsacionesporminuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "ppm"
 
@@ -343,7 +343,6 @@ msgstr "Calculando..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -369,7 +368,7 @@ msgstr "Registro de cambios"
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Borrar todas las letras"
@@ -390,8 +389,8 @@ msgstr "Cerrar la biblioteca"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "comentario"
 
@@ -402,8 +401,8 @@ msgstr "Comentario"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "compositor"
 
@@ -528,8 +527,8 @@ msgstr "Borrando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "descripción"
 
@@ -607,15 +606,15 @@ msgstr "Descartando las etiquetas..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "númerodeldisco"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "totaldeldisco"
 
@@ -784,13 +783,13 @@ msgstr "Introduzca aquí el año"
 msgid "Error"
 msgstr "Error"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "ERROR"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Letras ya existentes"
 
@@ -818,7 +817,7 @@ msgid "Export Front Album Art"
 msgstr "Exportar portada del álbum"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Exportar a LRC"
@@ -832,7 +831,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Exportada correctamente la portada del álbum al archivo"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Exportado con éxito a: {0}"
 
@@ -944,8 +943,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "género"
 
@@ -996,7 +995,7 @@ msgid "Hide Extras Pane"
 msgstr "Ocultar panel Extras"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Importar desde LRC"
@@ -1041,7 +1040,7 @@ msgid "Inserting album art..."
 msgstr "Insertando carátulas…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Mantener los textos de Tagger"
 
@@ -1070,7 +1069,7 @@ msgstr[1] "Cargados {0} archivos de música."
 msgid "Loading music files from library..."
 msgstr "Cargando los archivos de música de la biblioteca..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "letras"
 
@@ -1135,7 +1134,6 @@ msgid "New Custom Property"
 msgstr "Propiedad personalizada nueva"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Nueva letra sincronizada"
 
@@ -1362,8 +1360,8 @@ msgstr "Nombre de la propiedad"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "editor"
 
@@ -1379,8 +1377,8 @@ msgstr "Fecha de publicación"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "fechadepublicación"
 
@@ -1421,6 +1419,7 @@ msgid "Remove from Playlist"
 msgstr "Eliminar de la lista de reproducción"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Eliminar letra"
 
@@ -1621,14 +1620,14 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Marca de tiempo (hh:mm:ss o mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "título"
 
@@ -1647,8 +1646,8 @@ msgstr "Demasiados archivos seleccionados"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "pista"
 
@@ -1662,8 +1661,8 @@ msgstr "Pista"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "pistatotal"
 
@@ -1701,7 +1700,7 @@ msgid "Unable to download and install update."
 msgstr "No se puede descargar e instalar la actualización."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "No se puede exportar al LRC."
 
@@ -1711,7 +1710,7 @@ msgid "Unable to fix file"
 msgstr "No se puede arreglar el archivo"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "No se puede importar desde LRC."
 
@@ -1751,7 +1750,7 @@ msgid "Update"
 msgstr "Actualizar"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Usa las letras del LRC"
 
@@ -1778,7 +1777,7 @@ msgid "Web Services"
 msgstr "Servicios web"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"
@@ -1813,8 +1812,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "año"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-11-05 16:25+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -167,8 +167,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "albumi"
 
@@ -192,8 +192,8 @@ msgstr "Albumin esittäjä"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr ""
 
@@ -262,8 +262,8 @@ msgstr "Toteutetaanko muutokset?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "esittäjä"
 
@@ -300,15 +300,15 @@ msgstr "Tempo"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr ""
 
@@ -382,8 +382,8 @@ msgstr "Sulje kirjasto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "kommentti"
 
@@ -394,8 +394,8 @@ msgstr "Kommentti"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "säveltäjä"
 
@@ -520,8 +520,8 @@ msgstr "Poistetaan tageja..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "kuvaus"
 
@@ -588,15 +588,15 @@ msgstr "Hylätään tagit..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "kappale"
@@ -763,8 +763,8 @@ msgstr ""
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -926,8 +926,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "tyylilaji"
 
@@ -1052,7 +1052,7 @@ msgstr[1] "Ladattiin {0} musiikkitiedostoa."
 msgid "Loading music files from library..."
 msgstr "Ladataan musiikkitiedostoja kirjastosta..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 #, fuzzy
 msgid "lyrics"
 msgstr "Sanoitukset"
@@ -1342,8 +1342,8 @@ msgstr "Ominaisuuden nimi"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "julkaisija"
 
@@ -1359,8 +1359,8 @@ msgstr "Julkaisupäivä"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "julkaisija"
@@ -1402,6 +1402,7 @@ msgid "Remove from Playlist"
 msgstr "Poista soittolistalta"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Poista sanoitus"
 
@@ -1599,8 +1600,8 @@ msgstr "Aikaleima (hh:mm:ss tai mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "nimi"
 
@@ -1619,8 +1620,8 @@ msgstr "Liian monta tiedostoa valittu"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "kappale"
 
@@ -1634,8 +1635,8 @@ msgstr "Kappale"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 #, fuzzy
 msgid "tracktotal"
 msgstr "kappale"
@@ -1780,8 +1781,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "vuosi"
 

--- a/NickvisionTagger.Shared/Resources/po/fi.po
+++ b/NickvisionTagger.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-11-05 16:25+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-"
@@ -135,7 +135,7 @@ msgstr "AcoustId:n käyttäjän API-avain"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -198,7 +198,7 @@ msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Kaikki tiedostot"
@@ -335,7 +335,6 @@ msgstr "Lasketaan..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -361,7 +360,7 @@ msgstr "Muutosloki"
 msgid "Check for Updates"
 msgstr "Tarkista päivitykset"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Tyhjennä kaikki sanoitukset"
@@ -763,13 +762,13 @@ msgstr ""
 msgid "Error"
 msgstr "Virhe"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "VIRHE"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Olemassa olevat sanoitukset"
 
@@ -797,7 +796,7 @@ msgid "Export Front Album Art"
 msgstr "Vie albumin etukuvitus"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 #, fuzzy
 msgid "Export to LRC"
@@ -812,7 +811,7 @@ msgid "Exported front album art to file successfully"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Viety onnistuneesti: {0}"
 
@@ -978,7 +977,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Tuo LRC:stä"
@@ -1023,7 +1022,7 @@ msgid "Inserting album art..."
 msgstr "Syötetään albumin kuvitusta..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1118,7 +1117,6 @@ msgid "New Custom Property"
 msgstr "Uusi mukautettu ominaisuus"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Uusi synkronoitu sanoitus"
 
@@ -1594,7 +1592,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Aikaleima (hh:mm:ss tai mm:ss.xx)"
 
@@ -1673,7 +1671,7 @@ msgid "Unable to download and install update."
 msgstr "Päivityksen lataaminen ja asentaminen ei onnistunut."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 #, fuzzy
 msgid "Unable to export to LRC."
 msgstr "Ei voi tallentaa {0}."
@@ -1685,7 +1683,7 @@ msgid "Unable to fix file"
 msgstr "Kuvatiedoston lataaminen ei onnistu"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Tuonti LRC:stä ei onnistu."
 
@@ -1726,7 +1724,7 @@ msgid "Update"
 msgstr "Päivitä"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Käytä LRC:n sanoituksia"
 
@@ -1753,7 +1751,7 @@ msgid "Web Services"
 msgstr "Verkkopalvelut"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-23 10:55+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -175,8 +175,8 @@ msgstr "Informations sur la recherche avancée"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -200,8 +200,8 @@ msgstr "Artiste de l'album"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "artiste de l’album"
 
@@ -270,8 +270,8 @@ msgstr "Appliquer les changements ?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artiste"
 
@@ -308,15 +308,15 @@ msgstr "Battements par minute"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "battementsparminute"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -390,8 +390,8 @@ msgstr "Fermer la bibliothèque"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "commentaire"
 
@@ -402,8 +402,8 @@ msgstr "Commentaire"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "compositeur"
 
@@ -528,8 +528,8 @@ msgstr "Suppression des étiquettes..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "description"
 
@@ -608,15 +608,15 @@ msgstr "Abandon des balises…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "pistestotal"
@@ -789,8 +789,8 @@ msgstr "Entrez l’année ici"
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -954,8 +954,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "genre"
 
@@ -1080,7 +1080,7 @@ msgstr[1] "{0} musiques chargées."
 msgid "Loading music files from library..."
 msgstr "Chargement des fichiers de musiques depuis la bibliothèque…"
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "paroles"
 
@@ -1379,8 +1379,8 @@ msgstr "Nom de la propriété"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "maison de disques"
 
@@ -1397,8 +1397,8 @@ msgstr "Maison de disques"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "maison de disques"
@@ -1441,6 +1441,7 @@ msgid "Remove from Playlist"
 msgstr "Supprimer de la liste de lecture"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Supprimer les paroles"
 
@@ -1650,8 +1651,8 @@ msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "titre"
 
@@ -1670,8 +1671,8 @@ msgstr "Trop de fichiers sélectionnés"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "piste"
 
@@ -1685,8 +1686,8 @@ msgstr "Morceau"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "pistestotal"
 
@@ -1835,8 +1836,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "année"
 

--- a/NickvisionTagger.Shared/Resources/po/fr.po
+++ b/NickvisionTagger.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-10-23 10:55+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -143,7 +143,7 @@ msgstr "Clé utilisateur d’API AcoustId"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -206,7 +206,7 @@ msgid "albumartist"
 msgstr "artiste de l’album"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Tous les fichiers"
@@ -343,7 +343,6 @@ msgstr "Calcul…"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -369,7 +368,7 @@ msgstr "Journal des changements"
 msgid "Check for Updates"
 msgstr "Vérifier les mises à jour"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Effacer toutes les paroles"
@@ -789,13 +788,13 @@ msgstr "Entrez l’année ici"
 msgid "Error"
 msgstr "Erreur"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "ERREUR"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Paroles existantes"
 
@@ -823,7 +822,7 @@ msgid "Export Front Album Art"
 msgstr "Exporter la face de la pochette d’album"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Exporter vers LRC"
@@ -839,7 +838,7 @@ msgstr ""
 "La face de la pochette d’album a été exportée vers le fichier avec succès"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Exporté avec succès vers : {0}"
 
@@ -1006,7 +1005,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Importer depuis LRC"
@@ -1051,7 +1050,7 @@ msgid "Inserting album art..."
 msgstr "Ajout de la pochette d'album..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Conserver les paroles de Tagger"
 
@@ -1147,7 +1146,6 @@ msgid "New Custom Property"
 msgstr "Nouvelle propriété personnalisée"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Nouvelles paroles synchronisées"
 
@@ -1645,7 +1643,7 @@ msgid "TiB"
 msgstr "Tio"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Horodatage (hh:mm:ss ou mm:ss.xx)"
 
@@ -1728,7 +1726,7 @@ msgid "Unable to download and install update."
 msgstr "Impossible de charger l’image"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "Impossible d’exporter vers LRC."
 
@@ -1739,7 +1737,7 @@ msgid "Unable to fix file"
 msgstr "Impossible de charger l’image"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Impossible d’importer depuis LRC."
 
@@ -1779,7 +1777,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Utiliser les paroles LRC"
 
@@ -1806,7 +1804,7 @@ msgid "Web Services"
 msgstr "Services Web"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -142,7 +142,7 @@ msgstr "מפתח משתמש API ל־AcoustId"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -206,7 +206,7 @@ msgid "albumartist"
 msgstr "אמן האלבום"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 #, fuzzy
 msgid "All files"
@@ -345,7 +345,6 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -371,7 +370,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "ניקוי כל מילות השיר"
@@ -795,13 +794,13 @@ msgstr ""
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "תקלה"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "מילות שיר קיימות"
 
@@ -829,7 +828,7 @@ msgid "Export Front Album Art"
 msgstr "ייצוא עטיפת אלבום קדמית"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "ייצוא ל־LRC"
@@ -843,7 +842,7 @@ msgid "Exported front album art to file successfully"
 msgstr "עטיפת אלבום קדמית יוצאה בהצלחה"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "הייצוא בוצע בהצלחה אל: {0}"
 
@@ -1013,7 +1012,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "ייבוא מ־LRC"
@@ -1060,7 +1059,7 @@ msgid "Inserting album art..."
 msgstr "הכנסת עטיפת אלבום אחורית"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "לשמור מילות שיר מהמתייג"
 
@@ -1159,7 +1158,6 @@ msgid "New Custom Property"
 msgstr "מאפיין מותאם חדש"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1653,7 +1651,7 @@ msgid "TiB"
 msgstr "טבי״ב"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 #, fuzzy
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "חותמת זמן (hh:mm:ss)"
@@ -1738,7 +1736,7 @@ msgid "Unable to download and install update."
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "לא ניתן לייצא ל־LRC."
 
@@ -1749,7 +1747,7 @@ msgid "Unable to fix file"
 msgstr "לא ניתן לטעון את קובץ התמונה"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "לא ניתן לייבא מ־LRC."
 
@@ -1790,7 +1788,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "שימוש במילות שיר מ־LRC"
 
@@ -1817,7 +1815,7 @@ msgid "Web Services"
 msgstr "שרת אינטרנט"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/he.po
+++ b/NickvisionTagger.Shared/Resources/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-08-16 16:52+0000\n"
 "Last-Translator: Yosef Or Boczko <yoseforb@gnome.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -175,8 +175,8 @@ msgstr "חיפוש מידע מתקדם"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "אלבום"
 
@@ -200,8 +200,8 @@ msgstr "אמן האלבום"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "אמן האלבום"
 
@@ -272,8 +272,8 @@ msgstr "להחיל שינויים?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "אמן"
 
@@ -310,15 +310,15 @@ msgstr "פעימות לדקה"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "פעימות בדקה"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "פעימות בדקה (bpm)"
 
@@ -393,8 +393,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "הערכה"
 
@@ -405,8 +405,8 @@ msgstr "הערה"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "מלחין"
 
@@ -538,8 +538,8 @@ msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "תיאור"
 
@@ -609,15 +609,15 @@ msgstr "שומר תגיות…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "מספר רצועות כולל"
@@ -795,8 +795,8 @@ msgstr ""
 msgid "Error"
 msgstr "שגיאה"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "תקלה"
 
@@ -960,8 +960,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "סוגה"
 
@@ -1092,7 +1092,7 @@ msgstr[3] "נטענו {0} קובצי מוזיקה."
 msgid "Loading music files from library..."
 msgstr "מתבצעת טעינת קובצי מוזיקה מתיקייה…"
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "מילות שיר"
 
@@ -1392,8 +1392,8 @@ msgstr "שם מאפיין"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "מוציא לאור"
 
@@ -1410,8 +1410,8 @@ msgstr "מוציא לאור"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "מוציא לאור"
@@ -1455,6 +1455,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "הסרת מילות שיר"
 
@@ -1659,8 +1660,8 @@ msgstr "חותמת זמן (hh:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "כותרת"
 
@@ -1679,8 +1680,8 @@ msgstr "נבחרו יותר מדי קבצים"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "רצועה"
 
@@ -1694,8 +1695,8 @@ msgstr "רצועה"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "מספר רצועות כולל"
 
@@ -1846,8 +1847,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "שנה"
 

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -143,7 +143,7 @@ msgstr "API ključ AcoustId korisnika"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -207,7 +207,7 @@ msgid "albumartist"
 msgstr "izvođač albuma"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 #, fuzzy
 msgid "All files"
@@ -346,7 +346,6 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -372,7 +371,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr ""
@@ -797,13 +796,13 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "GREŠKA"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr ""
 
@@ -831,7 +830,7 @@ msgid "Export Front Album Art"
 msgstr "Izvezi prednju sliku albuma"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 #, fuzzy
 msgid "Export to LRC"
@@ -846,7 +845,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Prednja slika albuma je uspješno izvezena u datoteku"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -1017,7 +1016,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr ""
@@ -1063,7 +1062,7 @@ msgid "Inserting album art..."
 msgstr "Umetanje slike albuma …"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1160,7 +1159,6 @@ msgid "New Custom Property"
 msgstr "Novo prilagođeno svojstvo"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1658,7 +1656,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
@@ -1740,7 +1738,7 @@ msgid "Unable to download and install update."
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 #, fuzzy
 msgid "Unable to export to LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
@@ -1752,7 +1750,7 @@ msgid "Unable to fix file"
 msgstr "Neuspjelo učitavanje slikovne datoteke"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 #, fuzzy
 msgid "Unable to import from LRC."
 msgstr "Neuspjelo spremanje datoteke {0}."
@@ -1794,7 +1792,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr ""
 
@@ -1821,7 +1819,7 @@ msgid "Web Services"
 msgstr "Web usluge"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/hr.po
+++ b/NickvisionTagger.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-07-29 14:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/nickvision-"
@@ -176,8 +176,8 @@ msgstr "Informacije napredne pretrage"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -201,8 +201,8 @@ msgstr "Izvođač albuma"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "izvođač albuma"
 
@@ -273,8 +273,8 @@ msgstr "Primijeniti promjene?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "izvođač"
 
@@ -311,15 +311,15 @@ msgstr "BPM"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "broje otkucaja u minuti"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -394,8 +394,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "komentar"
 
@@ -406,8 +406,8 @@ msgstr "Komentar"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "skladatelj"
 
@@ -539,8 +539,8 @@ msgstr "Brisanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "opis"
 
@@ -610,15 +610,15 @@ msgstr "Spremanje oznaka …"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "broj pjesama"
@@ -797,8 +797,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -964,8 +964,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "žanr"
 
@@ -1094,7 +1094,7 @@ msgstr[2] "Učitano je {0} glazbenih datoteka."
 msgid "Loading music files from library..."
 msgstr "Učitavanje glazbenih datoteka iz mape …"
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr ""
 
@@ -1394,8 +1394,8 @@ msgstr "Ime svojstva"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "izdavač"
 
@@ -1412,8 +1412,8 @@ msgstr "Izdavač"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "izdavač"
@@ -1457,6 +1457,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 #, fuzzy
 msgid "Remove Lyric"
 msgstr "Ukloni"
@@ -1663,8 +1664,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "naslov"
 
@@ -1683,8 +1684,8 @@ msgstr "Odabrano je previše datoteka"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "pjesma"
 
@@ -1698,8 +1699,8 @@ msgstr "Pjesma"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "broj pjesama"
 
@@ -1848,8 +1849,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "godina"
 

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -176,8 +176,8 @@ msgstr "Informazioni sulla ricerca avanzata"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -201,8 +201,8 @@ msgstr "Artista dell'album"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "artistaalbum"
 
@@ -273,8 +273,8 @@ msgstr "Applicare le modifiche?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artista"
 
@@ -311,15 +311,15 @@ msgstr "Battiti al minuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "battitialminuto"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -394,8 +394,8 @@ msgstr "Chiudi la libreria"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "commento"
 
@@ -406,8 +406,8 @@ msgstr "Commento"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "compositore"
 
@@ -537,8 +537,8 @@ msgstr "Salvataggio delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "descrizione"
 
@@ -607,15 +607,15 @@ msgstr "Cancellazione delle etichette in corso…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "traccetotali"
@@ -792,8 +792,8 @@ msgstr ""
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -959,8 +959,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "genere"
 
@@ -1086,7 +1086,7 @@ msgstr[1] "Caricati {0} brani."
 msgid "Loading music files from library..."
 msgstr "Caricamento dei brani dalla libreria…"
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "testo"
 
@@ -1385,8 +1385,8 @@ msgstr "Nome della proprietà"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "etichetta"
 
@@ -1403,8 +1403,8 @@ msgstr "Etichetta"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "etichetta"
@@ -1447,6 +1447,7 @@ msgid "Remove from Playlist"
 msgstr "Rimuovi dalla playlist"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Rimuovi testo"
 
@@ -1654,8 +1655,8 @@ msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "titolo"
 
@@ -1674,8 +1675,8 @@ msgstr "Sono stati selezionati troppi file"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "traccia"
 
@@ -1689,8 +1690,8 @@ msgstr "Numero della traccia"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "traccetotali"
 
@@ -1841,8 +1842,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "anno"
 

--- a/NickvisionTagger.Shared/Resources/po/it.po
+++ b/NickvisionTagger.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-09-15 13:28+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-"
@@ -143,7 +143,7 @@ msgstr "Chiave delle API di AcoustId dell'utente"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -207,7 +207,7 @@ msgid "albumartist"
 msgstr "artistaalbum"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 #, fuzzy
 msgid "All files"
@@ -346,7 +346,6 @@ msgstr "Elaborazione in corso…"
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -372,7 +371,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Cancella tutto il testo"
@@ -792,13 +791,13 @@ msgstr ""
 msgid "Error"
 msgstr "Errore"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "ERRORE"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Testo esistente"
 
@@ -826,7 +825,7 @@ msgid "Export Front Album Art"
 msgstr "Esporta copertina (fronte)"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Esporta in LRC"
@@ -840,7 +839,7 @@ msgid "Exported front album art to file successfully"
 msgstr "La copertina anteriore è stata esportata correttamente"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Esportazione completata con successo su: {0}"
 
@@ -1012,7 +1011,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Importa da LRC"
@@ -1057,7 +1056,7 @@ msgid "Inserting album art..."
 msgstr "Inserimento della copertina..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Mantieni il testo di Tagger"
 
@@ -1153,7 +1152,6 @@ msgid "New Custom Property"
 msgstr "Nuova proprietà personalizzata"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Nuovo testo sincronizzato"
 
@@ -1649,7 +1647,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Istante (hh:mm:ss oppure mm:ss:xx)"
 
@@ -1733,7 +1731,7 @@ msgid "Unable to download and install update."
 msgstr "Caricamento del file immagine non riuscito"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "Esportazione in LRC non riuscita."
 
@@ -1744,7 +1742,7 @@ msgid "Unable to fix file"
 msgstr "Caricamento del file immagine non riuscito"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Importazione da LRC non riuscita."
 
@@ -1785,7 +1783,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Usa il testo da LRC"
 
@@ -1812,7 +1810,7 @@ msgid "Web Services"
 msgstr "Servizi in rete"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -175,8 +175,8 @@ msgstr "Geavanceerd zoeken"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -200,8 +200,8 @@ msgstr "Albumartiest"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "albumartiest"
 
@@ -272,8 +272,8 @@ msgstr "Wijzigingen toepassen?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artiest"
 
@@ -310,15 +310,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "bpm"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -393,8 +393,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "opmerking"
 
@@ -405,8 +405,8 @@ msgstr "Opmerking"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "componist"
 
@@ -532,8 +532,8 @@ msgstr "Bezig met verwijderen van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "omschrijving"
 
@@ -603,15 +603,15 @@ msgstr "Bezig met opslaan van tags…"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 #, fuzzy
 msgid "disctotal"
 msgstr "aantalnummers"
@@ -784,8 +784,8 @@ msgstr ""
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -956,8 +956,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "genre"
 
@@ -1087,7 +1087,7 @@ msgstr[1] "Er zijn %d muziekbestanden geladen."
 msgid "Loading music files from library..."
 msgstr "Bezig met laden van muziekbestanden…"
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 #, fuzzy
 msgid "lyrics"
 msgstr "Songtekst"
@@ -1395,8 +1395,8 @@ msgstr "Eigenschaps­naam"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "uitgever"
 
@@ -1413,8 +1413,8 @@ msgstr "Uitgever"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 #, fuzzy
 msgid "publishingdate"
 msgstr "uitgever"
@@ -1458,6 +1458,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Songtekst verwijderen"
 
@@ -1669,8 +1670,8 @@ msgstr "Tijdstempel (uu:mm:ss)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "titel"
 
@@ -1689,8 +1690,8 @@ msgstr "Teveel bestanden geselecteerd"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "nummer"
 
@@ -1704,8 +1705,8 @@ msgstr "Volgnummer"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "aantalnummers"
 
@@ -1848,8 +1849,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "jaar"
 

--- a/NickvisionTagger.Shared/Resources/po/nl.po
+++ b/NickvisionTagger.Shared/Resources/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-08-13 09:57+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -143,7 +143,7 @@ msgstr "AcoustId-api-sleutel"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -206,7 +206,7 @@ msgid "albumartist"
 msgstr "albumartiest"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 #, fuzzy
 msgid "All files"
@@ -345,7 +345,6 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -371,7 +370,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr ""
@@ -784,13 +783,13 @@ msgstr ""
 msgid "Error"
 msgstr "Fout"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "FOUT"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 #, fuzzy
 msgid "Existing Lyrics"
 msgstr "Songtekst beheren"
@@ -821,7 +820,7 @@ msgid "Export Front Album Art"
 msgstr "Albumhoes toevoegen"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 #, fuzzy
 msgid "Export to LRC"
@@ -838,7 +837,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Er zijn %d tags omgezet in bestandsnamen"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -1009,7 +1008,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr ""
@@ -1057,7 +1056,7 @@ msgid "Inserting album art..."
 msgstr "Bezig met toevoegen van albumhoes…"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1155,7 +1154,6 @@ msgid "New Custom Property"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1663,7 +1661,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 #, fuzzy
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Tijdstempel (uu:mm:ss)"
@@ -1743,7 +1741,7 @@ msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr ""
 
@@ -1753,7 +1751,7 @@ msgid "Unable to fix file"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr ""
 
@@ -1794,7 +1792,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr ""
 
@@ -1821,7 +1819,7 @@ msgid "Web Services"
 msgstr "Online-diensten"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -136,7 +136,7 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -199,7 +199,7 @@ msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr ""
@@ -336,7 +336,6 @@ msgstr "Wyliczanie..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -362,7 +361,7 @@ msgstr "Dziennik zmian"
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr ""
@@ -757,13 +756,13 @@ msgstr ""
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "BŁĄD"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr ""
 
@@ -791,7 +790,7 @@ msgid "Export Front Album Art"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr ""
@@ -805,7 +804,7 @@ msgid "Exported front album art to file successfully"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -970,7 +969,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr ""
@@ -1015,7 +1014,7 @@ msgid "Inserting album art..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1109,7 +1108,6 @@ msgid "New Custom Property"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1583,7 +1581,7 @@ msgid "TiB"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
@@ -1661,7 +1659,7 @@ msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr ""
 
@@ -1671,7 +1669,7 @@ msgid "Unable to fix file"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr ""
 
@@ -1711,7 +1709,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr ""
 
@@ -1738,7 +1736,7 @@ msgid "Web Services"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/pl.po
+++ b/NickvisionTagger.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-13 19:00+0000\n"
 "Last-Translator: Eryk Michalak <gnu.ewm@protonmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-tagger/"
@@ -168,8 +168,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -193,8 +193,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr ""
 
@@ -263,8 +263,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artysta"
 
@@ -301,15 +301,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -383,8 +383,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr ""
 
@@ -395,8 +395,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "kompozytor"
 
@@ -519,8 +519,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "opis"
 
@@ -588,15 +588,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr ""
 
@@ -757,8 +757,8 @@ msgstr ""
 msgid "Error"
 msgstr "Błąd"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -918,8 +918,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "gatunek"
 
@@ -1044,7 +1044,7 @@ msgstr[1] ""
 msgid "Loading music files from library..."
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "tekst"
 
@@ -1332,8 +1332,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr ""
 
@@ -1349,8 +1349,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr ""
 
@@ -1391,6 +1391,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr ""
 
@@ -1588,8 +1589,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr ""
 
@@ -1608,8 +1609,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr ""
 
@@ -1623,8 +1624,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr ""
 
@@ -1765,8 +1766,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-11-07 03:13+0000\n"
 "Last-Translator: 0que <0que@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/"
-"nickvision-tagger/app/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
+"tagger/app/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -144,7 +144,7 @@ msgstr "Ключ API пользователя AcoustId"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -176,8 +176,8 @@ msgstr "Информация по продвинутому поиску"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "альбом"
 
@@ -201,13 +201,13 @@ msgstr "Исполнитель альбома"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "альбомартист"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Все файлы"
@@ -271,8 +271,8 @@ msgstr "Применить изменения?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artist"
 
@@ -309,15 +309,15 @@ msgstr "Ударов в минуту"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -344,7 +344,6 @@ msgstr "Вычисление..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -370,7 +369,7 @@ msgstr "Список изменений"
 msgid "Check for Updates"
 msgstr "Проверить обновления"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Очистить весь текст"
@@ -391,8 +390,8 @@ msgstr "Закрыть библиотеку"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "комментарий"
 
@@ -403,8 +402,8 @@ msgstr "Комментарий"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "композитор"
 
@@ -530,8 +529,8 @@ msgstr "Удаление тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "описание"
 
@@ -609,15 +608,15 @@ msgstr "Отбраковка тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "номер диска"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "количество дисков"
 
@@ -785,13 +784,13 @@ msgstr "Введите год"
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "ОШИБКА"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Существующий текст"
 
@@ -819,7 +818,7 @@ msgid "Export Front Album Art"
 msgstr "Экспортировать переднюю обложку альбома"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "Экспорт в LRC"
@@ -833,7 +832,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Успешно экспортированы в файл передние обложки альбомов"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Успешно экспортировано в: {0}"
 
@@ -945,8 +944,8 @@ msgstr "Фёдор Соболев"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "жанр"
 
@@ -997,7 +996,7 @@ msgid "Hide Extras Pane"
 msgstr "Скрыть панель дополнительных настроек"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "Импорт из LRC"
@@ -1042,7 +1041,7 @@ msgid "Inserting album art..."
 msgstr "Добавление обложки альбома..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Оставить текст Tagger"
 
@@ -1072,7 +1071,7 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "текст"
 
@@ -1137,7 +1136,6 @@ msgid "New Custom Property"
 msgstr "Новое пользовательское свойство"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Новый синхронизированный текст"
 
@@ -1362,8 +1360,8 @@ msgstr "Имя свойства"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "издатель"
 
@@ -1379,8 +1377,8 @@ msgstr "Дата публикации"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "датапубликации"
 
@@ -1421,6 +1419,7 @@ msgid "Remove from Playlist"
 msgstr "Удалить из плейлиста"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
@@ -1618,14 +1617,14 @@ msgid "TiB"
 msgstr "ТиБ"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "название"
 
@@ -1644,8 +1643,8 @@ msgstr "Выбрано слишком много файлов"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "трек"
 
@@ -1659,8 +1658,8 @@ msgstr "Номер трека"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "количестводорожек"
 
@@ -1698,7 +1697,7 @@ msgid "Unable to download and install update."
 msgstr "Не удалось загрузить и установить обновление."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "Невозможно экспортировать в LRC."
 
@@ -1708,7 +1707,7 @@ msgid "Unable to fix file"
 msgstr "Не удалось исправить файл"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "Невозможно импортировать из LRC."
 
@@ -1748,7 +1747,7 @@ msgid "Update"
 msgstr "Обновить"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "Использовать текст из LRC"
 
@@ -1775,7 +1774,7 @@ msgid "Web Services"
 msgstr "Веб-сервисы"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"
@@ -1810,8 +1809,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "год"
 

--- a/NickvisionTagger.Shared/Resources/po/ru.po
+++ b/NickvisionTagger.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.nickvision.tagger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-23 17:02+0000\n"
 "Last-Translator: 0que <0que@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-"
@@ -176,8 +176,8 @@ msgstr "Информация по продвинутому поиску"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "альбом"
 
@@ -201,8 +201,8 @@ msgstr "Исполнитель альбома"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "альбомартист"
 
@@ -271,8 +271,8 @@ msgstr "Применить изменения?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "artist"
 
@@ -309,15 +309,15 @@ msgstr "Ударов в минуту"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "удароввминуту"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -391,8 +391,8 @@ msgstr "Закрыть библиотеку"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "комментарий"
 
@@ -403,8 +403,8 @@ msgstr "Комментарий"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "композитор"
 
@@ -530,8 +530,8 @@ msgstr "Удаление тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "описание"
 
@@ -609,15 +609,15 @@ msgstr "Отбраковка тегов..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "номер диска"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "количество дисков"
 
@@ -785,8 +785,8 @@ msgstr "Введите год"
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -947,8 +947,8 @@ msgstr "Фёдор Соболев"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "жанр"
 
@@ -1074,7 +1074,7 @@ msgstr[2] "Загружено {0} музыкальных файлов."
 msgid "Loading music files from library..."
 msgstr "Загрузка музыкальных файлов из библиотеки..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "текст"
 
@@ -1364,8 +1364,8 @@ msgstr "Имя свойства"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "издатель"
 
@@ -1381,8 +1381,8 @@ msgstr "Дата публикации"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "датапубликации"
 
@@ -1423,6 +1423,7 @@ msgid "Remove from Playlist"
 msgstr "Удалить из плейлиста"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Удалить текст"
 
@@ -1626,8 +1627,8 @@ msgstr "Временная метка (hh:mm:ss или mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "название"
 
@@ -1646,8 +1647,8 @@ msgstr "Выбрано слишком много файлов"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "трек"
 
@@ -1661,8 +1662,8 @@ msgstr "Номер трека"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "количестводорожек"
 
@@ -1813,8 +1814,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "год"
 

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,8 +166,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr ""
 
@@ -191,8 +191,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr ""
 
@@ -261,8 +261,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr ""
 
@@ -299,15 +299,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr ""
 
@@ -381,8 +381,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr ""
 
@@ -393,8 +393,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr ""
 
@@ -517,8 +517,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr ""
 
@@ -585,15 +585,15 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr ""
 
@@ -754,8 +754,8 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr ""
 
@@ -914,8 +914,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr[1] ""
 msgid "Loading music files from library..."
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr ""
 
@@ -1328,8 +1328,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr ""
 
@@ -1345,8 +1345,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr ""
 
@@ -1387,6 +1387,7 @@ msgid "Remove from Playlist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr ""
 
@@ -1584,8 +1585,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr ""
 
@@ -1604,8 +1605,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr ""
 
@@ -1619,8 +1620,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr ""
 
@@ -1761,8 +1762,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr ""
 

--- a/NickvisionTagger.Shared/Resources/po/tagger.pot
+++ b/NickvisionTagger.Shared/Resources/po/tagger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,7 +134,7 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -197,7 +197,7 @@ msgid "albumartist"
 msgstr ""
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr ""
@@ -334,7 +334,6 @@ msgstr ""
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -360,7 +359,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr ""
@@ -754,13 +753,13 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr ""
 
@@ -788,7 +787,7 @@ msgid "Export Front Album Art"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr ""
@@ -802,7 +801,7 @@ msgid "Exported front album art to file successfully"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr ""
 
@@ -966,7 +965,7 @@ msgid "Hide Extras Pane"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr ""
@@ -1011,7 +1010,7 @@ msgid "Inserting album art..."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr ""
 
@@ -1105,7 +1104,6 @@ msgid "New Custom Property"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr ""
 
@@ -1579,7 +1577,7 @@ msgid "TiB"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr ""
 
@@ -1657,7 +1655,7 @@ msgid "Unable to download and install update."
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr ""
 
@@ -1667,7 +1665,7 @@ msgid "Unable to fix file"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr ""
 
@@ -1707,7 +1705,7 @@ msgid "Update"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr ""
 
@@ -1734,7 +1732,7 @@ msgid "Web Services"
 msgstr ""
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 16:44-0500\n"
+"POT-Creation-Date: 2023-11-06 22:15-0500\n"
 "PO-Revision-Date: 2023-10-23 03:05+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -142,7 +142,7 @@ msgstr "AcoustId Kullanıcı API Anahtarı"
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1161
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:54
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:145
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:217
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1106
@@ -205,7 +205,7 @@ msgid "albumartist"
 msgstr "albümsanatçısı"
 
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:101
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:298
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:296
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:1067
 msgid "All files"
 msgstr "Tüm Dosyalar"
@@ -342,7 +342,6 @@ msgstr "Hesaplanıyor..."
 #: ../../../../NickvisionTagger.GNOME/Views/MainWindow.cs:1291
 #: ../../../../NickvisionTagger.WinUI/Controls/CreatePlaylistDialog.xaml.cs:34
 #: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:41
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:304
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:578
 #: ../../../../NickvisionTagger.WinUI/Views/MainWindow.xaml.cs:613
@@ -368,7 +367,7 @@ msgstr "Değişiklik günlüğü"
 msgid "Check for Updates"
 msgstr "Güncellemeleri Denetle"
 
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:137
 msgid "Clear All Lyrics"
 msgstr "Tüm Şarkı Sözlerini Temizle"
@@ -781,13 +780,13 @@ msgstr "Yılı buraya girin"
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
-#: ../../../Models/MusicFile.cs:1080
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:919
+#: ../../../Models/MusicFile.cs:1084
 msgid "ERROR"
 msgstr "HATA"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:257
 msgid "Existing Lyrics"
 msgstr "Var Olan Şarkı Sözleri"
 
@@ -815,7 +814,7 @@ msgid "Export Front Album Art"
 msgstr "Albüm Ön Kapağını Dışa Aktar"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:323
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:57
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:59
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:151
 msgid "Export to LRC"
 msgstr "LRC'ye Dışa Aktar"
@@ -829,7 +828,7 @@ msgid "Exported front album art to file successfully"
 msgstr "Albüm ön kapağı dosyaya dışa aktarıldı"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:341
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:310
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:308
 msgid "Exported successfully to: {0}"
 msgstr "Dışa aktarıldı: {0}"
 
@@ -995,7 +994,7 @@ msgid "Hide Extras Pane"
 msgstr "İlaveler Panelini Gizle"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:268
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:56
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:58
 #: NickvisionTagger.GNOME/Blueprints/lyrics_dialog.blp:144
 msgid "Import from LRC"
 msgstr "LRC'den İçe Aktar"
@@ -1040,7 +1039,7 @@ msgid "Inserting album art..."
 msgstr "Albüm kapağı ekleniyor..."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:281
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:261
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:259
 msgid "Keep Tagger's lyrics"
 msgstr "Tagger Şarkı Sözlerini Tut"
 
@@ -1134,7 +1133,6 @@ msgid "New Custom Property"
 msgstr "Yeni Özel Özellik"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
 msgid "New Synchronized Lyric"
 msgstr "Yeni Eşitlenmiş Şarkı Sözleri"
 
@@ -1616,7 +1614,7 @@ msgid "TiB"
 msgstr "TiB"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:241
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:216
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:55
 msgid "Timestamp (hh:mm:ss or mm:ss.xx)"
 msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
@@ -1695,7 +1693,7 @@ msgid "Unable to download and install update."
 msgstr "Güncellemeler indirilip kurulamadı."
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:345
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:316
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:314
 msgid "Unable to export to LRC."
 msgstr "LRC'ye dışa aktarılamıyor."
 
@@ -1706,7 +1704,7 @@ msgid "Unable to fix file"
 msgstr "Resim dosyası yüklenemedi"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:294
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:281
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:279
 msgid "Unable to import from LRC."
 msgstr "LRC'den içe aktarılamıyor."
 
@@ -1746,7 +1744,7 @@ msgid "Update"
 msgstr "Güncelle"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:284
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:262
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
 msgid "Use LRC's lyrics"
 msgstr "LRC şarkı sözlerini kullan"
 
@@ -1773,7 +1771,7 @@ msgid "Web Services"
 msgstr "Web Servisleri"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:279
-#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:260
+#: ../../../../NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs:258
 msgid ""
 "What would you like Tagger to do with lyrics found from the LRC file that "
 "conflict with existing lyrics of the same timestamp?"

--- a/NickvisionTagger.Shared/Resources/po/tr.po
+++ b/NickvisionTagger.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-05 13:06-0500\n"
+"POT-Creation-Date: 2023-11-06 16:44-0500\n"
 "PO-Revision-Date: 2023-10-23 03:05+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-"
@@ -174,8 +174,8 @@ msgstr "Gelişmiş Arama Bilgisi"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1355
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:701
-#: ../../../Models/MusicFile.cs:828
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:707
+#: ../../../Models/MusicFile.cs:834
 msgid "album"
 msgstr "album"
 
@@ -199,8 +199,8 @@ msgstr "Albüm Sanatçısı"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1404
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:729
-#: ../../../Models/MusicFile.cs:844
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:735
+#: ../../../Models/MusicFile.cs:850
 msgid "albumartist"
 msgstr "albümsanatçısı"
 
@@ -269,8 +269,8 @@ msgstr "Değişiklikler Uygulansın Mı?"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1351
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:697
-#: ../../../Models/MusicFile.cs:824
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:703
+#: ../../../Models/MusicFile.cs:830
 msgid "artist"
 msgstr "sanatçı"
 
@@ -307,15 +307,15 @@ msgstr "Dakika Başına Vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "beatsperminute"
 msgstr "dakika başına vuruş"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1416
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:741
-#: ../../../Models/MusicFile.cs:856
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:747
+#: ../../../Models/MusicFile.cs:862
 msgid "bpm"
 msgstr "bpm"
 
@@ -389,8 +389,8 @@ msgstr "Kitaplığı Kapat"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1412
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:737
-#: ../../../Models/MusicFile.cs:852
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:743
+#: ../../../Models/MusicFile.cs:858
 msgid "comment"
 msgstr "yorum"
 
@@ -401,8 +401,8 @@ msgstr "Yorum"
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1431
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:749
-#: ../../../Models/MusicFile.cs:860
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:755
+#: ../../../Models/MusicFile.cs:866
 msgid "composer"
 msgstr "besteci"
 
@@ -525,8 +525,8 @@ msgstr "Etiketler siliniyor..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1435
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:753
-#: ../../../Models/MusicFile.cs:864
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:759
+#: ../../../Models/MusicFile.cs:870
 msgid "description"
 msgstr "açıklama"
 
@@ -604,15 +604,15 @@ msgstr "Etiketler gözden çıkarılıyor..."
 
 #: ../../../Controllers/MainWindowController.cs:191
 #: ../../../Controllers/MainWindowController.cs:1439
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:757
-#: ../../../Models/MusicFile.cs:868
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:763
+#: ../../../Models/MusicFile.cs:874
 msgid "discnumber"
 msgstr "disk numarası"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1454
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:765
-#: ../../../Models/MusicFile.cs:872
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:771
+#: ../../../Models/MusicFile.cs:878
 msgid "disctotal"
 msgstr "toplamdisk"
 
@@ -781,8 +781,8 @@ msgstr "Yılı buraya girin"
 msgid "Error"
 msgstr "Hata"
 
-#: ../../../Models/MusicFile.cs:446 ../../../Models/MusicFile.cs:909
-#: ../../../Models/MusicFile.cs:1074
+#: ../../../Models/MusicFile.cs:447 ../../../Models/MusicFile.cs:915
+#: ../../../Models/MusicFile.cs:1080
 msgid "ERROR"
 msgstr "HATA"
 
@@ -943,8 +943,8 @@ msgstr "Fyodor Sobolev"
 
 #: ../../../Controllers/MainWindowController.cs:190
 #: ../../../Controllers/MainWindowController.cs:1408
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:733
-#: ../../../Models/MusicFile.cs:848
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:739
+#: ../../../Models/MusicFile.cs:854
 msgid "genre"
 msgstr "tür"
 
@@ -1069,7 +1069,7 @@ msgstr[1] "{0} müzik dosyası yüklendi."
 msgid "Loading music files from library..."
 msgstr "Müzik dosyaları kitaplıktan yükleniyor..."
 
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:816
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:822
 msgid "lyrics"
 msgstr "şarkı sözleri"
 
@@ -1359,8 +1359,8 @@ msgstr "Özellik Adı"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1469
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:773
-#: ../../../Models/MusicFile.cs:876
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:779
+#: ../../../Models/MusicFile.cs:882
 msgid "publisher"
 msgstr "yayımcı"
 
@@ -1376,8 +1376,8 @@ msgstr "Yayım Tarihi"
 
 #: ../../../Controllers/MainWindowController.cs:192
 #: ../../../Controllers/MainWindowController.cs:1473
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:777
-#: ../../../Models/MusicFile.cs:880
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:783
+#: ../../../Models/MusicFile.cs:886
 msgid "publishingdate"
 msgstr "yayım tarihi"
 
@@ -1418,6 +1418,7 @@ msgid "Remove from Playlist"
 msgstr "Çalma Listesinden Kaldır"
 
 #: ../../../../NickvisionTagger.GNOME/Views/LyricsDialog.cs:183
+#: ../../../../NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs:34
 msgid "Remove Lyric"
 msgstr "Şarkı Sözünü Kaldır"
 
@@ -1621,8 +1622,8 @@ msgstr "Zaman damgası (hh:mm:ss ya da mm:ss.xx)"
 
 #: ../../../Controllers/MainWindowController.cs:188
 #: ../../../Controllers/MainWindowController.cs:1347
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:693
-#: ../../../Models/MusicFile.cs:820
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:699
+#: ../../../Models/MusicFile.cs:826
 msgid "title"
 msgstr "başlık"
 
@@ -1641,8 +1642,8 @@ msgstr "Çok Fazla Dosya Seçildi"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1374
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:713
-#: ../../../Models/MusicFile.cs:836
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:719
+#: ../../../Models/MusicFile.cs:842
 msgid "track"
 msgstr "parça"
 
@@ -1656,8 +1657,8 @@ msgstr "Parça"
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1389
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:721
-#: ../../../Models/MusicFile.cs:840
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:727
+#: ../../../Models/MusicFile.cs:846
 msgid "tracktotal"
 msgstr "toplamparça"
 
@@ -1808,8 +1809,8 @@ msgstr ""
 
 #: ../../../Controllers/MainWindowController.cs:189
 #: ../../../Controllers/MainWindowController.cs:1359
-#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:705
-#: ../../../Models/MusicFile.cs:832
+#: ../../../Models/MusicFile.cs:81 ../../../Models/MusicFile.cs:711
+#: ../../../Models/MusicFile.cs:838
 msgid "year"
 msgstr "yıl"
 

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -39,12 +39,9 @@
     <binary>org.nickvision.tagger</binary>
   </provides>
   <releases>
-    <release version="2023.11.1" date="2023-11-05">
+    <release version="2023.11.2-next" date="2023-11-05">
       <description translatable="no">
-        <p>- Added the ability to specify ""/"" in a Tag to File Name format string to move files to a new directory when renaming files</p>
-        <p>- Tagger now has the ability to fix corrupted file right from within the app</p>
-        <p>- Tagger will now display files with corrupted album art as corrupted files</p>
-        <p>- Fixed an issue where some custom properties for vorbis and wav files could not be removed</p>
+        <p>- Fixed an issue where specifying the directory separator in Tag to File Name when Limit Filename Characters was enabled caused new directories to not be made</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>

--- a/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/org.nickvision.tagger.metainfo.xml.in
@@ -41,7 +41,8 @@
   <releases>
     <release version="2023.11.2-next" date="2023-11-05">
       <description translatable="no">
-        <p>- Fixed an issue where specifying the directory separator in Tag to File Name when Limit Filename Characters was enabled caused new directories to not be made</p>
+        <p>- On GNOME, fixed an issue where specifying the directory separator in Tag to File Name when Limit Filename Characters was enabled caused new directories to not be made</p>
+        <p>- On WinUI, improved the UX of the Lyrics dialog</p>
         <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>

--- a/NickvisionTagger.WinUI/App.xaml.cs
+++ b/NickvisionTagger.WinUI/App.xaml.cs
@@ -23,7 +23,8 @@ public partial class App : Application
         InitializeComponent();
         _controller = new MainWindowController(Array.Empty<string>());
         _controller.AppInfo.Changelog =
-            @"- Updated translations (Thanks everyone on Weblate!)";
+            @"- Improved the UX of the LyricsDialog
+- Updated translations (Thanks everyone on Weblate!)";
         if (_controller.Theme != Theme.System)
         {
             RequestedTheme = _controller.Theme switch

--- a/NickvisionTagger.WinUI/App.xaml.cs
+++ b/NickvisionTagger.WinUI/App.xaml.cs
@@ -23,7 +23,7 @@ public partial class App : Application
         InitializeComponent();
         _controller = new MainWindowController(Array.Empty<string>());
         _controller.AppInfo.Changelog =
-            @"- Improved the UX of the LyricsDialog
+            @"- Improved the UX of the Lyrics dialog
 - Updated translations (Thanks everyone on Weblate!)";
         if (_controller.Theme != Theme.System)
         {

--- a/NickvisionTagger.WinUI/App.xaml.cs
+++ b/NickvisionTagger.WinUI/App.xaml.cs
@@ -23,11 +23,7 @@ public partial class App : Application
         InitializeComponent();
         _controller = new MainWindowController(Array.Empty<string>());
         _controller.AppInfo.Changelog =
-            @"- Added the ability to specify ""\"" in a Tag to File Name format string to move files to a new directory when renaming files
-- Tagger now has the ability to fix corrupted file right from within the app
-- Tagger will now display files with corrupted album art as corrupted files
-- Fixed an issue where some custom properties for vorbis and wav files could not be removed
-- Updated translations (Thanks everyone on Weblate!)";
+            @"- Updated translations (Thanks everyone on Weblate!)";
         if (_controller.Theme != Theme.System)
         {
             RequestedTheme = _controller.Theme switch

--- a/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml
+++ b/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml
@@ -13,12 +13,6 @@
         <StackPanel Orientation="Horizontal" Spacing="6">
             <TextBox x:Name="TxtLyric" Width="274" IsSpellCheckEnabled="True" TextChanged="TxtLyric_TextChanged"/>
 
-            <Button x:Name="BtnApply" Height="32" VerticalAlignment="Center" IsEnabled="False" Click="Apply">
-                <Button.Content>
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE73E;"/>
-                </Button.Content>
-            </Button>
-
             <Button x:Name="BtnRemove" Height="32" VerticalAlignment="Center" Click="Remove">
                 <Button.Content>
                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE108;"/>

--- a/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using NickvisionTagger.Shared.Events;
 using NickvisionTagger.Shared.Helpers;
 using System;
+using static Nickvision.Aura.Localization.Gettext;
 
 namespace NickvisionTagger.WinUI.Controls;
 
@@ -29,6 +30,8 @@ public sealed partial class SyncLyricRow : UserControl
         InitializeComponent();
         Card.Header = e.Timestamp.MillisecondsToTimecode();
         TxtLyric.Text = e.Lyric;
+        //Localize Strings
+        ToolTipService.SetToolTip(BtnRemove, _("Remove Lyric"));
     }
 
     /// <summary>

--- a/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs
+++ b/NickvisionTagger.WinUI/Controls/SyncLyricRow.xaml.cs
@@ -12,9 +12,9 @@ namespace NickvisionTagger.WinUI.Controls;
 public sealed partial class SyncLyricRow : UserControl
 {
     /// <summary>
-    /// Occurs when a lyric's text is applied
+    /// Occurs when a lyric's text is changed
     /// </summary>
-    public event EventHandler<string>? LyricApplied;
+    public event EventHandler<string>? LyricChanged;
     /// <summary>
     /// Occurs when a lyric is to be removed
     /// </summary>
@@ -36,14 +36,7 @@ public sealed partial class SyncLyricRow : UserControl
     /// </summary>
     /// <param name="sender">object</param>
     /// <param name="e">TextChangedEventArgs</param>
-    private void TxtLyric_TextChanged(object sender, TextChangedEventArgs e) => BtnApply.IsEnabled = !string.IsNullOrEmpty(TxtLyric.Text);
-
-    /// <summary>
-    /// Occurs when the apply button is clicked
-    /// </summary>
-    /// <param name="sender">object</param>
-    /// <param name="e">RoutedEventArgs</param>
-    private void Apply(object sender, RoutedEventArgs e) => LyricApplied?.Invoke(this, TxtLyric.Text);
+    private void TxtLyric_TextChanged(object sender, TextChangedEventArgs e) => LyricChanged?.Invoke(this, TxtLyric.Text);
 
     /// <summary>
     /// Occurs when the remove button is clicked

--- a/NickvisionTagger.WinUI/Installer/InnoSetupScript.iss
+++ b/NickvisionTagger.WinUI/Installer/InnoSetupScript.iss
@@ -3,7 +3,7 @@
 
 #define MyAppName "Nickvision Tagger"
 #define MyAppShortName "Tagger"
-#define MyAppVersion "2023.11.1"
+#define MyAppVersion "2023.11.2"
 #define MyAppPublisher "Nickvision"
 #define MyAppURL "https://nickvision.org"
 #define MyAppExeName "NickvisionTagger.WinUI.exe"

--- a/NickvisionTagger.WinUI/Installer/InnoSetupScript.iss
+++ b/NickvisionTagger.WinUI/Installer/InnoSetupScript.iss
@@ -33,13 +33,14 @@ SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=admin
 DirExistsWarning=no
+CloseApplications=force
 
 [Code]
 procedure SetupDotnet();
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\deps\dotnet-runtime-7.0.11-win-x64.exe'), '/install /quiet /norestart', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode)
+  if not Exec(ExpandConstant('{app}\deps\dotnet-runtime-7.0.11-win-x64.exe'), '/install /quiet /norestart', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   then
     MsgBox('Unable to install .NET . Please try again', mbError, MB_OK);
 end;
@@ -48,7 +49,7 @@ procedure SetupWinAppSDK();
 var
   ResultCode: Integer;
 begin
-  if not Exec(ExpandConstant('{app}\deps\WindowsAppRuntimeInstall-x64.exe'), '--quiet', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode)
+  if not Exec(ExpandConstant('{app}\deps\WindowsAppRuntimeInstall-x64.exe'), '--quiet', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
   then
     MsgBox('Unable to install Windows App SDK. Please try again', mbError, MB_OK);
 end;

--- a/NickvisionTagger.WinUI/NickvisionTagger.WinUI.csproj
+++ b/NickvisionTagger.WinUI/NickvisionTagger.WinUI.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.17" />
-    <PackageReference Include="Nickvision.Aura" Version="2023.10.2" />
+    <PackageReference Include="Nickvision.Aura" Version="2023.11.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/NickvisionTagger.WinUI/Views/LyricsDialog.xaml
+++ b/NickvisionTagger.WinUI/Views/LyricsDialog.xaml
@@ -11,7 +11,7 @@
     mc:Ignorable="d" Style="{StaticResource DefaultContentDialogStyle}"
     DefaultButton="Primary" Loaded="Dialog_Loaded">
 
-    <ScrollViewer x:Name="ScrollViewer" VerticalScrollBarVisibility="Auto" MinWidth="500" SizeChanged="ScrollViewer_SizeChanged">
+    <ScrollViewer x:Name="ScrollViewer" VerticalScrollBarVisibility="Auto" MinWidth="600" SizeChanged="ScrollViewer_SizeChanged">
         <StackPanel x:Name="StackPanel" Orientation="Vertical" Spacing="6">
             <TextBlock x:Name="LblConfigure" Style="{StaticResource NavigationViewItemHeaderTextStyle}"/>
             
@@ -64,7 +64,7 @@
                 <TextBlock x:Name="LblEdit" VerticalAlignment="Center" Style="{StaticResource NavigationViewItemHeaderTextStyle}"/>
 
                 <StackPanel x:Name="SyncControls" Grid.Column="1" Orientation="Horizontal" Spacing="6">
-                    <Button x:Name="BtnAddSyncLyric" Click="AddSyncLyric">
+                    <Button x:Name="BtnAddSyncLyric">
                         <Button.Content>
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="16" Glyph="&#xE710;"/>
@@ -72,6 +72,16 @@
                                 <TextBlock x:Name="LblBtnAddSyncLyric" TextWrapping="WrapWholeWords"/>
                             </StackPanel>
                         </Button.Content>
+
+                        <Button.Flyout>
+                            <Flyout x:Name="FlyoutAddSyncLyric" Placement="Bottom">
+                                <StackPanel Orientation="Vertical" Spacing="6">
+                                    <TextBox x:Name="TxtAddSyncLyric" MinWidth="200" TextChanged="TxtAddSyncLyric_TextChanged"/>
+
+                                    <Button x:Name="BtnAddSyncLyricConfirm" Style="{ThemeResource AccentButtonStyle}" Click="AddSyncLyric"/>
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
                     </Button>
 
                     <Button x:Name="BtnClearAllSyncLyrics" Height="32" Click="ClearAllSyncLyrics">

--- a/NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs
+++ b/NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs
@@ -52,6 +52,8 @@ public sealed partial class LyricsDialog : ContentDialog
         ToolTipService.SetToolTip(BtnApplyOffset, _("Apply"));
         LblEdit.Text = _("Edit");
         LblBtnAddSyncLyric.Text = _("Add");
+        TxtAddSyncLyric.Header = _("Timestamp (hh:mm:ss or mm:ss.xx)");
+        BtnAddSyncLyricConfirm.Content = _("Add");
         ToolTipService.SetToolTip(BtnClearAllSyncLyrics, _("Clear All Lyrics"));
         ToolTipService.SetToolTip(BtnImportLRC, _("Import from LRC"));
         ToolTipService.SetToolTip(BtnExportLRC, _("Export to LRC"));
@@ -207,28 +209,24 @@ public sealed partial class LyricsDialog : ContentDialog
     }
 
     /// <summary>
+    /// Occurs when TxtAddSyncLyric's text is changed
+    /// </summary>
+    /// <param name="sender">object</param>
+    /// <param name="e">TextChangedEventArgs</param>
+    private void TxtAddSyncLyric_TextChanged(object sender, TextChangedEventArgs e) => BtnAddSyncLyricConfirm.IsEnabled = TxtAddSyncLyric.Text.TimecodeToMs() != -1;
+
+    /// <summary>
     /// Occurs when the add sync lyric button is clicked
     /// </summary>
     /// <param name="sender">object</param>
     /// <param name="e">RoutedEventArgs</param>
-    private async void AddSyncLyric(object sender, RoutedEventArgs e)
+    private void AddSyncLyric(object sender, RoutedEventArgs e)
     {
-        var entryDialog = new EntryDialog(_("New Synchronized Lyric"), "", _("Timestamp (hh:mm:ss or mm:ss.xx)"), _("Cancel"), _("Add"))
+        FlyoutAddSyncLyric.Hide();
+        var ms = TxtAddSyncLyric.Text.TimecodeToMs();
+        if (ms != -1)
         {
-            Validator = x => x.TimecodeToMs() != -1,
-            XamlRoot = XamlRoot
-        };
-        _showingAnotherDialog = true;
-        Hide();
-        var res = await entryDialog.ShowAsync();
-        _showingAnotherDialog = false;
-        if (!string.IsNullOrEmpty(res) && res != "NULL")
-        {
-            var ms = res.TimecodeToMs();
-            if (ms != -1)
-            {
-                _controller.AddSynchronizedLyric(ms);
-            }
+            _controller.AddSynchronizedLyric(ms);
         }
     }
 

--- a/NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs
+++ b/NickvisionTagger.WinUI/Views/LyricsDialog.xaml.cs
@@ -121,7 +121,7 @@ public sealed partial class LyricsDialog : ContentDialog
         if (!_syncRows.ContainsKey(e.Timestamp))
         {
             var row = new SyncLyricRow(e);
-            row.LyricApplied += (s, ea) => _controller.SetSynchronizedLyric(e.Timestamp, ea);
+            row.LyricChanged += (s, ea) => _controller.SetSynchronizedLyric(e.Timestamp, ea);
             row.LyricRemoved += (s, ea) => _controller.RemoveSynchronizedLyric(e.Timestamp);
             ListSync.Children.Add(row);
             _syncRows.Add(e.Timestamp, row);

--- a/NickvisionTagger.WinUI/Views/MainWindow.xaml
+++ b/NickvisionTagger.WinUI/Views/MainWindow.xaml
@@ -489,7 +489,7 @@
                     </nickvision:ViewStackPage>
 
                     <nickvision:ViewStackPage PageName="Library">
-                        <nickvision:ViewStack x:Name="FilesViewStack" Margin="6,0,6,0">
+                        <nickvision:ViewStack x:Name="FilesViewStack" Margin="6,0,0,0">
                             <nickvision:ViewStack.Pages>
                                 <nickvision:ViewStackPage PageName="NoFiles">
                                     <nickvision:StatusPage x:Name="StatusPageNoFiles" HorizontalAlignment="Center" VerticalAlignment="Center" Glyph="&#xE93C;"/>


### PR DESCRIPTION
Fixes #395 

TODO:

- [x] Fix Tagger ignoring space with invalid chars

WinUI Tweaks:
- [x] Removed Apply button for SyncLyricRow. Lyric will be automatically updated as the text box changes
- [x] Make add sync lyric a flyout instead of showing new ContentDialog
- [x] See where else flyouts can be used instead of full ContentDialogs