### PR TITLE
linux: Remove duplicated purism tag

### DIFF
--- a/NickvisionTagger.Shared/Linux/org.nickvision.tagger.metainfo.xml.in
+++ b/NickvisionTagger.Shared/Linux/org.nickvision.tagger.metainfo.xml.in
@@ -57,7 +57,6 @@
     <display_length compare="ge">360</display_length>
   </requires>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>


### PR DESCRIPTION
Fix duplicated Purism tag error removing workstation related tag.

> custom-key-duplicated Purism::form_factor
> A key can only be used once.